### PR TITLE
impr(board): enhance UI usability

### DIFF
--- a/src/services/rate.py
+++ b/src/services/rate.py
@@ -194,7 +194,8 @@ class RateService:
                 '''
                     SELECT "challenge"."acct_id", "challenge"."pro_id",
                     ROUND(MAX("challenge_state"."rate"), (SELECT rate_precision FROM problem WHERE pro_id = challenge.pro_id)) AS "rate",
-                    COUNT("challenge_state") AS "count"
+                    COUNT("challenge_state") AS "count",
+                    MIN("challenge_state"."state") AS "state"
                     FROM "challenge"
                     INNER JOIN "challenge_state"
                     ON "challenge"."chal_id" = "challenge_state"."chal_id"
@@ -208,7 +209,7 @@ class RateService:
             )
 
         statemap = defaultdict(dict)
-        for acct_id, pro_id, rate, count in result:
-            statemap[acct_id][pro_id] = {'rate': rate, 'count': count}
+        for acct_id, pro_id, rate, count, state in result:
+            statemap[acct_id][pro_id] = {'rate': rate, 'count': count, 'state': state}
 
         return None, statemap

--- a/src/static/templ/board-list.html
+++ b/src/static/templ/board-list.html
@@ -1,3 +1,4 @@
+{% from services.board import BoardConst %}
 <script type="text/javascript" id="contjs">
     function init() {
     }
@@ -8,11 +9,17 @@
 	    <tr>
 			<th scope="col">#</th>
 			<th scope="col">Board Name</th>
-			<th scope="col">Status</th>
+            <th scope="col">Expire Status</th>
+            {% if user.is_kernel() %}
+                <th scope="col">Public Status</th>
+            {% end %}
 	    </tr>
 	</thead>
 	<tbody>
 	{% for board in boardlist %}
+        {% if not user.is_kernel() and board['status'] != BoardConst.STATUS_ONLINE %}
+            {% continue %}
+        {% end %}
 	    <tr>
 			<th scope="row">{{ board['board_id'] }}</th>
             <td><a href="/oj/board/{{ board['board_id'] }}/">{{ board['name'] }}</a></td>
@@ -20,11 +27,20 @@
 				{% set delta = board['end'] - datetime.datetime.now().replace(tzinfo=datetime.timezone(datetime.timedelta(hours=8))) %}
 				{% set deltasecond = delta.days * 24 * 60 * 60 + delta.seconds %}
 				{% if deltasecond <= 0 %}
-				Over
+				    Over
 				{% else %}
-				Online
+				    Online
 				{% end %}
 			</td>
+            {% if user.is_kernel() %}
+                {% if board['status'] == BoardConst.STATUS_ONLINE %}
+                    <td>Public</td>
+                {% elif board['status'] == BoardConst.STATUS_HIDDEN %}
+                    <td>Hidden</td>
+                {% elif board['status'] == BoardConst.STATUS_OFFLINE %}
+                    <td>Offline</td>
+                {% end %}
+            {% end %}
 	    </tr>
 	{% end %}
 	</tbody>

--- a/src/static/templ/board.html
+++ b/src/static/templ/board.html
@@ -1,4 +1,5 @@
 {% import math %}
+{% from services.chal import ChalConst %}
 <style>
   table th._rank {
     text-align: center;
@@ -159,6 +160,10 @@
             {% if acct_id in ratemap and pro_id in ratemap[acct_id] %}
               {% set rate = ratemap[acct_id][pro_id] %}
               {% set sc = math.floor(rate['rate'] / 10) %}
+              {% if rate['state'] == ChalConst.STATE_AC %}
+                {% set sc = 10 %}
+              {% end %}
+
               <td class="_pro _state-{{ sc }} _state"><a href="/oj/chal/?acctid={{ acct_id }}&proid={{ pro_id }}&state=0">{{ rate['rate'] }} / {{ rate['count'] }}</a></td>
             {% else %}
               <td class="_pro _state">&nbsp</td>

--- a/src/static/templ/board.html
+++ b/src/static/templ/board.html
@@ -150,7 +150,7 @@
       <tbody>
         {% for acct in acctlist %}
         {% set acct_id = acct.acct_id %}
-        <tr>
+        <tr {% if acct_id == user.acct_id %} style="--bs-table-bg: #123456;" {% end %}>
           <td class="_rank">{{ acct.rank }}</td>
           <td class="_acct">&nbsp<a href="/oj/acct/{{ acct_id }}/">{{ acct.name }}</a></td>
           <td class="_score"><a href="/oj/chal/?acctid={{ acct_id }}">{{ acct.rate }} / {{ acct_submit[acct_id] }}</a></td>

--- a/src/static/templ/board.html
+++ b/src/static/templ/board.html
@@ -1,6 +1,55 @@
 {% import math %}
 {% from services.chal import ChalConst %}
 <style>
+  /* from https://www.astralweb.com.tw/pure-css-implementation-table-headers-columns-fixed/ */
+  /* freeze table head like excel */
+  table {
+    table-layout: fixed;
+  }
+  td._rank, th._rank {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+  }
+  table thead tr th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+  th._rank {
+    z-index: 4;
+  }
+  @media only screen and (min-width: 992px) {
+    td._acct {
+      position: sticky;
+      left: 64px;
+      z-index: 1;
+    }
+    tr th._acct {
+      position: sticky;
+      left: 64px;
+      z-index: 2;
+    }
+
+    td._score {
+      position: sticky;
+      left: 214px;
+      z-index: 1;
+    }
+    tr th._score {
+      position: sticky;
+      left: 214px;
+      z-index: 2;
+    }
+
+    td._submit {
+      position: sticky;
+      left: 0;
+      z-index: 2;
+    }
+  }
+  /* end */
+
   table th._rank {
     text-align: center;
     width: 64px;
@@ -85,6 +134,13 @@
     window.localStorage.setItem('board_scoll_left', board.scrollLeft)
   }, false)
 
+  $("#topScrollBar").scroll(function() {
+    $("#board1").scrollLeft($(this).scrollLeft());
+  });
+  $("#board1").scroll(function() {
+    $("#topScrollBar").scrollLeft($(this).scrollLeft());
+  });
+
   setTimeout(() => {
     var board = document.getElementById('board1');
     if (window.localStorage.getItem('board_scoll_left')) {
@@ -142,7 +198,10 @@
       <div id="count"></div>
     </h3>
   </div>
-  <div class="col-lg-12" style="overflow-x: scroll;" id="board1">
+  <div style="overflow-x: scroll; overflow-y: hidden;" id="topScrollBar">
+    <div style="height: 8px; width:{{9+64+150+112+len(prolist)*99}}px;"></div>
+  </div>
+  <div class="col-lg-12" id="board1" style="overflow-x: scroll; max-height: 100vh;">
     <table class="table table-hover table-sm table-bordered table-responsive-sm col mx-lg-3" style="width:{{9+64+150+112+len(prolist)*99}}px;">
       <thead>
         <tr>

--- a/src/static/templ/board.html
+++ b/src/static/templ/board.html
@@ -190,7 +190,10 @@
       <strong>Standings&nbsp;&nbsp;</strong>
       <select class="form-select" id="cont">
         {% for board in board_list %}
-        <option value="{{ board['board_id'] }}" {% if board['name'] == name %}selected{% end %}>{{ board['name'] }}</option>
+          {% if not user.is_kernel() and board['status'] != BoardConst.STATUS_ONLINE %}
+            {% continue %}
+          {% end %}
+          <option value="{{ board['board_id'] }}" {% if board['name'] == name %}selected{% end %}>{{ board['name'] }}</option>
         {% end %}
       </select>
     </div>

--- a/src/static/templ/board.html
+++ b/src/static/templ/board.html
@@ -97,22 +97,28 @@
 
   function GetCount() {
     var j_count = $('#count');
-    var now = new Date().getTime();
-    var delta = Math.floor((end - now) / 1000);
-    if (delta <= 0) {
-      j_count.text('Over');
+
+    let now = new Date().getTime();
+    let secs = Math.floor((end - now) / 1000);
+    let ss = 0, mm = 0, hh = 0, dd = 0;
+    ss = Math.floor(secs % 60);
+    if (secs > 0) {
+      dd = Math.floor(secs / 86400);
+      secs %= 86400;
+      hh = Math.floor(secs / 3600);
+      secs %= 3600;
+      mm = Math.floor(secs / 60) % 60;
+
+      const getS = (number) => {
+        return number > 1 ? 's': '';
+      };
+      j_count.text(`${dd} Day${getS(dd)} ${hh} Hour${getS(hh)} ${mm} Minute${getS(mm)} ${ss} Second${getS(ss)} Left`);
+      setTimeout(() => GetCount(), 1000);
     } else {
-      var hour = Math.floor(delta / 3600);
-      delta = (delta % 3600);
-      var minute = Math.floor(delta / 60);
-      delta = (delta % 60);
-      var second = Math.floor(delta);
-      j_count.text(hour + ' ' + 'hour' + (hour > 1 ? 's' : '') + '  ' + minute + ' ' + 'minute' + (minute > 1 ? 's' : '') + '  ' + second + ' ' + 'second' + (second >1 ? 's' : '') + ' ' + 'Left');
-      setTimeout(function(){
-        GetCount()
-      },1000);
+      j_count.text('Over');
     }
   }
+
   function init() {
     GetCount();
   }

--- a/src/static/templ/board.html
+++ b/src/static/templ/board.html
@@ -141,6 +141,17 @@
     $("#topScrollBar").scrollLeft($(this).scrollLeft());
   });
 
+  $("#showSelf").on('change', function (e) {
+    let clicked = $(this).is(":checked");
+    $("tbody > tr").each((idx, el) => {
+      el = $(el);
+      if (!el.hasClass("_self")) {
+        if (clicked) el.hide();
+        else el.show();
+      }
+    });
+  });
+
   setTimeout(() => {
     var board = document.getElementById('board1');
     if (window.localStorage.getItem('board_scoll_left')) {
@@ -200,6 +211,10 @@
     <h3>
       <div id="count"></div>
     </h3>
+    <div class="form-check form-check-inline">
+      <label class="form-check-label" for="showSelf">Only Show Myself</label>
+      <input type="checkbox" id="showSelf" class="form-check-input">
+    </div>
   </div>
   <div style="overflow-x: scroll; overflow-y: hidden;" id="topScrollBar">
     <div style="height: 8px; width:{{9+64+150+112+len(prolist)*99}}px;"></div>
@@ -219,7 +234,7 @@
       <tbody>
         {% for acct in acctlist %}
         {% set acct_id = acct.acct_id %}
-        <tr {% if acct_id == user.acct_id %} style="--bs-table-bg: #123456;" {% end %}>
+        <tr {% if acct_id == user.acct_id %} style="--bs-table-bg: #123456;" class="_self" {% end %}>
           <td class="_rank">{{ acct.rank }}</td>
           <td class="_acct">&nbsp<a href="/oj/acct/{{ acct_id }}/">{{ acct.name }}</a></td>
           <td class="_score"><a href="/oj/chal/?acctid={{ acct_id }}">{{ acct.rate }} / {{ acct_submit[acct_id] }}</a></td>

--- a/src/static/templ/manage/board/add.html
+++ b/src/static/templ/manage/board/add.html
@@ -94,6 +94,7 @@
 </script>
 {% end %}
 {% block content %}
+{% from services.board import BoardConst %}
 <div class="col-lg-10 ms-lg-2 mt-lg-2">
 	<form id="form">
 		<div class="mb-1">
@@ -103,9 +104,9 @@
         <div class="mb-1">
             <label for="#status" class="form-label">Status</label>
 			<select class="form-select" id="status">
-				<option value=0>Online</option>
-				<option value=1>Hidden</option>
-				<option value=2>Offline</option>
+                <option value="{{ BoardConst.STATUS_ONLINE }}">Online</option>
+				<option value="{{ BoardConst.STATUS_HIDDEN }}">Hidden</option>
+                <option value="{{ BoardConst.STATUS_OFFLINE }}">Offline</option>
 			</select>
         </div>
 

--- a/src/static/templ/manage/board/board-list.html
+++ b/src/static/templ/manage/board/board-list.html
@@ -8,6 +8,7 @@
 
 {% end %}
 {% block content %}
+{% from services.board import BoardConst %}
 <div class="col-lg-10 ms-lg-2 mt-lg-2">
 
 	<table class="table table-hover table-sm table-responsive-sm col mx-lg-3">
@@ -28,11 +29,11 @@
 					<th scope="row">{{ board['board_id'] }}</th>
 					<td><a href="/oj/board/{{ board['board_id'] }}/">{{ board['name'] }}</a></td>
 
-					{% if board['status'] == 0 %}
+					{% if board['status'] == BoardConst.STATUS_ONLINE %}
 						<td class="status-online">Online</td>
-					{% elif board['status'] == 1 %}
+					{% elif board['status'] == BoardConst.STATUS_HIDDEN %}
 						<td class="status-hidden">Hidden</td>
-					{% elif board['status'] == 2 %}
+					{% elif board['status'] == BoardConst.STATUS_OFFLINE %}
 						<td class="status-offline">Offline</td>
 					{% end %}
 

--- a/src/static/templ/manage/board/update.html
+++ b/src/static/templ/manage/board/update.html
@@ -39,7 +39,7 @@
             let pro_list = j_form.find("#pro_list").val();
             let acct_list = j_form.find("#acct_list").val();
 
-            start_time = start_date_picker.viewDate; 
+            start_time = start_date_picker.viewDate;
             if (start_time == '') {
                 index.show_notify_dialog("開始時間不可為空", index.DIALOG_TYPE.warning);
                 return;
@@ -109,6 +109,7 @@
 </script>
 {% end %}
 {% block content %}
+{% from services.board import BoardConst %}
 <div class="col-lg-10 ms-lg-2 mt-lg-2">
 	<form id="form">
 		<div class="mb-1">
@@ -118,9 +119,9 @@
         <div class="mb-1">
             <label for="#status" class="form-label">Status</label>
 			<select class="form-select" id="status">
-				<option value="0" {% if board['status'] == 0 %} selected {% end %} >Online</option>
-				<option value="1" {% if board['status'] == 1 %} selected {% end %} >Hidden</option>
-				<option value="2" {% if board['status'] == 2 %} selected {% end %} >Offline</option>
+                <option value="{{ BoardConst.STATUS_ONLINE }}" {% if board['status'] == BoardConst.STATUS_ONLINE %} selected {% end %} >Online</option>
+				<option value="{{ BoardConst.STATUS_HIDDEN }}" {% if board['status'] == BoardConst.STATUS_HIDDEN %} selected {% end %} >Hidden</option>
+                <option value="{{ BoardConst.STATUS_OFFLINE }}" {% if board['status'] == BoardConst.STATUS_OFFLINE %} selected {% end %} >Offline</option>
 			</select>
         </div>
 

--- a/src/static/templ/proset.html
+++ b/src/static/templ/proset.html
@@ -13,6 +13,7 @@
         function get_goto_url(proclass_id) {
             let order = j_filter.find("#order").val();
             let show = j_filter.find("#show").val();
+            let search_name = j_filter.find("#name").val();
             if (proclass_id == -1)
                 proclass_id = $("#curProclassId").attr("proclass");
             let is_online = j_filter.find("#online").is(":checked");
@@ -37,6 +38,10 @@
 
             if (proclass_id != 'None') {
                 url += `&proclass_id=${proclass_id}`;
+            }
+
+            if (search_name != '') {
+                url += `&name=${search_name}`;
             }
 
             return url;
@@ -309,6 +314,11 @@
             </div>
 
             <div class="mb-1">
+                <label for="name" class="form-label">Search Name</label>
+                <input type="text" id="name" class="form-control" placeholder="problem name" value="{{ flt['name'] if flt['name'] else '' }}">
+            </div>
+
+            <div class="mb-1">
                 <button id="filter_submit" class="btn btn-primary" type="button">Filter</button>
             </div>
 
@@ -390,6 +400,9 @@
         {% end %}
         {% if flt['reverse'] != False %}
         {% set postfix = postfix + f"&reverse={flt['reverse']}" %}
+        {% end %}
+        {% if flt['name'] != None %}
+        {% set postfix = postfix + f"&name={flt['name']}" %}
         {% end %}
 
         <div class="row">

--- a/src/tests/e2e/board.py
+++ b/src/tests/e2e/board.py
@@ -38,6 +38,7 @@ class BoardTest(AsyncTest):
             self.assertEqual(html.select('th._pro')[0].text, '1')
             self.assertEqual(html.select('th._pro')[1].text, '2')
             tr0 = html.select('tbody > tr')[0]
+            self.assertEqual(tr0.attrs['style'], '--bs-table-bg: #123456;')
             self.assertEqual(tr0.select_one('td._rank').text.strip(), '1')
             self.assertEqual(tr0.select_one('td._acct').text.strip(), 'admin')
             self.assertEqual(tr0.select_one('td._score').text.strip(), '200 / 9')

--- a/src/tests/e2e/board.py
+++ b/src/tests/e2e/board.py
@@ -49,14 +49,18 @@ class BoardTest(AsyncTest):
 
             # board list
             html = self.get_html('board', admin_session)
-            self.assertEqual(len(html.select('tr')[1:]), 1)
-            self.assertEqual(html.select('tr')[1:][0].select('td')[1].text.strip(), 'Online')
+            trs = html.select('tr')
+            self.assertEqual(trs[0].select('th')[2].text.strip(), 'Expire Status')
+            self.assertEqual(trs[0].select('th')[3].text.strip(), 'Public Status')
+            self.assertEqual(len(trs[1:]), 1)
+            self.assertEqual(trs[1:][0].select('td')[1].text.strip(), 'Online')
+            self.assertEqual(trs[1:][0].select('td')[2].text.strip(), 'Public')
 
             res = admin_session.post('manage/board/update', data={
                 'reqtype': 'update',
                 'board_id': 1,
                 'name': 'board1',
-                'status': BoardConst.STATUS_ONLINE,
+                'status': BoardConst.STATUS_HIDDEN,
                 'start': self.get_isoformat(datetime.datetime.now() - datetime.timedelta(days=14)),
                 'end': self.get_isoformat(datetime.datetime.now() - datetime.timedelta(days=7)),
                 'pro_list': '1, 2',
@@ -65,8 +69,22 @@ class BoardTest(AsyncTest):
             self.assertEqual(res.text, 'S')
 
             html = self.get_html('board', admin_session)
-            self.assertEqual(len(html.select('tr')[1:]), 1)
-            self.assertEqual(html.select('tr')[1:][0].select('td')[1].text.strip(), 'Over')
+            trs = html.select('tr')
+            self.assertEqual(len(trs[1:]), 1)
+            self.assertEqual(trs[1:][0].select('td')[1].text.strip(), 'Over')
+            self.assertEqual(trs[1:][0].select('td')[2].text.strip(), 'Hidden')
+
+            with AccountContext('test1@test', 'test') as user_session:
+                # only show STATUS_ONLINE board for normal user
+                html = self.get_html('board', user_session)
+                trs = html.select('tr')
+                self.assertEqual(trs[0].select('th')[2].text.strip(), 'Expire Status')
+                self.assertEqual(len(trs[0].select('th')), 3)
+                self.assertEqual(len(trs[1:]), 0)
+
+                res = user_session.get('board/1')
+                self.assertEqual(res.text, 'Eacces')
+
             html = self.get_html('board/1', admin_session)
             self.assertEqual(html.select('th._pro')[0].text, '1')
             self.assertEqual(html.select('th._pro')[1].text, '2')
@@ -76,6 +94,20 @@ class BoardTest(AsyncTest):
             self.assertEqual(tr0.select_one('td._score').text.strip(), '0 / 0')
             self.assertEqual(tr0.select('td._pro')[0].text.strip(), '')
             self.assertEqual(tr0.select('td._pro')[1].text.strip(), '')
+
+            res = admin_session.post('manage/board/update', data={
+                'reqtype': 'update',
+                'board_id': 1,
+                'name': 'board1',
+                'status': BoardConst.STATUS_OFFLINE,
+                'start': self.get_isoformat(datetime.datetime.now() - datetime.timedelta(days=14)),
+                'end': self.get_isoformat(datetime.datetime.now() - datetime.timedelta(days=7)),
+                'pro_list': '1, 2',
+                'acct_list': '1',
+            })
+            self.assertEqual(res.text, 'S')
+            res = admin_session.get('board/1')
+            self.assertEqual(res.text, 'Eacces')
 
             res = admin_session.post('manage/board/update', data={
                 'reqtype': 'remove',

--- a/src/tests/e2e/proset.py
+++ b/src/tests/e2e/proset.py
@@ -57,3 +57,13 @@ class ProsetTest(AsyncTest):
             self.assertEqual(trs[2].select('td')[3].text.strip().replace('\n', ''), '0.00%(0/ 0)')
             self.assertEqual(trs[2].select('td')[4].text.strip().replace('\n', ''), '0.00%(0/0)')
             self.assertEqual(trs[2].select('td')[5].text, '')
+
+            html = self.get_html('proset?name=猜數字', admin_session)
+            trs = html.select('#prolist > tbody > tr')
+            self.assertEqual(len(trs), 1)
+            self.assertEqual(trs[0].select('td')[0].text, '2')
+            self.assertEqual(trs[0].select('td')[1].text, ChalConst.STATE_LONG_STR[ChalConst.STATE_AC])
+            self.assertEqual(trs[0].select('td')[2].text.strip().replace('\n', ''), '猜數字')
+            self.assertEqual(trs[0].select('td')[3].text.strip().replace('\n', ''), '100.00%(1/ 1)')
+            self.assertEqual(trs[0].select('td')[4].text.strip().replace('\n', ''), '100.00%(1/1)')
+            self.assertEqual(trs[0].select('td')[5].text, '')


### PR DESCRIPTION
In this PR, we make some features, improvements and bugfix about board.

# Features
- Highlight the current column of the current user.
- Freeze table header and rows like in Excel.
- A checkbox to show only my column.

# Improvements
Change the time display from `hh:mm:ss` to `dd:hh:mm:ss` to reduce verbose text.

# Bugfixs
- Do not use scores to determine if the problem is accepted, since problem scores may not be 100.
- Ensure normal users can only access the online board.

# Other Features
- We can filter problems by problem name in proset.