### PR TITLE
fix: use a simple method to update `challenge_state` to prevent some uncaptured data

### DIFF
--- a/migration/202410101010_challenge_state.py
+++ b/migration/202410101010_challenge_state.py
@@ -1,0 +1,50 @@
+async def dochange(db, rs):
+    await db.execute('DROP TABLE last_update_time;')
+    await db.execute('DROP INDEX idx_test_last_modified;')
+    await db.execute('ALTER TABLE test DROP COLUMN last_modified')
+    await db.execute('DROP TRIGGER IF EXISTS test_last_modified_trigger ON test')
+    await db.execute('DROP FUNCTION IF EXISTS update_test_last_modified()')
+    await db.execute('DROP FUNCTION IF EXISTS refresh_challenge_state_incremental()')
+
+    await db.execute('CREATE INDEX challenge_state_idx_chal_id ON challenge_state USING btree (chal_id);')
+    await db.execute(
+    '''
+    CREATE OR REPLACE FUNCTION update_challenge_state(p_chal_id INTEGER)
+    RETURNS VOID AS $$
+    BEGIN
+        WITH challenge_summary AS (
+            SELECT
+                t.chal_id,
+                MAX(t.state) AS max_state,
+                SUM(t.runtime) AS total_runtime,
+                SUM(t.memory) AS total_memory,
+                SUM(CASE WHEN t.state = 1 THEN tvr.rate ELSE 0 END) AS total_rate
+            FROM test t
+            LEFT JOIN test_valid_rate tvr ON t.pro_id = tvr.pro_id AND t.test_idx = tvr.test_idx
+            WHERE t.chal_id = p_chal_id
+            GROUP BY t.chal_id
+        )
+        INSERT INTO challenge_state (chal_id, state, runtime, memory, rate)
+        SELECT
+            chal_id,
+            max_state,
+            total_runtime,
+            total_memory,
+            total_rate
+        FROM challenge_summary
+        ON CONFLICT (chal_id) DO UPDATE
+        SET
+            state = EXCLUDED.state,
+            runtime = EXCLUDED.runtime,
+            memory = EXCLUDED.memory,
+            rate = EXCLUDED.rate
+        WHERE
+            challenge_state.state != EXCLUDED.state OR
+            challenge_state.runtime != EXCLUDED.runtime OR
+            challenge_state.memory != EXCLUDED.memory OR
+            challenge_state.rate != EXCLUDED.rate;
+
+        RETURN;
+    END;
+    $$ LANGUAGE plpgsql;
+    ''')

--- a/src/runtests.py
+++ b/src/runtests.py
@@ -26,7 +26,7 @@ from tests.main import test_main
 MAX_WAIT_SECONDS_BEFORE_SHUTDOWN = 0
 
 
-def sig_handler(server, db, rs, pool, cov, view_task, sig, frame):
+def sig_handler(server, db, rs, pool, cov, sig, frame):
     io_loop = tornado.ioloop.IOLoop.current()
 
     def stop_loop(deadline):
@@ -35,16 +35,13 @@ def sig_handler(server, db, rs, pool, cov, view_task, sig, frame):
             print("Waiting for next tick")
             io_loop.add_timeout(now + 1, stop_loop, deadline)
         else:
-            view_task.kill()
             for task in asyncio.all_tasks():
                 task.cancel()
 
-            io_loop.run_in_executor(func=db.close, executor=None)
-            io_loop.run_in_executor(func=rs.aclose, executor=None)
-            io_loop.run_in_executor(func=pool.aclose, executor=None)
-            io_loop.run_in_executor(
-                func=JudgeServerClusterService.inst.disconnect_all_server, executor=None
-            )
+            io_loop.add_callback(db.close)
+            io_loop.add_callback(rs.aclose)
+            io_loop.add_callback(pool.aclose)
+            io_loop.add_callback(JudgeServerClusterService.inst.disconnect_all_server)
             io_loop.stop()
 
             print("Shutdown finally")
@@ -59,35 +56,6 @@ def sig_handler(server, db, rs, pool, cov, view_task, sig, frame):
 
     print("Caught signal: %s" % sig)
     io_loop.add_callback_from_signal(shutdown)
