### PR TITLE
feat(contest): introduce question and announce function

### DIFF
--- a/migration/20250314210300_add_contest_announcement_and_question.py
+++ b/migration/20250314210300_add_contest_announcement_and_question.py
@@ -1,0 +1,79 @@
+async def dochange(db, rs):
+    await db.execute(
+    '''
+    CREATE SEQUENCE IF NOT EXISTS contest_announcement_announce_id_seq
+        INCREMENT 1
+        START 1
+        MINVALUE 1
+        MAXVALUE 9223372036854775807
+        CACHE 1;
+    '''
+    )
+
+    await db.execute(
+    '''
+        CREATE TABLE contest_announcement (
+            contest_id integer NOT NULL,
+            announce_id integer NOT NULL DEFAULT nextval('contest_announcement_announce_id_seq'::regclass),
+            acct_id integer NOT NULL,
+            subject character varying NOT NULL,
+            content character varying NOT NULL,
+            "timestamp" TIMESTAMP WITH TIME ZONE
+        );
+    ''')
+
+    await db.execute(
+    '''
+        ALTER TABLE ONLY contest_announcement
+            ADD CONSTRAINT contest_announcement_forkey_contest_id FOREIGN KEY (contest_id) REFERENCES contest(contest_id) ON DELETE CASCADE;
+    ''')
+    await db.execute(
+    '''
+        ALTER TABLE ONLY contest_announcement
+            ADD CONSTRAINT contest_announcement_forkey_acct_id FOREIGN KEY (contest_id, acct_id) REFERENCES contest_users(contest_id, acct_id) ON DELETE CASCADE;
+    ''')
+
+    await db.execute(
+    '''
+    CREATE SEQUENCE IF NOT EXISTS contest_question_question_id_seq
+        INCREMENT 1
+        START 1
+        MINVALUE 1
+        MAXVALUE 9223372036854775807
+        CACHE 1;
+    '''
+    )
+
+    await db.execute(
+    '''
+        CREATE TABLE contest_question (
+            contest_id integer NOT NULL,
+            question_id integer NOT NULL DEFAULT nextval('contest_question_question_id_seq'::regclass),
+            ask_acct_id integer NOT NULL,
+            ask_subject character varying NOT NULL,
+            ask_content character varying NOT NULL,
+            ask_timestamp TIMESTAMP WITH TIME ZONE,
+
+            reply_acct_id integer,
+            reply_content character varying,
+            reply_timestamp TIMESTAMP WITH TIME ZONE
+        );
+    ''')
+
+    await db.execute(
+    '''
+        ALTER TABLE ONLY contest_question
+            ADD CONSTRAINT contest_question_forkey_contest_id FOREIGN KEY (contest_id) REFERENCES contest(contest_id) ON DELETE CASCADE;
+    ''')
+    await db.execute(
+    '''
+        ALTER TABLE ONLY contest_question
+            ADD CONSTRAINT contest_question_forkey_ask_acct_id FOREIGN KEY (contest_id, ask_acct_id) REFERENCES contest_users(contest_id, acct_id) ON DELETE CASCADE;
+    ''')
+    await db.execute(
+    '''
+        ALTER TABLE ONLY contest_question
+            ADD CONSTRAINT contest_question_forkey_reply_acct_id FOREIGN KEY (contest_id, reply_acct_id) REFERENCES contest_users(contest_id, acct_id) ON DELETE CASCADE;
+    ''')
+
+    await db.execute('ALTER TABLE contest_users ADD COLUMN notification_read_count INTEGER DEFAULT 0;')

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -125,7 +125,6 @@ class ContestManageProHandler(RequestHandler):
             await asyncio.create_task(_rechal(rechals=result))
             self.error(('S', f'Problem(#{pro_id}) is rechallenging.'))
 
-        # TODO: public e2e test
         elif reqtype == "public":
             pro_id = int(pro_id)
             if not self.contest.is_pro(pro_id):

--- a/src/handlers/contests/manage/qa.py
+++ b/src/handlers/contests/manage/qa.py
@@ -1,0 +1,158 @@
+import json
+import asyncio
+
+from services.contests import ContestService
+from services.user import UserService
+from handlers.base import RequestHandler, WebSocketSubHandler, reqenv
+from handlers.contests.base import contest_require_permission
+
+class ContestManageQuestionHandler(RequestHandler):
+    @reqenv
+    @contest_require_permission('admin')
+    async def get(self):
+        err, questions = await ContestService.inst.get_all_question(self.contest.contest_id)
+        if err:
+            self.error(err)
+            return
+
+
+        cache = {}
+        questions2 = []
+        for question in questions:
+            question = dict(question)
+            ask_acct_id, reply_acct_id = question['ask_acct_id'], question['reply_acct_id']
+            if ask_acct_id not in cache:
+                _, acct = await UserService.inst.info_acct(ask_acct_id)
+                cache[ask_acct_id] = acct
+            else:
+                acct = cache[ask_acct_id]
+
+            question['ask_acct'] = acct
+
+            if reply_acct_id:
+                if reply_acct_id not in cache:
+                    _, acct = await UserService.inst.info_acct(reply_acct_id)
+                    cache[reply_acct_id] = acct
+                else:
+                    acct = cache[reply_acct_id]
+
+                question['reply_acct'] = acct
+            questions2.append(question)
+        def _cmp(question):
+            return (question['reply_acct_id'] is None, question['ask_timestamp'], question['reply_timestamp'])
+
+        questions2.sort(key=_cmp)
+
+
+        await self.render('contests/manage/question', page='question', contest_id=self.contest.contest_id,
+                          contest=self.contest, questions=questions2)
+
+    @reqenv
+    @contest_require_permission('admin')
+    async def post(self):
+        reqtype = self.get_argument('reqtype')
+        if reqtype == 'reply':
+            question_id = int(self.get_argument('question_id'))
+            content = self.get_argument('content').strip()
+
+            if len(content) == 0:
+                self.error(('Eparam', 'Content should not be empty'))
+                return
+
+            await ContestService.inst.reply_question(self.contest.contest_id, question_id, self.acct.acct_id, content)
+            await self.rs.publish('contestnewqasub', json.dumps({
+                'contest_id': self.contest.contest_id,
+                'type': 'reply'
+            }))
+            self.error(('S', ''))
+
+class ContestManageAnnounceHandler(RequestHandler):
+    @reqenv
+    @contest_require_permission('admin')
+    async def get(self):
+        err, announces = await ContestService.inst.get_all_announce(self.contest.contest_id)
+        if err:
+            self.error(err)
+            return
+
+        await self.render('contests/manage/announce', page='announce', contest_id=self.contest.contest_id,
+                          contest=self.contest, announces=announces)
+
+    @reqenv
+    @contest_require_permission('admin')
+    async def post(self):
+        reqtype = self.get_argument('reqtype')
+
+        if reqtype == 'add-announce':
+            subject = self.get_argument('subject').strip()
+            content = self.get_argument('content').strip()
+
+            if len(subject) == 0:
+                self.error(('Eparam', 'Subject should not be empty'))
+                return
+
+            if len(content) == 0:
+                self.error(('Eparam', 'Content should not be empty'))
+                return
+
+            await ContestService.inst.add_announce(self.contest.contest_id, self.acct.acct_id, subject, content)
+            await self.rs.publish('contestnewqasub', json.dumps({
+                'contest_id': self.contest.contest_id,
+                'type': 'add-announce'
+            }))
+            self.error(('S', ''))
+
+        elif reqtype == 'edit-announce':
+            announce_id = int(self.get_argument('announce_id'))
+            subject = self.get_argument('subject')
+            content = self.get_argument('content')
+
+            if len(subject) == 0:
+                self.error(('Eparam', 'Subject should not be empty'))
+                return
+
+            if len(content) == 0:
+                self.error(('Eparam', 'Content should not be empty'))
+                return
+
+            await ContestService.inst.edit_announce(self.contest.contest_id, announce_id, subject, content)
+            await self.rs.publish('contestnewqasub', json.dumps({
+                'contest_id': self.contest.contest_id,
+                'type': 'edit-announce'
+            }))
+            self.error(('S', ''))
+
+        elif reqtype == 'popup-announce':
+            announce_id = int(self.get_argument('announce_id'))
+            err, announce = await ContestService.inst.get_announce(self.contest.contest_id, announce_id)
+            if err:
+                self.error(err)
+                return
+
+            await self.rs.publish('contestnewqasub', json.dumps({
+                'contest_id': self.contest.contest_id,
+                'type': 'popup-announce',
+                'subject': announce['subject'],
+                'content': announce['content'],
+                'timestamp': announce['timestamp'].strftime('%Y-%m-%d %H:%M:%S'),
+            }))
+            self.error(('S', ''))
+
+class ContestManageQANewQuesHandler(WebSocketSubHandler):
+    async def listen_newques(self):
+        async for msg in self.p.listen():
+            if msg['type'] != 'message':
+                continue
+
+            if int(msg['data']) == self.contest_id:
+                await self.write_message(str(int(msg['data'])))
+
+    async def open(self):
+        self.contest_id = -1
+        await self.p.subscribe('contestnewquessub')
+
+        self.task = asyncio.tasks.Task(self.listen_newques())
+
+    async def on_message(self, msg):
+        if self.contest_id == -1 and msg.isdigit():
+            self.contest_id = int(msg)

--- a/src/handlers/contests/manage/url.py
+++ b/src/handlers/contests/manage/url.py
@@ -7,13 +7,15 @@ from handlers.contests.manage.general import (
 )
 from handlers.contests.manage.pro import ContestManageProHandler
 from handlers.contests.manage.reg import ContestManageRegHandler
-
+from handlers.contests.manage.qa import ContestManageQuestionHandler, ContestManageAnnounceHandler, ContestManageQANewQuesHandler
 
 def get_contests_manage_url(db, rs, pool):
     args = {
         'db': db,
         'rs': rs,
     }
+
+    sub_args = {'pool': pool}
 
     return [
         (r'/contests/manage/add', ContestManageAddHandler, args),
@@ -24,4 +26,7 @@ def get_contests_manage_url(db, rs, pool):
         (r'/contests/\d+/manage/acct', ContestManageAcctHandler, args),
         (r'/contests/\d+/manage/pro', ContestManageProHandler, args),
         (r'/contests/\d+/manage/reg', ContestManageRegHandler, args),
+        (r'/contests/\d+/manage/question', ContestManageQuestionHandler, args),
+        (r'/contests/\d+/manage/announce', ContestManageAnnounceHandler, args),
+        (r'/contests/\d+/manage/qasub', ContestManageQANewQuesHandler, sub_args),
     ]

--- a/src/handlers/contests/qa.py
+++ b/src/handlers/contests/qa.py
@@ -1,0 +1,86 @@
+import asyncio
+import json
+
+from services.contests import ContestService
+
+from handlers.base import RequestHandler, WebSocketSubHandler, reqenv
+from handlers.contests.base import contest_require_permission
+
+class ContestQAHandler(RequestHandler):
+    @reqenv
+    async def get(self):
+        if self.contest.is_admin(self.acct):
+            self.error(('Eacces', 'Permission denied'))
+            return
+
+        err, announces = await ContestService.inst.get_all_announce(self.contest.contest_id)
+        if err:
+            self.error(err)
+            return
+
+        err, questions = await ContestService.inst.get_all_question(self.contest.contest_id, self.acct.acct_id)
+        if err:
+            self.error(err)
+            return
+
+        def _cmp(question):
+            return (question['reply_acct_id'] is not None, question['reply_timestamp'], question['ask_timestamp'])
+        questions.sort(key=_cmp)
+
+        await self.db.execute(
+            '''
+            UPDATE contest_users
+            SET notification_read_count = sub.total_count
+            FROM (
+                SELECT
+                    (SELECT COUNT(*) FROM contest_announcement WHERE contest_id = $1) +
+                    (SELECT COUNT(*) FROM contest_question WHERE contest_id = $1 AND ask_acct_id = $2 AND reply_acct_id IS NOT NULL)
+                    AS total_count
+            ) AS sub
+            WHERE contest_users.contest_id = $1
+            AND contest_users.acct_id = $2;
+            ''',
+            self.contest.contest_id, self.acct.acct_id
+        )
+
+        await self.render('contests/qa', contest=self.contest, announces=announces, questions=questions)
+
+
+    @reqenv
+    @contest_require_permission('normal')
+    async def post(self):
+        reqtype = self.get_argument('reqtype')
+        if reqtype == 'ask':
+            subject = self.get_argument('subject').strip()
+            content = self.get_argument('content').strip()
+
+            if len(subject) == 0:
+                self.error(('Eparam', 'Subject should not be empty'))
+                return
+
+            if len(content) == 0:
+                self.error(('Eparam', 'Content should not be empty'))
+                return
+
+            await ContestService.inst.ask_question(self.contest.contest_id, self.acct.acct_id, subject, content)
+            await self.rs.publish('contestnewquessub', str(self.contest.contest_id))
+            self.error(('S', ''))
+
+class ContestNewQAHandler(WebSocketSubHandler):
+    async def listen_newqa(self):
+        async for msg in self.p.listen():
+            if msg['type'] != 'message':
+                continue
+
+            if json.loads(msg['data'])['contest_id'] == self.contest_id:
+                await self.write_message(msg['data'])
+
+    async def open(self):
+        self.contest_id = -1
+        await self.p.subscribe('contestnewqasub')
+
+        self.task = asyncio.tasks.Task(self.listen_newqa())
+
+    async def on_message(self, msg):
+        if self.contest_id == -1 and msg.isdigit():
+            self.contest_id = int(msg)