-
-
-async def materialized_view_task():
-    db = await asyncpg.connect(
-        database=TestConfig.DBNAME_OJ,
-        user=TestConfig.DBUSER_OJ,
-        password=TestConfig.DBPW_OJ,
-        host="localhost",
-    )
-    rs = await aioredis.Redis(host="localhost", port=6379, db=TestConfig.REDIS_DB)
-    p = rs.pubsub()
-    await p.subscribe("materialized_view_req")
-
-    async def _update():
-        ret = await rs.incr("materialized_view_counter") - 1
-        await db.execute("SELECT refresh_challenge_state_incremental();")
-        return ret
-
-    counter = await _update()
-    async for msg in p.listen():
-        if msg["type"] != "message":
-            continue
-
-        ind = int(msg["data"])
-        if ind <= counter:
-            continue
-
-        counter = await _update()
-
 
 testing_loop = asyncio.get_event_loop()
 if not os.path.exists('db-inited'):
@@ -118,21 +86,7 @@ rs = aioredis.Redis.from_pool(pool)
 if __name__ == "__main__":
     e = multiprocessing.Event()
 
-    def run_materialized_view_task():
-        signal.signal(signal.SIGINT, lambda _, __: loop.stop())
-        signal.signal(signal.SIGTERM, lambda _, __: loop.stop())
-        loop = asyncio.new_event_loop()
-        try:
-            loop.run_until_complete(materialized_view_task())
-            loop.run_forever()
-
-        finally:
-            loop.stop()
-            loop.close()
-
-    view_task_process = multiprocessing.Process(target=run_materialized_view_task)
-
-    def m(event, view_task):
+    def m(event):
         asyncio.set_event_loop(asyncio.new_event_loop())
         cov = coverage.Coverage(data_file=f".coverage.{os.getpid()}", branch=True)
         cov.start()
@@ -167,11 +121,11 @@ if __name__ == "__main__":
 
         signal.signal(
             signal.SIGINT,
-            functools.partial(sig_handler, httpsrv, db2, rs2, pool2, cov, view_task),
+            functools.partial(sig_handler, httpsrv, db2, rs2, pool2, cov),
         )
         signal.signal(
             signal.SIGTERM,
-            functools.partial(sig_handler, httpsrv, db2, rs2, pool2, cov, view_task),
+            functools.partial(sig_handler, httpsrv, db2, rs2, pool2, cov),
         )
 
         try:
@@ -181,13 +135,11 @@ if __name__ == "__main__":
             pass
 
     asyncio.get_event_loop().run_until_complete(rs.flushall())
-    view_task_process.start()
-    main_process = multiprocessing.Process(target=m, args=(e, view_task_process))
+    main_process = multiprocessing.Process(target=m, args=(e,))
     main_process.start()
 
     while e.wait():
         services_init(db, rs)
         test_main(testing_loop)
-        view_task_process.terminate()
         main_process.terminate()
         break

--- a/src/services/judge.py
+++ b/src/services/judge.py
@@ -70,7 +70,7 @@ class JudgeServerService:
                 )
 
             self.running_chal_cnt -= 1
-            await self.rs.publish('materialized_view_req', (await self.rs.get('materialized_view_counter')))
+            await ChalService.inst.update_challenge_state(res['chal_id'])
 
             await self.rs.publish('chalstatesub', res['chal_id'])
             await self.rs.publish('challiststatesub', res['chal_id'])

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -284,7 +284,6 @@ class ProService:
         await self.db.execute("REFRESH MATERIALIZED VIEW test_valid_rate;")
         await self.rs.delete('rate')
         await self.rs.hdel('pro_rate', pro_id)
-        await self.rs.publish('materialized_view_req', (await self.rs.get('materialized_view_counter')))
 
         return None, None
 


### PR DESCRIPTION
The `challenge_state`has been updated three times.
- The original version
- [Incremental Update](https://tobiichi3227.eu.org:312/git/tobiichi3227/OJ312/commit/93fd93ca51501b0035658299aa453baa485a65cf)
- Current Version

## The structure of the original version
When the server starts, it will open a new process to handle refresh requests. 
The main process uses Redis publish to communicate with this process. 
When the main process needs to update challenge_state, such as adding new challenges or rejudging, it will send a request via Redis publish.

The `challenge_state` in this version is a materialized view.
Although using a materialized view to cache data is a good choice, refreshing a materialized view in PostgreSQL requires recalculating all data related to that view. 
This can lead to unnecessary recalculations of data that hasn't changed.
In TOJ, refreshing challenge_state takes about 800ms to 900ms and results in high CPU load.

## The structure of the incremental update
This version also uses a process similar to the original version.
But we changed the challenge_state from a materialized view to a normal table and implemented an incremental refresh update.
Although the performance issues have been resolved, this method may lead to some data being uncaptured.

## The structure of current version
We removed the request handling process, and we will update `challenge_state` in the main process.
The main process will specify which challenges need to be updated, so there won't be any uncaptured data.