--- a/src/handlers/contests/url.py
+++ b/src/handlers/contests/url.py
@@ -4,6 +4,7 @@ from handlers.contests.manage.url import get_contests_manage_url
 from handlers.contests.proset import ContestProsetHandler
 from handlers.contests.reg import ContestRegHandler
 from handlers.contests.scoreboard import ContestScoreboardHandler, ContestScoreboardNewChalHandler
+from handlers.contests.qa import ContestQAHandler, ContestNewQAHandler
 from handlers.pro import ProHandler, ProStaticHandler
 from handlers.submit import SubmitHandler
 
@@ -30,6 +31,7 @@ def get_contests_url(db, rs, pool):
         (r'/contests/\d+/reg', ContestRegHandler, args),
         (r'/contests/\d+/scoreboard', ContestScoreboardHandler, args),
         (r'/contests/\d+/scoreboardsub', ContestScoreboardNewChalHandler, sub_args),
-        # (r'/contests/\d+/question', args), # TODO: question
+        (r'/contests/\d+/qa', ContestQAHandler, args),
+        (r'/contests/\d+/qasub', ContestNewQAHandler, sub_args),
         # ('/contests/pro/(.+)', args),  # Experiment Problem UI
     ] + get_contests_manage_url(db, rs, pool)

--- a/src/handlers/index.py
+++ b/src/handlers/index.py
@@ -1,7 +1,7 @@
 import msgpack
 
 from handlers.base import RequestHandler, reqenv
-from services.contests import ContestService
+from services.contests import ContestService, UserStatus
 from services.ques import QuestionService
 
 class IndexHandler(RequestHandler):
@@ -11,6 +11,8 @@ class IndexHandler(RequestHandler):
         contest_manage = False
         contest = None
         contest_id = 0
+        contest_ask_cnt = 0
+        contest_notification_cnt = 0
 
         reply = False
         ask_cnt = 0
@@ -25,7 +27,23 @@ class IndexHandler(RequestHandler):
             if contest_id != 0:
                 _, contest = await ContestService.inst.get_contest(contest_id)
                 if contest.is_admin(self.acct):
+                    res = await self.db.fetch('SELECT COUNT(*) FROM contest_question WHERE contest_id = $1 AND reply_acct_id IS NULL;', contest_id)
+                    contest_ask_cnt = res[0]['count']
                     contest_manage = True
+
+                elif contest.is_member(self.acct, UserStatus.APPROVED):
+                    new_cnt = await self.db.fetch('''
+                    SELECT
+                        (SELECT COUNT(*) FROM contest_announcement WHERE contest_id = $1) +
+                        (SELECT COUNT(*) FROM contest_question WHERE contest_id = $1 AND ask_acct_id = $2 AND reply_acct_id IS NOT NULL)
+                    AS total_count;
+                    ''', contest.contest_id, self.acct.acct_id)
+                    new_cnt = new_cnt[0]['total_count']
+
+                    old_cnt = await self.db.fetch('SELECT notification_read_count FROM contest_users WHERE contest_id = $1 AND acct_id = $2',
+                                                  contest.contest_id, self.acct.acct_id)
+                    old_cnt = old_cnt[0]['notification_read_count']
+                    contest_notification_cnt = max(new_cnt - old_cnt, 0)
 
         if self.acct.is_kernel():
             _, _, ask_cnt = await QuestionService.inst.get_asklist()
@@ -33,7 +51,7 @@ class IndexHandler(RequestHandler):
         elif not self.acct.is_guest():
             reply = await QuestionService.inst.have_reply(self.acct.acct_id)
 
-        await self.render('index', ask_cnt=ask_cnt, reply=reply,
+        await self.render('index', ask_cnt=ask_cnt, reply=reply, contest_ask_cnt=contest_ask_cnt, contest_notification_cnt=contest_notification_cnt,
                           is_in_contest=is_in_contest, contest_manage=contest_manage, contest_id=contest_id, contest=contest)
 
 

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -319,6 +319,65 @@ class ContestService:
 
         return None, None
 
+    async def add_announce(self, contest_id: int, acct_id: int, subject: str, content: str):
+        res = await self.db.fetch('INSERT INTO contest_announcement ("contest_id", "acct_id", "subject", "content", "timestamp") VALUES ($1, $2, $3, $4, NOW()) RETURNING announce_id',
+                                  contest_id, acct_id, subject, content)
+
+        if len(res) != 1:
+            return ('Eunk', 'Unknown error'), None
+
+        return None, res[0]['announce_id']
+
+    async def edit_announce(self, contest_id: int, announce_id: int, subject: str, content: str):
+        await self.db.execute('UPDATE contest_announcement SET subject = $1, content = $2, timestamp = NOW() WHERE contest_id = $3 AND announce_id = $4',
+                              subject, content, contest_id, announce_id)
+
+        res = await self.db.fetch('SELECT acct_id FROM contest_users WHERE contest_id = $1 AND status = $2', contest_id, UserStatus.APPROVED)
+        for acct_id in res:
+            await self.db.execute('UPDATE contest_users SET notification_read_count = GREATEST(notification_read_count - 1, 0) WHERE contest_id = $1 AND acct_id = $2',
+                                  contest_id, int(acct_id[0]))
+
+        return None, None
+
+    async def get_all_announce(self, contest_id: int):
+        res = await self.db.fetch('SELECT * FROM contest_announcement WHERE contest_id = $1 ORDER BY "timestamp" DESC', contest_id)
+        return None, res
+
+    async def get_announce(self, contest_id: int, announce_id: int):
+        res = await self.db.fetch('SELECT * FROM contest_announcement WHERE contest_id = $1 AND announce_id = $2',
+                                  contest_id, announce_id)
+        if len(res) != 1:
+            return ('Eunk', 'Unknown error'), None
+
+        return None, res[0]
+
+    async def ask_question(self, contest_id: int, ask_acct_id: int, ask_subject: str, ask_content: str):
+        res = await self.db.fetch('INSERT INTO contest_question (contest_id, ask_subject, ask_content, ask_acct_id, ask_timestamp) VALUES ($1, $2, $3, $4, NOW()) RETURNING question_id',
+                                  contest_id, ask_subject, ask_content, ask_acct_id)
+        if len(res) != 1:
+            return ('Eunk', 'Unknown error'), None
+
+        return None, res[0]['question_id']
+
+    async def reply_question(self, contest_id: int, question_id: int, reply_acct_id: int, reply_content: str):
+        await self.db.execute('UPDATE contest_question SET reply_content = $1, reply_acct_id = $2, reply_timestamp = NOW() WHERE contest_id = $3 AND question_id = $4;',
+                              reply_content, reply_acct_id, contest_id, question_id)
+
+        return None, None
+
+    async def get_all_question(self, contest_id: int, ask_acct_id: int = 0):
+        if ask_acct_id:
+            res = await self.db.fetch('SELECT * FROM contest_question WHERE contest_id = $1 AND ask_acct_id = $2', contest_id, ask_acct_id)
+        else:
+            res = await self.db.fetch('SELECT * FROM contest_question WHERE contest_id = $1', contest_id)
+
+        return None, res
+
+    async def get_need_reply_question_cnt(self, contest_id: int):
+        res = await self.db.fetch('SELECT COUNT(*) FROM contest_question WHERE contest_id = $1 AND reply_acct_id IS NULL;', contest_id)
+        return None, res[0]['count']
+
+
     async def get_ioi2013_scores(self, contest_id: int, pro_id: int, before_time: datetime.datetime) -> dict:
         _, contest = await self.get_contest(contest_id)
         res = await self.db.fetch(

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -285,7 +285,7 @@ var index = new function() {
         info: 'info',
     });
 
-    that.show_notify_dialog = function(msg, dialog_type) {
+    that.show_notify_dialog = function(msg, dialog_type, custom_title=null) {
         let title = '';
         switch (dialog_type) {
             case this.DIALOG_TYPE.error:
@@ -300,6 +300,10 @@ var index = new function() {
             case this.DIALOG_TYPE.info:
                 title = 'Info';
                 break;
+        }
+
+        if (custom_title) {
+            title = custom_title;
         }
 
         // inject html to <body>

--- a/src/static/templ/contests/manage/announce.html
+++ b/src/static/templ/contests/manage/announce.html
@@ -1,0 +1,151 @@
+{% extends 'manage.html' %}
+{% block head %}
+<script type="text/javascript">
+    function init() {
+        $("#add").on('click', function(e) {
+            let subject = $("#form").find("#subject").val();
+            if (subject.length == 0) {
+                index.show_notify_dialog('Subject should not be empty.', index.DIALOG_TYPE.warning);
+                return;
+            }
+
+            let content = $("#form").find("#content").val();
+            if (content.length == 0) {
+                index.show_notify_dialog('Content should not be empty.', index.DIALOG_TYPE.warning);
+                return;
+            }
+
+            $.post('/oj/be/contests/{{ contest_id }}/manage/announce', {
+                reqtype: 'add-announce',
+                subject: subject,
+                content: content,
+            }, function (res) {
+                res = JSON.parse(res);
+                if (res.status == 'S') {
+                    index.show_notify_dialog('Add announcement successfully', index.DIALOG_TYPE.success);
+                    index.reload();
+                } else {
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
+                }
+            });
+        });
+
+        $("td.announce").each((_, element) => {
+            let td = $(element);
+            let announce_id = td.attr('announce_id');
+            td.find(".edit").on('click', function(e) {
+                td.find("form").show();
+                td.find(".view").hide();
+            });
+
+            td.find(".popup").on('click', function(e) {
+                $.post('/oj/be/contests/{{ contest_id }}/manage/announce', {
+                    reqtype: 'popup-announce',
+                    announce_id: announce_id,
+                }, function (res) {
+                    res = JSON.parse(res);
+                    if (res.status == 'S') {
+                        index.show_notify_dialog('Popup announcement successfully', index.DIALOG_TYPE.success);
+                        index.reload();
+                    } else {
+                        index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
+                    }
+                });
+            });
+
+            td.find("#cancel").on('click', function (e) {
+                td.find("form").hide();
+                td.find(".view").show();
+            })
+
+            td.find("#update").on('click', function (e) {
+                let subject = td.find("#subject").val();
+                if (subject.length == 0) {
+                    index.show_notify_dialog('Subject should not be empty.', index.DIALOG_TYPE.warning);
+                    return;
+                }
+
+                let content = td.find("#content").val();
+                if (content.length == 0) {
+                    index.show_notify_dialog('Content should not be empty.', index.DIALOG_TYPE.warning);
+                    return;
+                }
+
+                $.post('/oj/be/contests/{{ contest_id }}/manage/announce', {
+                    reqtype: 'edit-announce',
+                    announce_id: announce_id,
+                    subject: subject,
+                    content: content,
+                }, function (res) {
+                    res = JSON.parse(res);
+                    if (res.status == 'S') {
+                        index.show_notify_dialog('Edit announcement successfully', index.DIALOG_TYPE.success);
+                        index.reload();
+                    } else {
+                        index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
+                    }
+                });
+            });
+        });
+    }
+</script>
+{% end %}
+
+{% block content %}
+<div class="col-lg-10 ms-lg-2 mt-lg-2">
+    <form id="form">
+        <label for="" class="form-label">Add Announcement</label>
+		<div class="mb-1">
+            <label for="title" class="form-label">Subject</label>
+			<input class="form-control" id="subject" type="text">
+		</div>
+
+		<div class="mb-1">
+            <label for="content">Content</label>
+			<textarea class="form-control" name="content" id="content"></textarea>
+		</div>
+
+        <div class="mb-1">
+            <button class="btn btn-primary" id="add" type="button">Add</button>
+        </div>
+    </form>
+
+    <table class="table">
+        <tbody>
+            {% for announce in announces %}
+            <tr>
+                <td class="announce" announce_id={{ announce['announce_id'] }}>
+                    <form style="display: none;">
+                        <div class="mb-1">
+                            <label for="title" class="form-label">Subject</label>
+                            <input class="form-control" id="subject" type="text" value="{{ announce['subject'] }}">
+                        </div>
+
+                        <div class="mb-1">
+                            <label for="content">Content</label>
+                            <textarea class="form-control" name="content" id="content">{{ announce['content'] }}</textarea>
+                        </div>
+
+                        <div class="mb-1">
+                            <button class="btn btn-primary" id="update" type="button">Update</button>
+                            <button class="btn btn-secondary" id="cancel" type="button">Cancel</button>
+                        </div>
+                    </form>
+                    <div class="view">
+                        <div class="card mt-2">
+                            <div class="card-body">
+                                <h4 class="card-title">{{ announce['subject'] }}</h4>
+                                <p class="card-text">{{ announce['content'] }}</p>
+                                <h6>{{ announce['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                            </div>
+                        </div>
+                        <button class="btn btn-primary edit">Edit</button>
+                        <button class="btn btn-warning popup">Popup</button>
+                    </div>
+                </td>
+            </tr>
+            {% end %}
+        </tbody>
+    </table>
+</div>
+{% end %}

--- a/src/static/templ/contests/manage/manage.html
+++ b/src/static/templ/contests/manage/manage.html
@@ -8,7 +8,8 @@
 		<a href="/oj/contests/{{ contest_id }}/manage/acct/" class="nav-link {% if page == 'acct' %} active{% end %}">Account</a>
 		<a href="/oj/contests/{{ contest_id }}/manage/pro/" class="nav-link {% if page == 'pro' %} active{% end %}">Problem</a>
 		<a href="/oj/contests/{{ contest_id }}/manage/reg/" class="nav-link {% if page == 'reg' %} active{% end %}">Registration</a>
-		<a href="/oj/contests/{{ contest_id }}/manage/question/" class="nav-link{% if page == 'question' %} active{% end %}">Q & A</a>
+		<a href="/oj/contests/{{ contest_id }}/manage/question/" class="nav-link{% if page == 'question' %} active{% end %}">Question</a>
+		<a href="/oj/contests/{{ contest_id }}/manage/announce/" class="nav-link{% if page == 'announce' %} active{% end %}">Announce</a>
 	</nav>
 </div>
 {% block content %}{% end %}

--- a/src/static/templ/contests/manage/question.html
+++ b/src/static/templ/contests/manage/question.html
@@ -1,0 +1,121 @@
+{% extends 'manage.html' %}
+{% block head %}
+<script type="text/javascript">
+    function init() {
+        $("td.reply").each((_, element) => {
+            let td = $(element);
+            let question_id = td.attr('question_id');
+            td.find(".edit").on('click', function(e) {
+                td.find(".update").show();
+                td.find(".view").hide();
+            });
+
+            td.find(".cancel").on('click', function(e) {
+                td.find(".update").hide();
+                td.find(".view").show();
+            });
+
+            td.find(".answer-type").on('change', function(e) {
+                let t = $(this).val();
+                if (t === 'Other') {
+                    td.find("textarea").show();
+                } else {
+                    td.find("textarea").hide();
+                }
+            });
+
+            td.find("button.reply").on('click', function(e) {
+                let answer = td.find(".answer-type").val();
+                if (answer === 'Other') {
+                    answer = td.find("textarea").val();
+                    if (answer.length == 0) {
+                        index.show_notify_dialog('Reply answer should not be empty.', index.DIALOG_TYPE.warning);
+                        return;
+                    }
+                }
+
+                $.post('/oj/be/contests/{{ contest_id }}/manage/question', {
+                    reqtype: 'reply',
+                    content: answer,
+                    question_id: question_id,
+                }, function(res) {
+                    res = JSON.parse(res);
+                    if (res.status == 'S') {
+                        location.href = location.href;
+                    } else {
+                        index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
+                    }
+                });
+            });
+        });
+    }
+</script>
+{% end %}
+
+{% block content%}
+<div class="col-lg-10 ms-lg-2 mt-lg-2">
+    <div id="form">
+        <table class="table">
+            <thead>
+                <tr>
+                    <td>Question</td>
+                    <td colspan=2>Reply</td>
+                </tr>
+            </thead>
+
+            <tbody>
+            {% for question in questions %}
+                <tr>
+                    <td style="width: 50%">
+                        <div class="card mt-2">
+                            <div class="card-body">
+                                <h4 class="card-title">
+                                    <span>{{ question['ask_subject'] }}</span>
+                                    <span class="float-end"><a href="/oj/acct/{{ question['ask_acct'].acct_id }}/">{{ question['ask_acct'].name }}</a></span>
+                                </h4>
+                                <p class="card-text">{{ question['ask_content'] }}</p>
+                                <h6>Ask Time: {{ question['ask_timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                            </div>
+                        </div>
+                    </td>
+
+                    <td style="width: 50%" class="reply" question_id="{{ question['question_id'] }}">
+                        {% set replied = question['reply_timestamp'] is not None %}
+                        <div class="update" {% if replied %} style="display: none;" {% end %}>
+                            <label for="" class="form-label">Precompiled Answer</label>
+                            <select class="form-select answer-type">
+                                <option value="Yes">Yes</option>
+                                <option value="No">No</option>
+                                <option value="No comment">No comment</option>
+                                <option value="Answered in problem description">Answered in problem description</option>
+                                <option value="Invalid question">Invalid question</option>
+                                <option value="Other" selected>Other</option>
+                            </select>
+
+                            {% if replied %}
+                                <textarea class="form-control" cols="8" rows="4" style="white-space: pre-line;">{{ question['reply_content'] }}</textarea>
+                            {% else %}
+                                <textarea class="form-control" cols="8" rows="4" style="white-space: pre-line;"></textarea>
+                            {% end %}
+                            <button class="btn btn-primary reply">Reply</button>
+
+                            {% if replied %}
+                                <button class="btn btn-secondary cancel">Cancel</button>
+                            {% end %}
+                        </div>
+
+                        {% if replied %}
+                        <div class="view">
+                            <p><strong>Reply: {{ question['reply_content'] }}</strong></p>
+                            <h6>Reply Time: {{ question['reply_timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                            <button class="btn btn-primary edit">Edit Reply</button>
+                        </div>
+                        {% end %}
+                    </td>
+                </tr>
+            {% end %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% end %}

--- a/src/static/templ/contests/qa.html
+++ b/src/static/templ/contests/qa.html
@@ -1,0 +1,114 @@
+<script>
+    function init() {
+        // TODO: markdown feature
+
+        $("#ask").on('click', function(e) {
+            let subject = $("#subject").val();
+            let content = $("#content").val();
+
+            if (subject.length == 0) {
+                index.show_notify_dialog('Subject should not be empty', index.DIALOG_TYPE.warning);
+                return;
+            }
+
+            if (content.length == 0) {
+                index.show_notify_dialog('Content should not be empty', index.DIALOG_TYPE.warning);
+                return;
+            }
+
+            $.post('/oj/be/contests/{{ contest.contest_id }}/qa', {
+                'reqtype': 'ask',
+                'subject': subject,
+                'content': content,
+            }, function(res) {
+                res = JSON.parse(res);
+                if (res.status == 'S') {
+                    index.show_notify_dialog('Ask successfully', index.DIALOG_TYPE.success);
+                    index.reload();
+                } else {
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
+                }
+            });
+        });
+    }
+</script>
+
+<div class="row">
+    <div class="col-lg-5 col-12">
+        <h1>Announcement</h1>
+
+        <!-- TODO: add a button to close collapse when col-12 -->
+        <div class="announce" style="overflow-y:scroll; max-height: 80vh;">
+            {% for announce in announces %}
+                <div class="card mt-2">
+                    <div class="card-body">
+                        <h4 class="card-title">{{ announce['subject'] }}</h4>
+                        <p class="card-text">{{ announce['content'] }}</p>
+                        <h6>{{ announce['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                    </div>
+                </div>
+            {% end %}
+        </div>
+    </div>
+
+    <div class="col-lg-7 col-12">
+        <div class="row">
+            <h1>Question</h1>
+            <form>
+                <div class="mb-1">
+                    <label for="title" class="form-label">Subject</label>
+                    <input class="form-control" id="subject" type="text">
+                </div>
+
+                <div class="mb-1">
+                    <label for="content">Content</label>
+                    <textarea class="form-control" name="content" id="content"></textarea>
+                </div>
+
+                <div class="mt-2">
+                    <button type="button" class="btn btn-primary" id="ask">Ask</button>
+                </div>
+            </form>
+        </div>
+        <div class="row">
+            <h1>Reply</h1>
+            <div style="overflow-y:scroll; max-height: 50vh;">
+                <table border=1 class="table">
+                    <thead>
+                        <tr>
+                            <td>Question</td>
+                            <td colspan=2>Reply</td>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                    {% for question in questions %}
+                        <tr>
+                            <td style="width: 50%">
+                                <div class="card mt-2">
+                                    <div class="card-body">
+                                        <h4 class="card-title">{{ question['ask_subject'] }}</h4>
+                                        <p class="card-text">{{ question['ask_content'] }}</p>
+                                        <h6>{{ question['ask_timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                                    </div>
+                                </div>
+                            </td>
+
+                            <td style="width: 50%">
+                                <div class="card mt-2">
+                                    <div class="card-body">
+                                        {% if question['reply_timestamp'] %}
+                                        <p class="card-text">{{ question['reply_content'] }}</p>
+                                        <h6>{{ question['reply_timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                                        {% end %}
+                                    </div>
+                                </div>
+                            </td>
+                        </tr>
+                    {% end %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/static/templ/index.html
+++ b/src/static/templ/index.html
@@ -61,34 +61,65 @@
         index.go('/oj/info/');
       });
 
-      {% if is_in_contest and not contest.is_end() %}
-        var contest_start = new Date("{{ contest.contest_start }}");
-        var contest_end = new Date("{{ contest.contest_end }}");
-        var started = false, ended = false;
-        function timer1() {
-            let cur_time = new Date();
-            if (cur_time >= contest_start && !started) {
-                started = true;
-                if (confirm("The contest has started. Do you want to reload the page?")) {
-                    index.reload();
+    {% if is_in_contest %}
+        {% if not contest.is_end() %}
+            var contest_start = new Date("{{ contest.contest_start }}");
+            var contest_end = new Date("{{ contest.contest_end }}");
+            var started = false, ended = false;
+            function timer1() {
+                let cur_time = new Date();
+                if (cur_time >= contest_start && !started) {
+                    started = true;
+                    if (confirm("The contest has started. Do you want to reload the page?")) {
+                        index.reload();
+                    }
                 }
             }
-        }
-        function timer2() {
-            let cur_time = new Date();
-            if (cur_time >= contest_end && !ended) {
-                ended = true;
-                if (confirm("The contest has ended. Do you want to reload the page?")) {
-                    index.reload();
+            function timer2() {
+                let cur_time = new Date();
+                if (cur_time >= contest_end && !ended) {
+                    ended = true;
+                    if (confirm("The contest has ended. Do you want to reload the page?")) {
+                        index.reload();
+                    }
                 }
             }
-        }
-        let cur_time = new Date();
-        if (cur_time < contest_start) {
-            setInterval(timer1, 1);
-        } else if (cur_time > contest_start && cur_time < contest_end) {
-            setInterval(timer2, 1);
-        }
+            let cur_time = new Date();
+            if (cur_time < contest_start) {
+                setInterval(timer1, 1);
+            } else if (cur_time > contest_start && cur_time < contest_end) {
+                setInterval(timer2, 1);
+            }
+        {% end %}
+
+        {% if contest.is_admin(user) %}
+            let ws = index.get_ws("contests/{{ contest.contest_id }}/manage/qasub");
+            let contest_ask_cnt = parseInt("{{ contest_ask_cnt }}");
+            ws.onopen = (e) => {
+                ws.send("{{ contest.contest_id }}");
+            };
+            ws.onmessage = (e) => {
+                contest_ask_cnt += 1;
+                $("#notifyRedDot").text(contest_ask_cnt);
+                $("#notifyRedDot").show();
+            };
+        {% elif contest.is_start() %}
+            let ws = index.get_ws("contests/{{ contest.contest_id }}/qasub");
+            let contest_notification_cnt = parseInt("{{ contest_notification_cnt }}");
+            ws.onopen = (e) => {
+                ws.send("{{ contest.contest_id }}");
+            };
+            ws.onmessage = (e) => {
+                e = JSON.parse(e.data);
+                if (e.type == 'popup-announce') {
+                    index.show_notify_dialog(e.content, index.DIALOG_TYPE.info, e.subject);
+                } else {
+                    contest_notification_cnt += 1;
+                    $("#notifyRedDot").text(contest_notification_cnt);
+                    $("#notifyRedDot").show();
+                }
+            };
+        {% end %}
     {% end %}
 
     });
@@ -119,10 +150,35 @@
           <li class="nav-item proset"><a class="nav-link" href="/oj/contests/{{ contest_id }}/proset/">ProblemSet</a></li>
           <li class="nav-item chal"><a class="nav-link" href="/oj/contests/{{ contest_id }}/chal/">Challenges</a></li>
           <li class="nav-item scoreboard"><a class="nav-link" href="/oj/contests/{{ contest_id }}/scoreboard/">Scoreboard</a></li>
-          <li class="nav-item question"></li><a class="nav-link" href="/oj/contests/{{ contest_id }}/question/">Q & A</a></li>
+
+          {% if not contest_manage %}
+            <li class="nav-item qa"></li>
+                <a class="nav-link position-relative" href="/oj/contests/{{ contest_id }}/qa/">
+                    Q & A
+                    <span
+                        class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
+                        {% if not contest_notification_cnt %} style="display: none;" {% end %}
+                        id="notifyRedDot"
+                    >
+                        {{ contest_notification_cnt }}
+                    </span>
+                </a>
+            </li>
+          {% end %}
 
           {% if contest_manage %}
-            <li class="nav-item manage"><a class="nav-link" href="/oj/contests/{{ contest_id }}/manage/">Manage</a></li>
+            <li class="nav-item manage">
+                <a class="nav-link position-relative" href="/oj/contests/{{ contest_id }}/manage/">
+                    Manage
+                    <span
+                        class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
+                        {% if not contest_ask_cnt %} style="display: none;" {% end %}
+                        id="notifyRedDot"
+                    >
+                        {{ contest_ask_cnt }}
+                    </span>
+                </a>
+            </li>
           {% end %}
         </ul>
         {% else %}

--- a/src/tests/e2e/board.py
+++ b/src/tests/e2e/board.py
@@ -6,13 +6,14 @@ from .util import AsyncTest, AccountContext
 
 class BoardTest(AsyncTest):
     async def main(self):
+        now = datetime.datetime.now()
         with AccountContext('admin@test', 'testtest') as admin_session:
             res = admin_session.post('manage/board/add', data={
                 'reqtype': 'add',
                 'name': 'board1',
                 'status': BoardConst.STATUS_ONLINE,
-                'start': self.get_isoformat(datetime.datetime.now() - datetime.timedelta(days=7)),
-                'end': self.get_isoformat(datetime.datetime.now() + datetime.timedelta(days=7)),
+                'start': self.get_isoformat(now - datetime.timedelta(days=7)),
+                'end': self.get_isoformat(now + datetime.timedelta(days=7)),
                 'pro_list': '1, 2',
                 'acct_list': '1',
             })
@@ -28,9 +29,9 @@ class BoardTest(AsyncTest):
             self.assertEqual(html.select_one('input#name').attrs.get('value').strip(), 'board1')
             self.assertIsNotNone(html.select('option')[0].attrs.get('selected'))
             self.assertEqual(html.select_one('input#datepickerStartInput').attrs.get('value'),
-                             (datetime.datetime.now() - datetime.timedelta(days=7)).strftime('%Y/%m/%d %H:%M'))
+                             (now - datetime.timedelta(days=7)).strftime('%Y/%m/%d %H:%M'))
             self.assertEqual(html.select_one('input#datepickerEndInput').attrs.get('value'),
-                             (datetime.datetime.now() + datetime.timedelta(days=7)).strftime('%Y/%m/%d %H:%M'))
+                             (now + datetime.timedelta(days=7)).strftime('%Y/%m/%d %H:%M'))
             self.assertEqual(html.select_one('input#pro_list').attrs.get('value').strip(), '1,2')
             self.assertEqual(html.select_one('input#acct_list').attrs.get('value').strip(), '1')
 
@@ -61,8 +62,8 @@ class BoardTest(AsyncTest):
                 'board_id': 1,
                 'name': 'board1',
                 'status': BoardConst.STATUS_HIDDEN,
-                'start': self.get_isoformat(datetime.datetime.now() - datetime.timedelta(days=14)),
-                'end': self.get_isoformat(datetime.datetime.now() - datetime.timedelta(days=7)),
+                'start': self.get_isoformat(now - datetime.timedelta(days=14)),
+                'end': self.get_isoformat(now - datetime.timedelta(days=7)),
                 'pro_list': '1, 2',
                 'acct_list': '1',
             })
@@ -100,8 +101,8 @@ class BoardTest(AsyncTest):
                 'board_id': 1,
                 'name': 'board1',
                 'status': BoardConst.STATUS_OFFLINE,
-                'start': self.get_isoformat(datetime.datetime.now() - datetime.timedelta(days=14)),
-                'end': self.get_isoformat(datetime.datetime.now() - datetime.timedelta(days=7)),
+                'start': self.get_isoformat(now - datetime.timedelta(days=14)),
+                'end': self.get_isoformat(now - datetime.timedelta(days=7)),
                 'pro_list': '1, 2',
                 'acct_list': '1',
             })

--- a/src/tests/e2e/contest.py
+++ b/src/tests/e2e/contest.py
@@ -498,8 +498,175 @@ class ContestTest(AsyncTest):
             res = user_session.get('pro/8')
             self.assertAPIReturnValue(res.text, ('Enoext', 'Problem not found'))
 
+        def _message(msg):
+            if msg is None:
+                return
 
-        # is_public_scoreboard: bool = False
+            self.assertEqual(int(msg), 1)
+
+        ws = await websocket_connect('ws://localhost:5501/contests/1/manage/qasub', on_message_callback=_message)
+        await ws.write_message("1")
+        with AccountContext('contest1@test', 'test') as user_session:
+            res = user_session.post('contests/1/qa', data={
+                'reqtype': 'ask',
+                'subject': 'subject',
+                'content': 'content',
+            })
+            self.assertAPIReturnSuccess(res.text)
+
+            html = self.get_html('contests/1/qa', user_session)
+            trs = html.select('table > tbody > tr')
+            td0 = trs[0].select('td')[0]
+            td1 = trs[0].select('td')[1]
+            self.assertEqual(td0.select_one('h4').text, 'subject')
+            self.assertEqual(td0.select_one('p').text, 'content')
+            self.assertIsNone(td1.select_one('p'))
+            self.assertIsNone(td1.select_one('h6'))
+            ws.close()
+
+        with AccountContext('admin@test', 'testtest') as admin_session:
+            html = self.get_html('index/contests/1', admin_session)
+            self.assertEqual(html.select_one('#notifyRedDot').text.strip(), "1")
+
+            html = self.get_html('contests/1/manage/question', admin_session)
+            trs = html.select('table > tbody > tr')
+            td0 = trs[0].select('td')[0]
+            td1 = trs[0].select('td')[1]
+            self.assertEqual(td0.select('h4 > span')[0].text, 'subject')
+            self.assertEqual(td0.select('h4 > span')[1].text, 'contest1')
+            self.assertEqual(td0.select_one('h4 > span > a').attrs['href'], '/oj/acct/4/')
+            self.assertEqual(td0.select_one('p').text, 'content')
+            self.assertIsNone(td1.select_one('div.view'))
+            self.assertIsNotNone(td1.select_one('div.update'))
+            self.assertEqual(td1.select_one('textarea').text, '')
+            question_id = int(html.select_one('td.reply').attrs['question_id'])
+            self.assertEqual(question_id, 1)
+
+            def _message(msg):
+                if msg is None:
+                    return
+
+                j = json.loads(msg)
+                self.assertEqual(j['contest_id'], 1)
+                self.assertEqual(j['type'], 'reply')
+            ws = await websocket_connect('ws://localhost:5501/contests/1/qasub', on_message_callback=_message)
+            await ws.write_message('1')
+            res = admin_session.post('contests/1/manage/question', data={
+                'reqtype': 'reply',
+                'content': 'answer',
+                'question_id': question_id
+            })
+            self.assertAPIReturnSuccess(res.text)
+            ws.close()
+
+            html = self.get_html('index/contests/1', admin_session)
+            self.assertEqual(html.select_one('#notifyRedDot').text.strip(), "0")
+            html = self.get_html('contests/1/manage/question', admin_session)
+            trs = html.select('table > tbody > tr')
+            td1 = trs[0].select('td')[1]
+            self.assertIsNotNone(td1.select_one('div.view'))
+            self.assertEqual(td1.select_one('p').text, 'Reply: answer')
+            self.assertIsNotNone(td1.select_one('div.view').select_one('h6'))
+            self.assertEqual(td1.select_one('textarea').text, 'answer')
+
+        with AccountContext('contest1@test', 'test') as user_session:
+            html = self.get_html('index/contests/1', user_session)
+            self.assertEqual(html.select_one('#notifyRedDot').text.strip(), "1")
+
+            html = self.get_html('contests/1/qa', user_session)
+            trs = html.select('table > tbody > tr')
+            td0 = trs[0].select('td')[0]
+            td1 = trs[0].select('td')[1]
+            self.assertEqual(td1.select_one('p').text, 'answer')
+            self.assertIsNotNone(td1.select_one('h6'))
+
+            html = self.get_html('index/contests/1', user_session)
+            self.assertEqual(html.select_one('#notifyRedDot').text.strip(), "0")
+
+        with AccountContext('admin@test', 'testtest') as admin_session:
+            def _message(msg):
+                if msg is None:
+                    return
+
+                j = json.loads(msg)
+                self.assertEqual(j['contest_id'], 1)
+                self.assertEqual(j['type'], 'add-announce')
+
+            ws = await websocket_connect('ws://localhost:5501/contests/1/qasub', on_message_callback=_message)
+            await ws.write_message("1")
+            res = admin_session.post('contests/1/manage/announce', data={
+                'reqtype': 'add-announce',
+                'subject': 'subject',
+                'content': 'content',
+            })
+            self.assertAPIReturnSuccess(res.text)
+            ws.close()
+
+        with AccountContext('contest1@test', 'test') as user_session:
+            html = self.get_html('index/contests/1', user_session)
+            self.assertEqual(html.select_one('#notifyRedDot').text.strip(), "1")
+
+            html = self.get_html('contests/1/qa', user_session)
+            announces = html.select_one('div.announce')
+            self.assertEqual(announces.select(".card-body")[0].select_one('h4').text, 'subject')
+            self.assertEqual(announces.select(".card-body")[0].select_one('p').text, 'content')
+
+            html = self.get_html('index/contests/1', user_session)
+            self.assertEqual(html.select_one('#notifyRedDot').text.strip(), "0")
+
+        with AccountContext('admin@test', 'testtest') as admin_session:
+            def _message(msg):
+                if msg is None:
+                    return
+
+                j = json.loads(msg)
+                self.assertEqual(j['contest_id'], 1)
+                self.assertEqual(j['type'], 'edit-announce')
+
+            ws = await websocket_connect('ws://localhost:5501/contests/1/qasub', on_message_callback=_message)
+            await ws.write_message("1")
+            res = admin_session.post('contests/1/manage/announce', data={
+                'reqtype': 'edit-announce',
+                'subject': 'subject2',
+                'content': 'content2',
+                'announce_id': 1,
+            })
+            self.assertAPIReturnSuccess(res.text)
+            ws.close()
+
+        with AccountContext('contest1@test', 'test') as user_session:
+            html = self.get_html('index/contests/1', user_session)
+            self.assertEqual(html.select_one('#notifyRedDot').text.strip(), "1")
+
+            html = self.get_html('contests/1/qa', user_session)
+            announces = html.select_one('div.announce')
+            self.assertEqual(announces.select(".card-body")[0].select_one('h4').text, 'subject2')
+            self.assertEqual(announces.select(".card-body")[0].select_one('p').text, 'content2')
+
+            html = self.get_html('index/contests/1', user_session)
+            self.assertEqual(html.select_one('#notifyRedDot').text.strip(), "0")
+
+        with AccountContext('admin@test', 'testtest') as admin_session:
+            def _message(msg):
+                if msg is None:
+                    return
+
+                j = json.loads(msg)
+                self.assertEqual(j['contest_id'], 1)
+                self.assertEqual(j['type'], 'popup-announce')
+
+            ws = await websocket_connect('ws://localhost:5501/contests/1/qasub', on_message_callback=_message)
+            await ws.write_message("1")
+            res = admin_session.post('contests/1/manage/announce', data={
+                'reqtype': 'popup-announce',
+                'announce_id': 1,
+            })
+            self.assertAPIReturnSuccess(res.text)
+            ws.close()
+
+            res = admin_session.get('contests/1/qa')
+            self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
+
         # freeze_scoreboard_period: int = 0
 
         # test scoreboard, challist


### PR DESCRIPTION
In this PR, we introduce question and announce function.

Participants can ask questions, and the admin interface will display the number of inquiries.
Admins can post announcements and send global notifications, which will be displayed as pop-up messages on the participant interface.

Additionally, fixed an issue in the board test.