### PR TITLE
fix: contest and manage fixes and impr

### DIFF
--- a/src/handlers/acct.py
+++ b/src/handlers/acct.py
@@ -19,13 +19,11 @@ class AcctHandler(RequestHandler):
         acct_id = int(acct_id)
         err, acct = await UserService.inst.info_acct(acct_id)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         err, rate_data = await RateService.inst.get_acct_rate_and_chal_cnt(acct)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         max_status = ProService.inst.get_acct_limit(self.acct)
         async with self.db.acquire() as con:
@@ -71,13 +69,11 @@ class AcctConfigHandler(RequestHandler):
     @reqenv
     async def get(self, acct_id=None):
         if acct_id is None:
-            self.error(('Enoext', 'Missing parameter acct_id'))
-            return
+            return self.error(('Enoext', 'Missing parameter acct_id'))
         acct_id = int(acct_id)
         err, acct = await UserService.inst.info_acct(acct_id)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         await self.render('acct/acct-config', acct=acct)
 
@@ -94,8 +90,7 @@ class AcctConfigHandler(RequestHandler):
             target_acct_id = self.get_argument('acct_id')
 
             if target_acct_id != str(self.acct.acct_id):
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             self.acct.name = name
             self.acct.photo = photo
@@ -103,11 +98,9 @@ class AcctConfigHandler(RequestHandler):
             self.acct.motto = motto
             err, _ = await UserService.inst.update_acct(self.acct)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
-            self.error(('S', ''))
-            return
+            return self.error(('S', ''))
 
         elif reqtype == 'reset':
             old = self.get_argument('old')
@@ -115,24 +108,20 @@ class AcctConfigHandler(RequestHandler):
             target_acct_id = int(self.get_argument('acct_id'))
 
             if not (self.acct.acct_id == target_acct_id or self.acct.is_kernel()):
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             err, _ = await UserService.inst.update_pw(target_acct_id, old, pw, self.acct.is_kernel())
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             if not err and target_acct_id != self.acct.acct_id:
                 await LogService.inst.add_log(
                     f"{self.acct.name} was changing the password of user #{target_acct_id}.", 'manage.acct.update.pwd'
                 )
 
-            self.error(('S', ''))
-            return
+            return self.error(('S', ''))
 
-        self.error(('Eunk', 'Unknown error'))
-
+        return self.error(('Eunk', 'Unknown error'))
 class AcctProClassHandler(RequestHandler):
     @reqenv
     @require_permission([UserConst.ACCTTYPE_USER, UserConst.ACCTTYPE_KERNEL])
@@ -155,8 +144,7 @@ class AcctProClassHandler(RequestHandler):
             proclass_id = int(self.get_argument('proclassid'))
             _, proclass = await ProClassService.inst.get_proclass(proclass_id)
             if proclass['acct_id'] != self.acct.acct_id:
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             await self.render('acct/proclass-update', proclass_id=proclass_id, proclass=proclass)
 
@@ -174,20 +162,16 @@ class AcctProClassHandler(RequestHandler):
             p_list = parse_list_str(p_list_str)
 
             if err := self.len_check(name, ProClassConst.NAME_MIN, ProClassConst.NAME_MAX, 'Name'):
-                self.error(err)
-                return
+                return self.error(err)
 
             if err := self.len_check(desc, ProClassConst.DESC_MIN, ProClassConst.DESC_MAX, 'Desc'):
-                self.error(err)
-                return
+                return self.error(err)
 
             if proclass_type not in [ProClassConst.USER_PUBLIC, ProClassConst.USER_HIDDEN]:
-                self.error(('Eparam', 'Invalid problem class type'))
-                return
+                return self.error(('Eparam', 'Invalid problem class type'))
 
             if len(p_list) == 0:
-                self.error(('Eparam', 'Problem list should not be empty'))
-                return
+                return self.error(('Eparam', 'Problem list should not be empty'))
 
             if reqtype == 'add':
                 await LogService.inst.add_log(
@@ -200,8 +184,7 @@ class AcctProClassHandler(RequestHandler):
                 )
                 err, proclass_id = await ProClassService.inst.add_proclass(name, p_list, desc, acct_id, proclass_type)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 self.error(('S', proclass_id))
 
@@ -213,8 +196,7 @@ class AcctProClassHandler(RequestHandler):
                     await LogService.inst.add_log(
                         f"{self.acct.name} tried to remove proclass name={proclass['name']}, but this proclass is not owned by them", 'user.proclass.update.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 await LogService.inst.add_log(
                     f"{self.acct.name} update proclass name={name}", 'user.proclass.update',
@@ -224,10 +206,8 @@ class AcctProClassHandler(RequestHandler):
                         "proclass_type": proclass_type,
                     }
                 )
-                err = await ProClassService.inst.update_proclass(proclass_id, name, p_list, desc, proclass_type)
-                if err:
-                    self.error(err)
-                    return
+                if err := await ProClassService.inst.update_proclass(proclass_id, name, p_list, desc, proclass_type):
+                    return self.error(err)
 
                 self.error(('S', ''))
 
@@ -236,15 +216,13 @@ class AcctProClassHandler(RequestHandler):
             err, proclass = await ProClassService.inst.get_proclass(proclass_id)
 
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             if proclass['acct_id'] != self.acct.acct_id:
                 await LogService.inst.add_log(
                     f"{self.acct.name} tried to remove proclass name={proclass['name']}, but this proclass is not owned by them", 'user.proclass.remove.failed'
                 )
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             await LogService.inst.add_log(
                 f"{self.acct.name} remove proclass name={proclass['name']}.", 'user.proclass.remove'
@@ -277,8 +255,7 @@ class SignHandler(RequestHandler):
                         'err': err,
                     },
                 )
-                self.error(err)
-                return
+                return self.error(err)
 
             await LogService.inst.add_log(
                 f'#{acct_id} sign in successfully', 'signin.success', {'type': 'signin.success', 'acct_id': acct_id}
@@ -294,8 +271,7 @@ class SignHandler(RequestHandler):
 
             err, acct_id = await UserService.inst.sign_up(mail, pw, name)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             self.set_secure_cookie('id', str(acct_id), path='/oj', httponly=True)
             self.error(('S', ''))

--- a/src/handlers/acct.py
+++ b/src/handlers/acct.py
@@ -173,22 +173,12 @@ class AcctProClassHandler(RequestHandler):
             p_list_str = self.get_argument('list')
             p_list = parse_list_str(p_list_str)
 
-            name_len = len(name)
-            desc_len = len(desc)
-            if name_len < ProClassConst.NAME_MIN:
-                self.error(('Eparam', 'Name too short'))
+            if err := self.len_check(name, ProClassConst.NAME_MIN, ProClassConst.NAME_MAX, 'Name'):
+                self.error(err)
                 return
 
-            elif name_len > ProClassConst.NAME_MAX:
-                self.error(('Eparam', 'Name too long'))
-                return
-
-            if desc_len < ProClassConst.DESC_MIN:
-                self.error(('Eparam', 'Desc too short'))
-                return
-
-            elif desc_len > ProClassConst.DESC_MAX:
-                self.error(('Eparam', 'Desc too long'))
+            if err := self.len_check(desc, ProClassConst.DESC_MIN, ProClassConst.DESC_MAX, 'Desc'):
+                self.error(err)
                 return
 
             if proclass_type not in [ProClassConst.USER_PUBLIC, ProClassConst.USER_HIDDEN]:

--- a/src/handlers/board.py
+++ b/src/handlers/board.py
@@ -18,16 +18,13 @@ class BoardHandler(RequestHandler):
         board_id = int(board_id)
         err, meta = await BoardService.inst.get_board(board_id)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         if meta['status'] == BoardConst.STATUS_OFFLINE:
-            self.error(('Eacces', 'Permission denied'))
-            return
+            return self.error(('Eacces', 'Permission denied'))
 
         if meta['status'] == BoardConst.STATUS_HIDDEN and not self.acct.is_kernel():
-            self.error(('Eacces', 'Permission denied'))
-            return
+            return self.error(('Eacces', 'Permission denied'))
 
         min_type = UserConst.ACCTTYPE_USER
         if self.acct.is_kernel():

--- a/src/handlers/bulletin.py
+++ b/src/handlers/bulletin.py
@@ -19,8 +19,7 @@ class BulletinHandler(RequestHandler):
         bulletin_id = int(bulletin_id)
         err, bulletin = await BulletinService.inst.get_bulletin(bulletin_id)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         await self.render('bulletin', bulletin=bulletin)
 

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -110,27 +110,22 @@ class ChalHandler(RequestHandler):
 
         err, chal = await ChalService.inst.get_chal(chal_id)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         if chal['contest_id'] and not self.contest:
-            self.error(('Enoext', 'Contest not found'))
-            return
+            return self.error(('Enoext', 'Contest not found'))
         elif self.contest:
             if not self.contest.is_start():
                 if self.contest.is_admin(acct_id=chal['acct_id']) and not self.contest.is_admin(self.acct):
-                    self.error(('Eacces', 'Permission denied'))
-                    return
+                    return self.error(('Eacces', 'Permission denied'))
 
             elif self.contest.is_running():
                 if self.contest.hide_admin and self.contest.is_admin(acct_id=chal['acct_id']) and not self.contest.is_admin(self.acct):
-                    self.error(('Eacces', 'Permission denied'))
-                    return
+                    return self.error(('Eacces', 'Permission denied'))
 
         err, pro = await ProService.inst.get_pro(chal['pro_id'], self.acct, is_contest=self.contest is not None)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         chal['comp_type'] = ChalConst.COMPILER_NAME[chal['comp_type']]
 

--- a/src/handlers/code.py
+++ b/src/handlers/code.py
@@ -17,8 +17,7 @@ class CodeHandler(RequestHandler):
 
         err, code, comp_type = await CodeService.inst.get_code(chal_id, self.acct)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         if comp_type in ['gcc', 'g++', 'clang', 'clang++']:
             comp_type = 'cpp'

--- a/src/handlers/contests/manage/acct.py
+++ b/src/handlers/contests/manage/acct.py
@@ -34,8 +34,7 @@ class ContestManageAcctHandler(RequestHandler):
         elif list_type == "admin":
             status = UserStatus.ADMIN
         else:
-            self.error(('Eparam', 'Invalid list type'))
-            return
+            return self.error(('Eparam', 'Invalid list type'))
 
         if reqtype == "add":
             acct_id = int(acct_id)
@@ -49,8 +48,7 @@ class ContestManageAcctHandler(RequestHandler):
         elif reqtype == "remove":
             acct_id = int(acct_id)
             if acct_id not in self.contest.user_list:
-                self.error(('Enoext', 'User is not in contest'))
-                return
+                return self.error(('Enoext', 'User is not in contest'))
 
             self.contest.user_list.pop(acct_id)
             await ContestService.inst.update_contest(self.acct, self.contest, userlist_updated=True)
@@ -80,8 +78,7 @@ class ContestManageAcctHandler(RequestHandler):
             self.error(('S', f'Accounts(#{acct_list} successfully removed from user list.'))
 
         else:
-            self.error(('Eunk', 'Unknown error'))
-            return
+            return self.error(('Eunk', 'Unknown error'))
 
         if list_type == "normal" or (list_type == "admin" and not self.contest.hide_admin):
             await self.rs.delete(f"contest_{self.contest.contest_id}_scores")

--- a/src/handlers/contests/manage/general.py
+++ b/src/handlers/contests/manage/general.py
@@ -61,16 +61,13 @@ class ContestManageGeneralHandler(RequestHandler):
 
             err, contest_start = trantime(contest_start)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
             err, contest_end = trantime(contest_end)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
             err, reg_end = trantime(reg_end)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             self.contest.name = name
 
@@ -128,7 +125,7 @@ class ContestManageDescEditHandler(RequestHandler):
                 self.contest.desc_after_contest = desc
 
             else:
-                self.error(('Eunk', 'Unknown error'))
+                return self.error(('Eunk', 'Unknown error'))
 
             await ContestService.inst.update_contest(self.acct, self.contest)
 

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -34,8 +34,7 @@ class ContestManageProHandler(RequestHandler):
             pro_id = int(pro_id)
 
             if self.contest.is_pro(pro_id):
-                self.error(('Eexist', f'Problem(#{pro_id}) is already in contest'))
-                return
+                return self.error(('Eexist', f'Problem(#{pro_id}) is already in contest'))
 
             self.contest.pro_list[pro_id] = {
                 "score_type": ProblemScoreType.IOI2017.value
@@ -49,8 +48,7 @@ class ContestManageProHandler(RequestHandler):
             pro_id = int(pro_id)
 
             if not self.contest.is_pro(pro_id):
-                self.error(('Enoext', f'Problem(#{pro_id}) not in contest'))
-                return
+                return self.error(('Enoext', f'Problem(#{pro_id}) not in contest'))
 
             self.contest.pro_list.pop(pro_id)
 
@@ -86,13 +84,11 @@ class ContestManageProHandler(RequestHandler):
             pro_id = int(pro_id)
             can_submit = JudgeServerClusterService.inst.is_server_online()
             if not can_submit:
-                self.error(('Ejudge', 'No judge available'))
-                return
+                return self.error(('Ejudge', 'No judge available'))
 
             err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=True)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             async with self.db.acquire() as con:
                 result = await con.fetch(
@@ -128,22 +124,18 @@ class ContestManageProHandler(RequestHandler):
         elif reqtype == "public":
             pro_id = int(pro_id)
             if not self.contest.is_pro(pro_id):
-                self.error(('Enoext', f'Problem(#{pro_id}) not in contest'))
-                return
+                return self.error(('Enoext', f'Problem(#{pro_id}) not in contest'))
 
             if not self.contest.is_end():
-                self.error(('Etime', 'Contest is not over yet'))
-                return
+                return self.error(('Etime', 'Contest is not over yet'))
 
             err, pro = await ProService.inst.get_pro(pro_id, is_contest=True)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             err, _ = await ProService.inst.update_pro(pro_id, pro['name'], ProConst.STATUS_ONLINE, None, None, pro['tags'])
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             self.error(('S', ''))
 

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -15,7 +15,9 @@ class ContestManageProHandler(RequestHandler):
     async def get(self):
         pro_list = []
         for pro_id in self.contest.pro_list.keys():
-            _, pro = await ProService.inst.get_pro(pro_id, is_contest=True)
+            err, pro = await ProService.inst.get_pro(pro_id, is_contest=True)
+            if err:
+                continue
             pro_list.append(pro)
 
         await self.render('contests/manage/pro', page='pro', contest_id=self.contest.contest_id,

--- a/src/handlers/contests/manage/qa.py
+++ b/src/handlers/contests/manage/qa.py
@@ -59,20 +59,14 @@ class ContestManageQuestionHandler(RequestHandler):
         if reqtype == 'reply':
             question_id = int(self.get_argument('question_id'))
             content = self.get_argument('content').strip()
-            content_len = len(content)
-
-            if content_len < CONTENT_MIN:
-                self.error(('Eparam', 'Content too short'))
-                return
-
-            elif content_len > CONTENT_MAX:
-                self.error(('Eparam', 'Content too long'))
-                return
+            if err := self.len_check(content, CONTENT_MIN, CONTENT_MAX, 'Content'):
+                return self.error(err)
 
             err, question = await ContestService.inst.get_question(self.contest.contest_id, question_id)
             if err:
                 self.error(err)
                 return
+                return self.error(err)
 
             await ContestService.inst.reply_question(self.contest.contest_id, question_id, self.acct.acct_id, content)
             await self.rs.publish('contestnewqasub', json.dumps({
@@ -102,24 +96,10 @@ class ContestManageAnnounceHandler(RequestHandler):
         if reqtype in ['add-announce', 'edit-announce']:
             subject = self.get_argument('subject').strip()
             content = self.get_argument('content').strip()
-            subject_len = len(subject)
-            content_len = len(content)
-
-            if subject_len < SUBJECT_MIN:
-                self.error(('Eparam', 'Subject too short'))
-                return
-
-            elif subject_len > SUBJECT_MAX:
-                self.error(('Eparam', 'Subject too long'))
-                return
-
-            if content_len < CONTENT_MIN:
-                self.error(('Eparam', 'Content too short'))
-                return
-
-            elif content_len > CONTENT_MAX:
-                self.error(('Eparam', 'Content too long'))
-                return
+            if err := self.len_check(subject, SUBJECT_MIN, SUBJECT_MAX, 'Subject'):
+                return self.error(err)
+            if err := self.len_check(content, CONTENT_MIN, CONTENT_MAX, 'Content'):
+                return self.error(err)
 
             if reqtype == 'add-announce':
                 await ContestService.inst.add_announce(self.contest.contest_id, self.acct.acct_id, subject, content)

--- a/src/handlers/contests/manage/qa.py
+++ b/src/handlers/contests/manage/qa.py
@@ -117,20 +117,22 @@ class ContestManageAnnounceHandler(RequestHandler):
 
             if reqtype == 'add-announce':
                 await ContestService.inst.add_announce(self.contest.contest_id, self.acct.acct_id, subject, content)
-                await self.rs.publish('contestnewqasub', json.dumps({
-                    'contest_id': self.contest.contest_id,
-                    'type': 'add-announce'
-                }))
+                if self.contest.is_start():
+                    await self.rs.publish('contestnewqasub', json.dumps({
+                        'contest_id': self.contest.contest_id,
+                        'type': 'add-announce'
+                    }))
                 self.error(('S', ''))
 
             elif reqtype == 'edit-announce':
                 announce_id = int(self.get_argument('announce_id'))
 
                 await ContestService.inst.edit_announce(self.contest.contest_id, announce_id, subject, content)
-                await self.rs.publish('contestnewqasub', json.dumps({
-                    'contest_id': self.contest.contest_id,
-                    'type': 'edit-announce'
-                }))
+                if self.contest.is_start():
+                    await self.rs.publish('contestnewqasub', json.dumps({
+                        'contest_id': self.contest.contest_id,
+                        'type': 'edit-announce'
+                    }))
                 self.error(('S', ''))
 
         elif reqtype == 'popup-announce':

--- a/src/handlers/contests/manage/qa.py
+++ b/src/handlers/contests/manage/qa.py
@@ -46,7 +46,7 @@ class ContestManageQuestionHandler(RequestHandler):
         def _cmp(question):
             return (question['reply_acct_id'] is None, question['ask_timestamp'], question['reply_timestamp'])
 
-        questions2.sort(key=_cmp)
+        questions2.sort(key=_cmp, reverse=True)
 
 
         await self.render('contests/manage/question', page='question', contest_id=self.contest.contest_id,

--- a/src/handlers/contests/manage/qa.py
+++ b/src/handlers/contests/manage/qa.py
@@ -69,9 +69,15 @@ class ContestManageQuestionHandler(RequestHandler):
                 self.error(('Eparam', 'Content too long'))
                 return
 
+            err, question = await ContestService.inst.get_question(self.contest.contest_id, question_id)
+            if err:
+                self.error(err)
+                return
+
             await ContestService.inst.reply_question(self.contest.contest_id, question_id, self.acct.acct_id, content)
             await self.rs.publish('contestnewqasub', json.dumps({
                 'contest_id': self.contest.contest_id,
+                'ask_acct_id': question['ask_acct_id'],
                 'type': 'reply'
             }))
             self.error(('S', ''))

--- a/src/handlers/contests/manage/qa.py
+++ b/src/handlers/contests/manage/qa.py
@@ -17,8 +17,7 @@ class ContestManageQuestionHandler(RequestHandler):
     async def get(self):
         err, questions = await ContestService.inst.get_all_question(self.contest.contest_id)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
 
         cache = {}
@@ -64,8 +63,6 @@ class ContestManageQuestionHandler(RequestHandler):
 
             err, question = await ContestService.inst.get_question(self.contest.contest_id, question_id)
             if err:
-                self.error(err)
-                return
                 return self.error(err)
 
             await ContestService.inst.reply_question(self.contest.contest_id, question_id, self.acct.acct_id, content)
@@ -82,8 +79,7 @@ class ContestManageAnnounceHandler(RequestHandler):
     async def get(self):
         err, announces = await ContestService.inst.get_all_announce(self.contest.contest_id)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         await self.render('contests/manage/announce', page='announce', contest_id=self.contest.contest_id,
                           contest=self.contest, announces=announces)
@@ -125,8 +121,7 @@ class ContestManageAnnounceHandler(RequestHandler):
             announce_id = int(self.get_argument('announce_id'))
             err, announce = await ContestService.inst.get_announce(self.contest.contest_id, announce_id)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             await self.rs.publish('contestnewqasub', json.dumps({
                 'contest_id': self.contest.contest_id,

--- a/src/handlers/contests/manage/reg.py
+++ b/src/handlers/contests/manage/reg.py
@@ -28,8 +28,7 @@ class ContestManageRegHandler(RequestHandler):
             acct_id = int(self.get_argument('acct_id'))
 
             if not self.contest.member_is_status(acct_id, UserStatus.REQUESTED):
-                self.error(('Enoext', f'Account(#{acct_id}) should be in the request status'))
-                return
+                return self.error(('Enoext', f'Account(#{acct_id}) should be in the request status'))
 
             self.contest.user_list[acct_id]['status'] = UserStatus.APPROVED
 
@@ -42,8 +41,7 @@ class ContestManageRegHandler(RequestHandler):
             acct_id = int(self.get_argument('acct_id'))
 
             if not self.contest.member_is_status(acct_id, UserStatus.REQUESTED):
-                self.error(('Enoext', f'Account(#{acct_id}) should be in the request status'))
-                return
+                return self.error(('Enoext', f'Account(#{acct_id}) should be in the request status'))
 
             self.contest.user_list[acct_id]['status'] = UserStatus.REJECTED
 

--- a/src/handlers/contests/proset.py
+++ b/src/handlers/contests/proset.py
@@ -15,12 +15,10 @@ class ContestProsetHandler(RequestHandler):
 
         show_ac_ratio = False
         if not self.contest.is_start() and not self.contest.is_admin(self.acct):
-            self.error(('Eacces', 'Permission denied'))
-            return
+            return self.error(('Eacces', 'Permission denied'))
 
         elif self.contest.is_running() and not self.contest.is_member(self.acct):
-            self.error(('Eacces', 'Permission denied'))
-            return
+            return self.error(('Eacces', 'Permission denied'))
 
         else:
             _, acct_rates = await RateService.inst.map_rate_acct(self.acct, contest_id=self.contest.contest_id)

--- a/src/handlers/contests/qa.py
+++ b/src/handlers/contests/qa.py
@@ -20,10 +20,13 @@ class ContestQAHandler(RequestHandler):
             self.error(('Eacces', 'Permission denied'))
             return
 
-        err, announces = await ContestService.inst.get_all_announce(self.contest.contest_id)
-        if err:
-            self.error(err)
-            return
+        if self.contest.is_start():
+            err, announces = await ContestService.inst.get_all_announce(self.contest.contest_id)
+            if err:
+                self.error(err)
+                return
+        else:
+            announces = []
 
         err, questions = await ContestService.inst.get_all_question(self.contest.contest_id, self.acct.acct_id)
         if err:

--- a/src/handlers/contests/qa.py
+++ b/src/handlers/contests/qa.py
@@ -74,25 +74,10 @@ class ContestQAHandler(RequestHandler):
 
             subject = self.get_argument('subject').strip()
             content = self.get_argument('content').strip()
-            subject_len = len(subject)
-            content_len = len(content)
-
-            if subject_len < SUBJECT_MIN:
-                self.error(('Eparam', 'Subject too short'))
-                return
-
-            elif subject_len > SUBJECT_MAX:
-                self.error(('Eparam', 'Subject too long'))
-                return
-
-            if content_len < CONTENT_MIN:
-                self.error(('Eparam', 'Content too short'))
-                return
-
-            elif content_len > CONTENT_MAX:
-                self.error(('Eparam', 'Content too long'))
-                return
-
+            if err := self.len_check(subject, SUBJECT_MIN, SUBJECT_MAX, 'Subject'):
+                return self.error(err)
+            if err := self.len_check(content, CONTENT_MIN, CONTENT_MAX, 'Content'):
+                return self.error(err)
 
             if not last_ask_time:
                 await self.rs.set(last_ask_name, int(time.time()), ex=ASK_CD_TIME)  # ex means expire

--- a/src/handlers/contests/qa.py
+++ b/src/handlers/contests/qa.py
@@ -17,21 +17,18 @@ class ContestQAHandler(RequestHandler):
     @reqenv
     async def get(self):
         if self.contest.is_admin(self.acct):
-            self.error(('Eacces', 'Permission denied'))
-            return
+            return self.error(('Eacces', 'Permission denied'))
 
         if self.contest.is_start():
             err, announces = await ContestService.inst.get_all_announce(self.contest.contest_id)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
         else:
             announces = []
 
         err, questions = await ContestService.inst.get_all_question(self.contest.contest_id, self.acct.acct_id)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         def _cmp(question):
             return (question['reply_acct_id'] is not None, question['reply_timestamp'], question['ask_timestamp'])
@@ -69,8 +66,7 @@ class ContestQAHandler(RequestHandler):
                 if elapsed_time < ASK_CD_TIME:
                     remaining_time = ASK_CD_TIME - elapsed_time
                     remaining_time = max(remaining_time, 0)
-                    self.error(('Einternal', f'Ask CD Time: {ASK_CD_TIME} Secs, Remaining: {remaining_time} Secs'))
-                    return
+                    return self.error(('Einternal', f'Ask CD Time: {ASK_CD_TIME} Secs, Remaining: {remaining_time} Secs'))
 
             subject = self.get_argument('subject').strip()
             content = self.get_argument('content').strip()

--- a/src/handlers/contests/qa.py
+++ b/src/handlers/contests/qa.py
@@ -109,15 +109,22 @@ class ContestNewQAHandler(WebSocketSubHandler):
             if msg['type'] != 'message':
                 continue
 
-            if json.loads(msg['data'])['contest_id'] == self.contest_id:
-                await self.write_message(msg['data'])
+            data = json.loads(msg['data'])
+            if data['contest_id'] == self.contest_id:
+                if data['type'] != 'reply':
+                    await self.write_message(msg['data'])
+                elif data['ask_acct_id'] == self.acct_id:
+                    await self.write_message(msg['data'])
 
     async def open(self):
         self.contest_id = -1
+        self.acct_id = -1
         await self.p.subscribe('contestnewqasub')
 
         self.task = asyncio.tasks.Task(self.listen_newqa())
 
     async def on_message(self, msg):
-        if self.contest_id == -1 and msg.isdigit():
-            self.contest_id = int(msg)
+        j = json.loads(msg)
+        if self.contest_id == -1 or self.acct_id == -1:
+            self.contest_id = int(j['contest_id'])
+            self.acct_id = int(j['acct_id'])

--- a/src/handlers/contests/reg.py
+++ b/src/handlers/contests/reg.py
@@ -10,12 +10,10 @@ class ContestRegHandler(RequestHandler):
     @require_permission([UserConst.ACCTTYPE_USER, UserConst.ACCTTYPE_KERNEL])
     async def get(self):
         if not self.contest:
-            self.error(('Enoext', 'Contest not found'))
-            return
+            return self.error(('Enoext', 'Contest not found'))
 
         if self.contest.is_admin(self.acct):
-            self.error(('Eacces', 'Contest admin do not need to register'))
-            return
+            return self.error(('Eacces', 'Contest admin do not need to register'))
 
         await self.render('contests/reg', contest=self.contest)
 
@@ -27,8 +25,7 @@ class ContestRegHandler(RequestHandler):
 
         if reqtype == 'reg':
             if self.contest.is_admin(self.acct):
-                self.error(('Eacces', 'Contest admin do not need to register'))
-                return
+                return self.error(('Eacces', 'Contest admin do not need to register'))
 
             else:
                 status = None
@@ -39,16 +36,13 @@ class ContestRegHandler(RequestHandler):
                     status = UserStatus.REQUESTED
 
                 if acct_id in self.contest.user_list and self.contest.user_list[acct_id]['status'] == status:
-                    self.error(('Eexist', 'Already registered'))
-                    return
+                    return self.error(('Eexist', 'Already registered'))
 
             if datetime.datetime.now().replace(tzinfo=datetime.timezone(datetime.timedelta(hours=+8))) > self.contest.reg_end:
-                self.error(('Etime', 'Registration time has passed. Please remember to register earlier next time'))
-                return
+                return self.error(('Etime', 'Registration time has passed. Please remember to register earlier next time'))
 
             if self.contest.reg_mode is RegMode.INVITED:
-                self.error(('Eacces', 'Invited mode do not allow register'))
-                return
+                return self.error(('Eacces', 'Invited mode do not allow register'))
 
             elif self.contest.reg_mode is RegMode.FREE_REG:
                 self.contest.user_list[acct_id] = {
@@ -65,16 +59,13 @@ class ContestRegHandler(RequestHandler):
 
         elif reqtype == 'unreg':
             if self.contest.is_admin(self.acct):
-                self.error(('Eacces', 'Contest admin do not need to register'))
-                return
+                return self.error(('Eacces', 'Contest admin do not need to register'))
 
             if self.contest.reg_mode is RegMode.INVITED:
-                self.error(('Eacces', 'Invited mode do not allow register'))
-                return
+                return self.error(('Eacces', 'Invited mode do not allow register'))
 
             if acct_id not in self.contest.user_list:
-                self.error(('Enoext', 'You have not registered yet' ))
-                return
+                return self.error(('Enoext', 'You have not registered yet' ))
 
             self.contest.user_list.pop(acct_id)
 

--- a/src/handlers/contests/scoreboard.py
+++ b/src/handlers/contests/scoreboard.py
@@ -48,11 +48,9 @@ class ContestScoreboardHandler(RequestHandler):
     @reqenv
     async def post(self):
         if not self.contest.is_start() and not self.contest.is_admin(self.acct):
-            self.error(('Eacces', 'Permission denied'))
-            return
+            return self.error(('Eacces', 'Permission denied'))
         elif not self.contest.is_public_scoreboard and not self.contest.is_member(self.acct):
-            self.error(('Eacces', 'Permission denied'))
-            return
+            return self.error(('Eacces', 'Permission denied'))
 
         has_end_time = True
         start_time = self.contest.contest_start

--- a/src/handlers/log.py
+++ b/src/handlers/log.py
@@ -25,8 +25,7 @@ class LogHandler(RequestHandler):
 
             err, log = await LogService.inst.list_log(pageoff, 50, logtype)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             await self.render(
                 'loglist',
@@ -40,8 +39,7 @@ class LogHandler(RequestHandler):
 
         err, log = await LogService.inst.view_log(log_id)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         await self.render('log', log=log)
 

--- a/src/handlers/manage/acct.py
+++ b/src/handlers/manage/acct.py
@@ -46,8 +46,7 @@ class ManageAcctHandler(RequestHandler):
                     f"{self.acct.name}(#{self.acct.acct_id}) had been send a request to update the account #{acct_id} but not found",
                     'manage.acct.update.failure',
                 )
-                self.error(err)
-                return
+                return self.error(err)
 
             await LogService.inst.add_log(
                 f"{self.acct.name}(#{self.acct.acct_id}) had been send a request to update the account {acct.name}(#{acct.acct_id})",
@@ -57,8 +56,7 @@ class ManageAcctHandler(RequestHandler):
             acct.acct_type = acct_type
             err, _ = await UserService.inst.update_acct(acct)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             _ = await GroupService.inst.set_acct_group(acct_id, group)
             self.error(('S', ''))

--- a/src/handlers/manage/board.py
+++ b/src/handlers/manage/board.py
@@ -53,13 +53,11 @@ class ManageBoardHandler(RequestHandler):
 
             err, start = trantime(start)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             err, end = trantime(end)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             acct_list = await self._get_acct_list(acct_list_str)
             pro_list = self._get_pro_list(pro_list_str)
@@ -77,7 +75,7 @@ class ManageBoardHandler(RequestHandler):
 
             err, board_id = await BoardService.inst.add_board(name, status, start, end, pro_list, acct_list)
             if err:
-                self.error(err)
+                return self.error(err)
 
             self.error(('S', board_id))
 
@@ -89,13 +87,11 @@ class ManageBoardHandler(RequestHandler):
             end = self.get_argument('end')
             err, start = trantime(start)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             err, end = trantime(end)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             pro_list_str = str(self.get_argument('pro_list'))
             acct_list_str = str(self.get_argument('acct_list'))

--- a/src/handlers/manage/bulletin.py
+++ b/src/handlers/manage/bulletin.py
@@ -38,18 +38,15 @@ class ManageBulletinHandler(RequestHandler):
                 pinned = False
             color = self.get_argument('color')
             if err := self.len_check(title, BulletinConst.TITLE_MIN, BulletinConst.TITLE_MAX, 'Title'):
-                self.error(err)
-                return
+                return self.error(err)
 
             if err := self.len_check(content, BulletinConst.CONTENT_MIN, BulletinConst.CONTENT_MAX, 'Content'):
-                self.error(err)
-                return
+                return self.error(err)
 
             if reqtype == 'add':
                 err, bulletin_id = await BulletinService.inst.add_bulletin(title, content, self.acct.acct_id, color, pinned)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 await LogService.inst.add_log(
                     f"{self.acct.name} added a line on bulletin: \"{title}\".", 'manage.inform.add',
@@ -75,8 +72,8 @@ class ManageBulletinHandler(RequestHandler):
                 )
                 err, _ = await BulletinService.inst.edit_bulletin(bulletin_id, title, content, self.acct.acct_id, color, pinned)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
+
                 self.error(('S', ''))
 
             await self.rs.publish('bulletinsub', 1)
@@ -88,8 +85,7 @@ class ManageBulletinHandler(RequestHandler):
             )
             err, _ = await BulletinService.inst.del_bulletin(bulletin_id)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             await self.rs.publish('bulletinsub', 1)
             self.error(('S', ''))

--- a/src/handlers/manage/group.py
+++ b/src/handlers/manage/group.py
@@ -47,16 +47,13 @@ class ManageGroupHandler(RequestHandler):
             gtype = int(self.get_argument('gtype'))
             gclas = int(self.get_argument('gclas'))
             if gname == GroupConst.KERNEL_GROUP:
-                self.error(('Ekernel', 'Cannot edit kernel group'))
-                return
+                return self.error(('Ekernel', 'Cannot edit kernel group'))
 
             await LogService.inst.add_log(
                 f"{self.acct.name} updated group={gname} group_type={gtype} group_class={gclas}.", 'manage.group.update'
             )
-            err = await GroupService.inst.update_group(gname, gtype, gclas)
-            if err:
-                self.error(err)
-                return
+            if err := await GroupService.inst.update_group(gname, gtype, gclas):
+                return self.error(err)
 
             self.error(('S', ''))
 
@@ -68,24 +65,18 @@ class ManageGroupHandler(RequestHandler):
             await LogService.inst.add_log(
                 f"{self.acct.name} added group={gname} group_type={gtype} group_class={gclas}.", 'manage.group.add'
             )
-            err = await GroupService.inst.add_group(gname, gtype, gclas)
-            if err:
-                self.error(err)
-                return
+            if err := await GroupService.inst.add_group(gname, gtype, gclas):
+                return self.error(err)
 
             self.error(('S', ''))
 
         elif reqtype == 'del_group':
             gname = str(self.get_argument('gname'))
             if gname in [GroupConst.KERNEL_GROUP, GroupConst.DEFAULT_GROUP]:
-                self.error(('Ekernel', 'Cannot remove kernel and default group'))
-                return
+                return self.error(('Ekernel', 'Cannot remove kernel and default group'))
 
             await LogService.inst.add_log(f"{self.acct.name} deleted group={gname}", 'manage.group.delete')
-            err = await GroupService.inst.del_group(gname)
-            if err:
-                self.error(err)
-                return
+            if err := await GroupService.inst.del_group(gname):
+                return self.error(err)
 
             self.error(('S', ''))
-            return

--- a/src/handlers/manage/judge.py
+++ b/src/handlers/manage/judge.py
@@ -34,13 +34,11 @@ class ManageJudgeHandler(RequestHandler):
             if (server_name := server_inform['name']) == '':
                 server_name = f"server-{index}"
 
-            err = await JudgeServerClusterService.inst.connect_server(index)
-            if err:
+            if err := await JudgeServerClusterService.inst.connect_server(index):
                 await LogService.inst.add_log(
                     f"{self.acct.name} tried connected {server_name} but failed.", 'manage.judge.connect.failure'
                 )
-                self.error(err)
-                return
+                return self.error(err)
 
             await LogService.inst.add_log(
                 f"{self.acct.name} had been connected {server_name} succesfully.", 'manage.judge.connect'
@@ -60,16 +58,13 @@ class ManageJudgeHandler(RequestHandler):
                 await LogService.inst.add_log(
                     f"{self.acct.name} tried to disconnect {server_name} but failed.", 'manage.judge.disconnect.failure'
                 )
-                self.error(('Eacces', 'Wrong password'))
-                return
+                return self.error(('Eacces', 'Wrong password'))
 
-            err = await JudgeServerClusterService.inst.disconnect_server(index)
+            if err := await JudgeServerClusterService.inst.disconnect_server(index):
+                return self.error(err)
             await LogService.inst.add_log(
                 f"{self.acct.name} had been disconnected {server_name} succesfully.", 'manage.judge.disconnect'
             )
-            if err:
-                self.error(err)
-                return
 
             self.error(('S', ''))
 

--- a/src/handlers/manage/pro.py
+++ b/src/handlers/manage/pro.py
@@ -46,8 +46,7 @@ class ManageProHandler(RequestHandler):
 
             err, pro = await ProService.inst.get_pro(pro_id, self.acct)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             lock = await self.rs.get(f"{pro['pro_id']}_owner")
 
@@ -62,8 +61,7 @@ class ManageProHandler(RequestHandler):
             pro_id = int(self.get_argument('proid'))
             err, pro = await ProService.inst.get_pro(pro_id, self.acct)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             testm_conf = pro['testm_conf']
             dirs = []
@@ -131,8 +129,7 @@ class ManageProHandler(RequestHandler):
 
             err, pro = await ProService.inst.get_pro(pro_id, self.acct)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             files = natsorted(set(map(lambda file: file.replace('.in', '').replace('.out', ''),
                         filter(lambda file: file.endswith('.in') or file.endswith('.out'), os.listdir(f'problem/{pro_id}/res/testdata')))))
@@ -164,8 +161,7 @@ class ManageProHandler(RequestHandler):
                 f"{self.acct.name} has sent a request to add the problem #{pro_id}", 'manage.pro.add.pro'
             )
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             self.error(('S', pro_id))
 
@@ -177,12 +173,10 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 if test_type not in ['out', 'in']:
-                    self.error(('Eparam', 'Invalid testcase file type'))
-                    return
+                    return self.error(('Eparam', 'Invalid testcase file type'))
 
                 filename += f".{test_type}"
                 basepath = f'problem/{pro_id}/res/testdata'
@@ -191,8 +185,7 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to preview file:{filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.tests.preview.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 filepath = os.path.join(basepath, filename)
 
@@ -201,16 +194,14 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to preview file:{filename} for problem #{pro_id} but not found',
                         'manage.pro.update.tests.preview.failed'
                     )
-                    self.error(('Enoext', 'File not found'))
-                    return
+                    return self.error(('Enoext', 'File not found'))
 
                 await LogService.inst.add_log(f'{self.acct.name} preview file:{filename} for problem #{pro_id}',
                                             'manage.pro.update.tests.preview')
                 with open(filepath, 'r') as testcase_f:
                     content = testcase_f.readlines()
                     if len(content) > 25:
-                        self.error(('Efile', 'File too large'))
-                        return
+                        return self.error(('Efile', 'File too large'))
 
                     self.error(('S', ''.join(content)))
 
@@ -221,14 +212,12 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 test_group = pro['testm_conf']['test_group']
 
                 if group not in test_group:
-                    self.error(('Enoext', 'Group not found'))
-                    return
+                    return self.error(('Enoext', 'Group not found'))
 
                 test_group[group]['weight'] = weight
                 await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
@@ -247,8 +236,7 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 test_group = pro['testm_conf']['test_group']
 
@@ -274,13 +262,11 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 test_group = pro['testm_conf']['test_group']
                 if group not in test_group:
-                    self.error(('Enoext', 'Group not found'))
-                    return
+                    return self.error(('Enoext', 'Group not found'))
 
                 test_group.pop(group)
                 remain_groups = list(test_group.values())
@@ -303,18 +289,15 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 basepath = f'problem/{pro_id}/res/testdata'
                 if not os.path.exists(f'{basepath}/{testcase}.in') or not os.path.exists(f'{basepath}/{testcase}.out'):
-                    self.error(('Enoext', 'Testcase file not found'))
-                    return
+                    return self.error(('Enoext', 'Testcase file not found'))
 
                 test_group = pro['testm_conf']['test_group']
                 if group not in test_group:
-                    self.error(('Enoext', 'Group not found'))
-                    return
+                    return self.error(('Enoext', 'Group not found'))
 
                 for t in test_group[group]['metadata']['data']:
                     if testcase == str(t):
@@ -322,8 +305,7 @@ class ManageProHandler(RequestHandler):
                             f'{self.acct.name} tried to add testcase:{testcase} for problem #{pro_id} but already exists',
                             'manage.pro.update.tests.addsingletestcase',
                         )
-                        self.error(('Eexist', 'Testcase already exists'))
-                        return
+                        return self.error(('Eexist', 'Testcase already exists'))
 
                 test_group[group]['metadata']['data'].append(testcase)
                 await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
@@ -340,19 +322,16 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 test_group = pro['testm_conf']['test_group']
                 if group not in test_group:
-                    self.error(('Enoext', 'Group not found'))
-                    return
+                    return self.error(('Enoext', 'Group not found'))
 
                 try:
                     test_group[group]['metadata']['data'].remove(testcase)
                 except ValueError:
-                    self.error(('Enoext', 'Testcase not found'))
-                    return
+                    return self.error(('Enoext', 'Testcase not found'))
 
                 await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
                 await LogService.inst.add_log(
@@ -368,8 +347,7 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 # check filename
                 basepath = f'problem/{pro_id}/res/testdata'
@@ -382,24 +360,21 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to rename {old_filename} to {new_filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.tests.renamesinglefile.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 if not os.path.exists(old_inputfile_path) or not os.path.exists(old_outputfile_path):
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to rename {old_filename} to {new_filename} for problem #{pro_id} but {old_filename} not found',
                         'manage.pro.update.tests.renamesinglefile.failed'
                     )
-                    self.error(('Enoext', 'Old filename not found'))
-                    return
+                    return self.error(('Enoext', 'Old filename not found'))
 
                 if os.path.exists(new_inputfile_path) or os.path.exists(new_outputfile_path):
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to rename {old_filename} to {new_filename} for problem #{pro_id} but {new_filename} already exists',
                         'manage.pro.update.tests.renamesinglefile.failed'
                     )
-                    self.error(('Eexist', 'New filename already exists'))
-                    return
+                    return self.error(('Eexist', 'New filename already exists'))
 
                 os.rename(old_inputfile_path, new_inputfile_path)
                 os.rename(old_outputfile_path, new_outputfile_path)
@@ -429,13 +404,11 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 if test_type not in ['output', 'input']:
                     PackService.inst.clear(pack_token)
-                    self.error(('Eparam', 'Invalid testcase file type'))
-                    return
+                    return self.error(('Eparam', 'Invalid testcase file type'))
 
                 basepath = f'problem/{pro_id}/res/testdata'
                 filepath = f'{basepath}/{filename}.{test_type[0:-3]}'
@@ -446,8 +419,7 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to update {filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.tests.updatesinglefile.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 if not os.path.exists(filepath):
                     PackService.inst.clear(pack_token)
@@ -455,8 +427,7 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to update {filename}.{test_type[0:-3]} for problem #{pro_id} but not found',
                         'manage.pro.update.tests.updatesinglefile.failed'
                     )
-                    self.error(('Enoext', 'Testcase file not found'))
-                    return
+                    return self.error(('Enoext', 'Testcase file not found'))
 
                 _ = await PackService.inst.direct_copy(pack_token, filepath)
 
@@ -476,8 +447,7 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 basepath = f'problem/{pro_id}/res/testdata'
                 inputfile_path = f'{basepath}/{filename}.in'
@@ -492,8 +462,7 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to add a single file:{filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.tests.addsinglefile.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 if os.path.exists(inputfile_path) or os.path.exists(outputfile_path):
                     PackService.inst.clear(input_pack_token)
@@ -502,8 +471,7 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to add single file:{filename} for problem #{pro_id} but {filename} already exists',
                         'manage.pro.update.tests.addsinglefile.failed'
                     )
-                    self.error(('Eexist', 'File already exists'))
-                    return
+                    return self.error(('Eexist', 'File already exists'))
 
                 _ = await PackService.inst.direct_copy(input_pack_token, inputfile_path)
                 _ = await PackService.inst.direct_copy(output_pack_token, outputfile_path)
@@ -521,8 +489,7 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 basepath = f'problem/{pro_id}/res/testdata'
                 if not self._is_file_access_safe(basepath, f'{filename}.in'):
@@ -530,16 +497,14 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to delete a single file:{filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.tests.deletesinglefile.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 if not os.path.exists(f'{basepath}/{filename}.in') or not os.path.exists(f'{basepath}/{filename}.out'):
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to delete a single file:{filename} for problem #{pro_id} but not found',
                         'manage.pro.update.tests.deletesinglefile.failed'
                     )
-                    self.error(('Enoext', 'Testcase file not found'))
-                    return
+                    return self.error(('Enoext', 'Testcase file not found'))
 
                 os.remove(f'{basepath}/{filename}.in')
                 os.remove(f'{basepath}/{filename}.out')
@@ -568,12 +533,10 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 if basepath not in ['http', 'res/check', 'res/make']:
-                    self.error(('Eparam', 'Invalid basepath'))
-                    return
+                    return self.error(('Eparam', 'Invalid basepath'))
 
                 basepath = f'problem/{pro_id}/{basepath}'
                 if not self._is_file_access_safe(basepath, filename):
@@ -581,8 +544,7 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to preview {filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.filemanager.preview.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 filepath = os.path.join(basepath, filename)
 
@@ -591,8 +553,7 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to preview {filename} for problem #{pro_id} but not found',
                         'manage.pro.update.filemanager.preview.failed'
                     )
-                    self.error(('Enoext', 'File not found'))
-                    return
+                    return self.error(('Enoext', 'File not found'))
 
                 await LogService.inst.add_log(f'{self.acct.name} preview {filename} for problem #{pro_id}',
                                               'manage.pro.update.filemanager.preview')
@@ -600,8 +561,7 @@ class ManageProHandler(RequestHandler):
                     try:
                         content = tornado.escape.xhtml_escape(f.read())
                     except UnicodeDecodeError:
-                        self.error(('Eunicode', 'That even use like unicode shit that make your programs not compile.'))
-                        return
+                        return self.error(('Eunicode', 'That even use like unicode shit that make your programs not compile.'))
 
                     self.error(('S', ''.join(content)))
 
@@ -617,8 +577,7 @@ class ManageProHandler(RequestHandler):
                     return
 
                 if basepath not in ['http', 'res/check', 'res/make']:
-                    self.error(('Eparam', 'Invalid basepath'))
-                    return
+                    return self.error(('Eparam', 'Invalid basepath'))
 
                 basepath = f'problem/{pro_id}/{basepath}'
                 old_filepath = f'{basepath}/{old_filename}'
@@ -628,24 +587,21 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to rename {old_filename} to {new_filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.filemanager.renamesinglefile.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 if not os.path.exists(old_filepath):
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to rename {old_filename} to {new_filename} for problem #{pro_id} but {old_filename} not found',
                         'manage.pro.update.filemanager.renamesinglefile.failed'
                     )
-                    self.error(('Enoext', 'Old filename not found'))
-                    return
+                    return self.error(('Enoext', 'Old filename not found'))
 
                 if os.path.exists(new_filepath):
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to rename {old_filename} to {new_filename} for problem #{pro_id} but {new_filename} already exists',
                         'manage.pro.update.filemanager.renamesinglefile.failed'
                     )
-                    self.error(('Eexist', 'New filename already exists'))
-                    return
+                    return self.error(('Eexist', 'New filename already exists'))
 
                 os.rename(old_filepath, new_filepath)
                 await LogService.inst.add_log(
@@ -662,12 +618,10 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 if basepath not in ['http', 'res/check', 'res/make']:
-                    self.error(('Eparam', 'Invalid basepath'))
-                    return
+                    return self.error(('Eparam', 'Invalid basepath'))
 
                 basepath = f'problem/{pro_id}/{basepath}'
                 filepath = f'{basepath}/{filename}'
@@ -678,8 +632,7 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to update {filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.filemanager.updatesinglefile.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 if not os.path.exists(filepath):
                     PackService.inst.clear(pack_token)
@@ -687,8 +640,7 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to update {filename} for problem #{pro_id} but not found',
                         'manage.pro.update.filemanager.updatesinglefile.failed'
                     )
-                    self.error(('Enoext', 'File not found'))
-                    return
+                    return self.error(('Enoext', 'File not found'))
 
                 _ = await PackService.inst.direct_copy(pack_token, filepath)
                 await LogService.inst.add_log(
@@ -706,12 +658,10 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 if basepath not in ['http', 'res/check', 'res/make']:
-                    self.error(('Eparam', 'Invalid basepath'))
-                    return
+                    return self.error(('Eparam', 'Invalid basepath'))
 
                 basepath = f'problem/{pro_id}/{basepath}'
                 filepath = f'{basepath}/{filename}'
@@ -722,8 +672,7 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to add {filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.filemanager.addsinglefile.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 if os.path.exists(filepath):
                     PackService.inst.clear(pack_token)
@@ -731,8 +680,7 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to add {filename} for problem #{pro_id} but {filename} already exists',
                         'manage.pro.update.filemanager.addsinglefile.failed'
                     )
-                    self.error(('Eexist', 'File already exists'))
-                    return
+                    return self.error(('Eexist', 'File already exists'))
 
                 _ = await PackService.inst.direct_copy(pack_token, filepath)
                 await LogService.inst.add_log(
@@ -749,12 +697,10 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 if basepath not in ['http', 'res/check', 'res/make']:
-                    self.error(('Eparam', 'Invalid basepath'))
-                    return
+                    return self.error(('Eparam', 'Invalid basepath'))
 
                 basepath = f'problem/{pro_id}/{basepath}'
                 filepath = f'{basepath}/{filename}'
@@ -763,16 +709,14 @@ class ManageProHandler(RequestHandler):
                         f'{self.acct.name} tried to delete {filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.filemanager.deletesinglefile.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 if not os.path.exists(filepath):
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to delete {filename} for problem #{pro_id} but not found',
                         'manage.pro.update.filemanager.deletesinglefile.failed'
                     )
-                    self.error(('Enoext', 'File not found'))
-                    return
+                    return self.error(('Enoext', 'File not found'))
 
                 os.remove(f'{basepath}/{filename}')
 
@@ -793,8 +737,7 @@ class ManageProHandler(RequestHandler):
                 # NOTE: test config
                 rate_precision = int(self.get_argument('rate_precision'))
                 if rate_precision > ProConst.RATE_PRECISION_MAX or rate_precision < ProConst.RATE_PRECISION_MIN:
-                    self.error(('Eparam', 'Invalid rate precision'))
-                    return
+                    return self.error(('Eparam', 'Invalid rate precision'))
 
                 is_makefile = self.get_argument('is_makefile') == "true"
                 check_type = int(self.get_argument('check_type'))
@@ -805,16 +748,14 @@ class ManageProHandler(RequestHandler):
                     try:
                         chalmeta = json.loads(chalmeta)
                     except json.JSONDecodeError:
-                        self.error(('Econf', 'Challenge metadata json syntax error'))
-                        return
+                        return self.error(('Econf', 'Challenge metadata json syntax error'))
 
                 err, _ = await ProService.inst.update_pro(
                     pro_id, name, status, None, None, tags, allow_submit
                 )
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 old_is_makefile = pro['testm_conf']['is_makefile']
                 old_check_type = pro['testm_conf']['check_type']
@@ -848,8 +789,7 @@ class ManageProHandler(RequestHandler):
                     }
                 )
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 self.error(('S', ''))
 
@@ -860,8 +800,7 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 err, _ = await ProService.inst.update_pro(
                     pro_id, pro['name'], pro['status'], ProService.PACKTYPE_FULL, pack_token, pro['tags'], pro['allow_submit']
@@ -876,8 +815,7 @@ class ManageProHandler(RequestHandler):
                             'err': err
                         }
                     )
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 suspicious_files = []
                 for file in os.listdir(f"problem/{pro_id}/res/testdata"):
@@ -903,8 +841,7 @@ class ManageProHandler(RequestHandler):
 
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 ALLOW_COMPILERS = set(list(ChalConst.ALLOW_COMPILERS) + ['default'])
                 if pro['testm_conf']['is_makefile']:
@@ -923,8 +860,7 @@ class ManageProHandler(RequestHandler):
                     new_limits[comp_type] = limit
 
                 if 'default' not in new_limits:
-                    self.error(('Eparam', 'Missing default limit config'))
-                    return
+                    return self.error(('Eparam', 'Missing default limit config'))
 
                 pro['testm_conf']['limit'] = new_limits
                 await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
@@ -959,8 +895,7 @@ class ManageProHandler(RequestHandler):
                 pwd = str(self.get_argument('pwd'))
 
                 if config.unlock_pwd != base64.b64encode(packb(pwd)):
-                    self.error(('Eacces', 'Wrong password'))
-                    return
+                    return self.error(('Eacces', 'Wrong password'))
 
                 lock_list = unpackb((await self.rs.get('lock_list')))
                 lock_list.remove(pro_id)
@@ -970,27 +905,23 @@ class ManageProHandler(RequestHandler):
 
         elif page is None:  # pro-list
             if reqtype not in ['rechal', 'rechalall']:
-                self.error(('Eunk', 'Unknown error'))
-                return
+                return self.error(('Eunk', 'Unknown error'))
 
             is_all_chal = False
             if reqtype == 'rechalall':
                 pwd = self.get_argument('pwd')
                 if config.unlock_pwd != base64.b64encode(packb(pwd)):
-                    self.error(('Eacces', 'Wrong password'))
-                    return
+                    return self.error(('Eacces', 'Wrong password'))
                 is_all_chal = True
 
             pro_id = int(self.get_argument('pro_id'))
             can_submit = JudgeServerClusterService.inst.is_server_online()
             if not can_submit:
-                self.error(('Ejudge', 'No available judge'))
-                return
+                return self.error(('Ejudge', 'No available judge'))
 
             err, pro = await ProService.inst.get_pro(pro_id, self.acct)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             log_type = ""
             async with self.db.acquire() as con:

--- a/src/handlers/manage/proclass.py
+++ b/src/handlers/manage/proclass.py
@@ -51,22 +51,12 @@ class ManageProClassHandler(RequestHandler):
             p_list_str = self.get_argument('list')
             p_list = parse_list_str(p_list_str)
 
-            name_len = len(name)
-            desc_len = len(desc)
-            if name_len < ProClassConst.NAME_MIN:
-                self.error(('Eparam', 'Name too short'))
+            if err := self.len_check(name, ProClassConst.NAME_MIN, ProClassConst.NAME_MAX, 'Name'):
+                self.error(err)
                 return
 
-            elif name_len > ProClassConst.NAME_MAX:
-                self.error(('Eparam', 'Name too long'))
-                return
-
-            if desc_len < ProClassConst.DESC_MIN:
-                self.error(('Eparam', 'Desc too short'))
-                return
-
-            elif desc_len > ProClassConst.DESC_MAX:
-                self.error(('Eparam', 'Desc too long'))
+            if err := self.len_check(desc, ProClassConst.DESC_MIN, ProClassConst.DESC_MAX, 'Desc'):
+                self.error(err)
                 return
 
             if proclass_type not in [ProClassConst.OFFICIAL_PUBLIC, ProClassConst.OFFICIAL_HIDDEN]:

--- a/src/handlers/manage/proclass.py
+++ b/src/handlers/manage/proclass.py
@@ -34,8 +34,7 @@ class ManageProClassHandler(RequestHandler):
             proclass_id = int(self.get_argument('proclassid'))
             _, proclass = await ProClassService.inst.get_proclass(proclass_id)
             if proclass['type'] not in [ProClassConst.OFFICIAL_PUBLIC, ProClassConst.OFFICIAL_HIDDEN]:
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             await self.render('manage/proclass/update', page='proclass', proclass_id=proclass_id, proclass=proclass)
 
@@ -52,20 +51,16 @@ class ManageProClassHandler(RequestHandler):
             p_list = parse_list_str(p_list_str)
 
             if err := self.len_check(name, ProClassConst.NAME_MIN, ProClassConst.NAME_MAX, 'Name'):
-                self.error(err)
-                return
+                return self.error(err)
 
             if err := self.len_check(desc, ProClassConst.DESC_MIN, ProClassConst.DESC_MAX, 'Desc'):
-                self.error(err)
-                return
+                return self.error(err)
 
             if proclass_type not in [ProClassConst.OFFICIAL_PUBLIC, ProClassConst.OFFICIAL_HIDDEN]:
-                self.error(('Eparam', 'Invalid problem class type'))
-                return
+                return self.error(('Eparam', 'Invalid problem class type'))
 
             if len(p_list) == 0:
-                self.error(('Eparam', 'Problem list should not be empty'))
-                return
+                return self.error(('Eparam', 'Problem list should not be empty'))
 
             if reqtype == 'add':
                 await LogService.inst.add_log(
@@ -78,8 +73,7 @@ class ManageProClassHandler(RequestHandler):
                 )
                 err, proclass_id = await ProClassService.inst.add_proclass(name, p_list, desc, None, proclass_type)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 self.error(('S', proclass_id))
 
@@ -87,15 +81,13 @@ class ManageProClassHandler(RequestHandler):
                 proclass_id = int(self.get_argument('proclass_id'))
                 err, proclass = await ProClassService.inst.get_proclass(proclass_id)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
                 if proclass['type'] not in [ProClassConst.OFFICIAL_PUBLIC, ProClassConst.OFFICIAL_HIDDEN]:
                     await LogService.inst.add_log(
                         f"{self.acct.name} tried to update proclass name={proclass['name']}, but an admin cannot modify a user's own proclass", 'manage.proclass.update.failed'
                     )
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 await LogService.inst.add_log(
                     f"{self.acct.name} update proclass name={name}", 'manage.proclass.update',
@@ -105,10 +97,8 @@ class ManageProClassHandler(RequestHandler):
                         "proclass_type": proclass_type,
                     }
                 )
-                err = await ProClassService.inst.update_proclass(proclass_id, name, p_list, desc, proclass_type)
-                if err:
-                    self.error(err)
-                    return
+                if err := await ProClassService.inst.update_proclass(proclass_id, name, p_list, desc, proclass_type):
+                    return self.error(err)
 
                 self.error(('S', ''))
 
@@ -116,15 +106,13 @@ class ManageProClassHandler(RequestHandler):
             proclass_id = int(self.get_argument('proclass_id'))
             err, proclass = await ProClassService.inst.get_proclass(proclass_id)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             if proclass['type'] not in [ProClassConst.OFFICIAL_PUBLIC, ProClassConst.OFFICIAL_HIDDEN]:
                 await LogService.inst.add_log(
                     f"{self.acct.name} tried to remove proclass name={proclass['name']}, but an admin cannot modify a user's own proclass", 'manage.proclass.remove.failed'
                 )
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             await LogService.inst.add_log(
                 f"{self.acct.name} remove proclass name={proclass['name']}.", 'manage.proclass.remove'

--- a/src/handlers/manage/question.py
+++ b/src/handlers/manage/question.py
@@ -33,14 +33,8 @@ class ManageQuestionHandler(RequestHandler):
         if page == "reply":
             reqtype = self.get_argument('reqtype')
             rtext = self.get_argument('rtext').strip()
-            rtext_len = len(rtext)
-            if rtext_len < QuestionConst.QUESTION_MIN:
-                self.error(('Erplmin', 'Reply too short'))
-                return
-
-            elif rtext_len > QuestionConst.QUESTION_MAX:
-                self.error(('Erplmax', 'Reply too long'))
-                return
+            if err := self.len_check(rtext, QuestionConst.QUESTION_MIN, QuestionConst.QUESTION_MAX, 'Reply'):
+                return self.error(err)
 
             if reqtype == 'rpl':
                 await LogService.inst.add_log(

--- a/src/handlers/pro.py
+++ b/src/handlers/pro.py
@@ -86,16 +86,13 @@ class ProsetHandler(RequestHandler):
         if proclass_id:
             err, proclass = await ProClassService.inst.get_proclass(proclass_id)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
             proclass = dict(proclass)
 
             if proclass['type'] == ProClassConst.OFFICIAL_HIDDEN and not self.acct.is_kernel():
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
             elif proclass['type'] == ProClassConst.USER_HIDDEN and proclass['acct_id'] != self.acct.acct_id:
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             p_list = proclass['list']
             prolist = list(filter(lambda pro: pro['pro_id'] in p_list, prolist))
@@ -205,14 +202,12 @@ class ProsetHandler(RequestHandler):
 
         elif reqtype == "collect":
             if self.acct.is_guest():
-                self.error(('Eacces', 'Please login'))
-                return
+                return self.error(('Eacces', 'Please login'))
 
             proclass_id = int(self.get_argument('proclass_id'))
 
             if proclass_id in self.acct.proclass_collection:
-                self.error(('Eexist', 'Problem class is already collected'))
-                return
+                return self.error(('Eexist', 'Problem class is already collected'))
 
             self.acct.proclass_collection.append(proclass_id)
             self.acct.proclass_collection.sort()
@@ -221,14 +216,12 @@ class ProsetHandler(RequestHandler):
 
         elif reqtype == "decollect":
             if self.acct.is_guest():
-                self.error(('Eacces', 'Please login'))
-                return
+                return self.error(('Eacces', 'Please login'))
 
             proclass_id = int(self.get_argument('proclass_id'))
 
             if proclass_id not in self.acct.proclass_collection:
-                self.error(('Enoext', 'Problem class is not in your collection'))
-                return
+                return self.error(('Enoext', 'Problem class is not in your collection'))
 
             self.acct.proclass_collection.remove(proclass_id)
             self.acct.proclass_collection.sort()
@@ -242,26 +235,21 @@ class ProStaticHandler(RequestHandler):
         pro_id = int(pro_id)
         if self.contest:
             if not self.contest.is_pro(pro_id):
-                self.error(('Enoext', 'Problem not in contest'))
-                return
+                return self.error(('Enoext', 'Problem not in contest'))
 
         err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         if pro['status'] == ProConst.STATUS_OFFLINE:
-            self.error(PERMISSION_DENIED_ERROR)
-            return
+            return self.error(PERMISSION_DENIED_ERROR)
 
         elif pro['status'] == ProConst.STATUS_CONTEST:
             if not self.contest:
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             elif not (self.contest.is_running() or self.contest.is_admin(self.acct)):
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
         if path.endswith('pdf'):
             self.set_header('Pragma', 'public')
@@ -289,29 +277,23 @@ class ProHandler(RequestHandler):
 
         if self.contest:
             if not self.contest.is_pro(pro_id):
-                self.error(('Enoext', 'Problem not in contest'))
-                return
+                return self.error(('Enoext', 'Problem not in contest'))
 
             if not self.contest.is_start() and not self.contest.is_admin(self.acct):
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             elif not self.contest.is_running() and not self.contest.is_member(self.acct):
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
         err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         if pro['status'] == ProConst.STATUS_OFFLINE:
-            self.error(PERMISSION_DENIED_ERROR)
-            return
+            return self.error(PERMISSION_DENIED_ERROR)
 
         elif pro['status'] == ProConst.STATUS_CONTEST and not self.contest:
-            self.error(PERMISSION_DENIED_ERROR)
-            return
+            return self.error(PERMISSION_DENIED_ERROR)
 
         # NOTE: Guest cannot see tags
         # NOTE: Admin can see tags
@@ -360,8 +342,7 @@ class ProTagsHandler(RequestHandler):
 
         err, pro = await ProService.inst.get_pro(pro_id, self.acct)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         await LogService.inst.add_log(
             (self.acct.name + " updated the tag of problem #" + str(pro_id) + " to: \"" + str(tags) + "\"."),
@@ -373,7 +354,6 @@ class ProTagsHandler(RequestHandler):
         )
 
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         self.error(('S', ''))

--- a/src/handlers/pro.py
+++ b/src/handlers/pro.py
@@ -177,28 +177,49 @@ class ProsetHandler(RequestHandler):
     async def post(self):
         reqtype = self.get_argument('reqtype')
         if reqtype == "listproclass":
+            proclass_type = self.get_argument('proclass_type')
+            _, proclass_list = await ProClassService.inst.get_proclass_list()
+
             _, accts = await UserService.inst.list_acct(UserConst.ACCTTYPE_KERNEL)
             accts = {acct.acct_id: acct.name for acct in accts}
 
-            _, proclass_list = await ProClassService.inst.get_proclass_list()
-            def _set_creator_name(proclass):
-                proclass = dict(proclass)
+            if proclass_type == 'official':
+                if self.acct.is_kernel():
+                    proclass_list = list(filter(
+                        lambda proclass: proclass['type'] in [ProClassConst.OFFICIAL_PUBLIC, ProClassConst.OFFICIAL_HIDDEN], proclass_list))
+                else:
+                    proclass_list = list(filter(lambda proclass: proclass['type'] == ProClassConst.OFFICIAL_PUBLIC, proclass_list))
+
+            elif proclass_type == 'shared':
+                proclass_list = list(filter(lambda proclass: proclass['type'] == ProClassConst.USER_PUBLIC, proclass_list))
+
+            elif proclass_type == 'collection':
+                proclass_list = list(filter(lambda proclass: proclass['proclass_id'] in self.acct.proclass_collection, proclass_list))
+
+            elif proclass_type == 'own':
+                proclass_list = list(filter(lambda proclass: proclass['acct_id'] == self.acct.acct_id, proclass_list))
+
+            else:
+                self.error(('Eparam', 'Wrong proclass_type'))
+                return
+
+            _, acct_states = await RateService.inst.map_rate_acct(self.acct)
+            for i in range(len(proclass_list)):
+                proclass_list[i] = dict(proclass_list[i])
+                proclass = proclass_list[i]
+                ac_cnt = 0
+                err, p = await ProClassService.inst.get_proclass(proclass['proclass_id'])
                 if proclass['acct_id']:
                     proclass['creator_name'] = accts[proclass['acct_id']]
 
-                return proclass
-            proclass_list = list(map(_set_creator_name, proclass_list))
+                for pro_id in p['list']:
+                    if pro_id in acct_states:
+                        ac_cnt += acct_states[pro_id]['state'] == ChalConst.STATE_AC
 
-            proclass_cata = {
-                "official": list(filter(lambda proclass: proclass['type'] == ProClassConst.OFFICIAL_PUBLIC, proclass_list)),
-                "shared": list(filter(lambda proclass: proclass['type'] == ProClassConst.USER_PUBLIC, proclass_list)),
-                "collection": list(filter(lambda proclass: proclass['proclass_id'] in self.acct.proclass_collection, proclass_list)),
-                "own": list(filter(lambda proclass: proclass['acct_id'] == self.acct.acct_id, proclass_list)),
-            }
-            if self.acct.is_kernel():
-                proclass_cata['official'].extend(filter(lambda proclass: proclass['type'] == ProClassConst.OFFICIAL_HIDDEN, proclass_list))
+                proclass['ac_cnt'] = ac_cnt
+                proclass['total_cnt'] = len(p['list'])
 
-            self.error(('S', proclass_cata))
+            self.error(('S', proclass_list))
 
         elif reqtype == "collect":
             if self.acct.is_guest():

--- a/src/handlers/ques.py
+++ b/src/handlers/ques.py
@@ -11,8 +11,7 @@ class QuestionHandler(RequestHandler):
     async def get(self):
         err, ques_list = await QuestionService.inst.get_queslist(self.acct.acct_id)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         await self.rs.set(f"{self.acct.acct_id}_have_reply", packb(False))
         await self.render('question', ques_list=ques_list)
@@ -27,18 +26,14 @@ class QuestionHandler(RequestHandler):
             if err := self.len_check(qtext, QuestionConst.QUESTION_MIN, QuestionConst.QUESTION_MAX, 'Question'):
                 return self.error(err)
 
-            err = await QuestionService.inst.set_ques(self.acct.acct_id, qtext)
-            if err:
-                self.error(err)
-                return
+            if err := await QuestionService.inst.set_ques(self.acct.acct_id, qtext):
+                return self.error(err)
 
             self.error(('S', ''))
 
         elif reqtype == 'rm_ques':
             index = int(self.get_argument('index'))
-            err = await QuestionService.inst.rm_ques(self.acct.acct_id, index)
-            if err:
-                self.error(err)
-                return
+            if err := await QuestionService.inst.rm_ques(self.acct.acct_id, index):
+                return self.error(err)
 
             self.error(('S', ''))

--- a/src/handlers/ques.py
+++ b/src/handlers/ques.py
@@ -24,14 +24,8 @@ class QuestionHandler(RequestHandler):
 
         if reqtype == 'ask':
             qtext = str(self.get_argument('qtext')).strip()
-            qtext_len = len(qtext)
-            if qtext_len < QuestionConst.QUESTION_MIN:
-                self.error(('Equesmin', 'Question too short'))
-                return
-
-            elif qtext_len > QuestionConst.QUESTION_MAX:
-                self.error(('Equesmax', 'Question too long'))
-                return
+            if err := self.len_check(qtext, QuestionConst.QUESTION_MIN, QuestionConst.QUESTION_MAX, 'Question'):
+                return self.error(err)
 
             err = await QuestionService.inst.set_ques(self.acct.acct_id, qtext)
             if err:

--- a/src/handlers/submit.py
+++ b/src/handlers/submit.py
@@ -18,20 +18,17 @@ class SubmitHandler(RequestHandler):
     @contest_require_permission('all')
     async def get(self, pro_id=None):
         if pro_id is None:
-            self.error(('Enoext', 'Missing parameter pro_id'))
-            return
+            return self.error(('Enoext', 'Missing parameter pro_id'))
 
         pro_id = int(pro_id)
 
         allow_compilers = ChalConst.ALLOW_COMPILERS
         if self.contest:
             if not self.contest.is_running() and not self.contest.is_admin(self.acct):
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             if not self.contest.is_pro(pro_id):
-                self.error(('Enoext', 'Problem not in contest'))
-                return
+                return self.error(('Enoext', 'Problem not in contest'))
 
             allow_compilers = self.contest.allow_compilers
 
@@ -44,16 +41,13 @@ class SubmitHandler(RequestHandler):
         pro_id = int(pro_id)
         err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         if pro['status'] == ProService.STATUS_OFFLINE:
-            self.error(PERMISSION_DENIED_ERROR)
-            return
+            return self.error(PERMISSION_DENIED_ERROR)
 
         if not pro['allow_submit']:
-            self.error(('Eacces', 'Problem did not allow submit'))
-            return
+            return self.error(('Eacces', 'Problem did not allow submit'))
 
         if pro['testm_conf']['is_makefile']:
             allow_compilers = list(filter(lambda compiler: compiler in ['gcc', 'g++', 'clang', 'clang++'], allow_compilers))
@@ -68,8 +62,7 @@ class SubmitHandler(RequestHandler):
         can_submit = JudgeServerClusterService.inst.is_server_online()
 
         if not can_submit:
-            self.error(('Ejudge', 'No available judge'))
-            return
+            return self.error(('Ejudge', 'No available judge'))
 
         contest_id = 0
         if self.contest:
@@ -84,48 +77,38 @@ class SubmitHandler(RequestHandler):
             if self.contest:
                 pri = ChalConst.CONTEST_PRI
                 if not self.contest.is_running() and not self.contest.is_admin(self.acct):
-                    self.error(PERMISSION_DENIED_ERROR)
-                    return
+                    return self.error(PERMISSION_DENIED_ERROR)
 
                 if not self.contest.is_pro(pro_id):
-                    self.error(('Enoext', 'Problem not in contest'))
-                    return
+                    return self.error(('Enoext', 'Problem not in contest'))
             else:
                 pri = ChalConst.NORMAL_PRI
 
-            err = await self.is_allow_submit(code, comp_type, pro_id)
-            if err:
-                self.error(err)
-                return
+            if err := await self.is_allow_submit(code, comp_type, pro_id):
+                return self.error(err)
 
             err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             if pro['status'] == ProService.STATUS_OFFLINE:
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             elif pro['status'] == ProService.STATUS_CONTEST and not self.contest:
-                self.error(PERMISSION_DENIED_ERROR)
-                return
+                return self.error(PERMISSION_DENIED_ERROR)
 
             if not pro['allow_submit']:
-                self.error(('Eacces', 'Problem did not allow submit'))
-                return
+                return self.error(('Eacces', 'Problem did not allow submit'))
 
             err, chal_id = await ChalService.inst.add_chal(pro_id, self.acct.acct_id, contest_id, comp_type, code)
             if err:
-                self.error(err)
-                return
+                return self.error(err)
 
             if self.acct.last_compiler != comp_type:
                 self.acct.last_compiler = comp_type
                 err, _ = await UserService.inst.update_acct(self.acct)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
         elif reqtype == 'rechal':
             if ((self.contest is None and self.acct.is_kernel())  # not in contest
@@ -144,12 +127,10 @@ class SubmitHandler(RequestHandler):
                 comp_type = chal['comp_type']
                 err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
                 if err:
-                    self.error(err)
-                    return
+                    return self.error(err)
 
         else:
-            self.error(('Eunk', 'Unknown error'))
-            return
+            return self.error(('Eunk', 'Unknown error'))
 
         err, _ = await ChalService.inst.emit_chal(
             chal_id,
@@ -159,8 +140,7 @@ class SubmitHandler(RequestHandler):
             pri=pri
         )
         if err:
-            self.error(err)
-            return
+            return self.error(err)
 
         if reqtype == 'submit' and pro['status'] == ProService.STATUS_ONLINE:
             await self.rs.publish('challist_sub', str(1))

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -347,6 +347,13 @@ class ContestService:
 
         return None, None
 
+    async def get_question(self, contest_id: int, question_id: int):
+        res = await self.db.fetch('SELECT * FROM contest_question WHERE contest_id = $1 AND question_id = $2', contest_id, question_id)
+        if len(res) != 1:
+            return ('Eunk', 'Unknown error'), None
+
+        return None, res[0]
+
     async def get_all_question(self, contest_id: int, ask_acct_id: int = 0):
         if ask_acct_id:
             res = await self.db.fetch('SELECT * FROM contest_question WHERE contest_id = $1 AND ask_acct_id = $2', contest_id, ask_acct_id)

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -224,7 +224,7 @@ class ContestService:
 
         b_contest = pickle.dumps(contest)
 
-        await self.rs.hset('contests', f'{contest_id}', b_contest)
+        await self.rs.hset('contest', f'{contest_id}', b_contest)
 
         return None, contest_id
 

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -268,7 +268,8 @@ class ContestService:
 
             if prolist_updated:
                 order = 0
-                for order, (pro_id, v) in enumerate(contest.pro_list.items()):
+                failed = []
+                for pro_id, v in contest.pro_list.items():
                     try:
                         await con.execute('''
                             INSERT INTO contest_problem_joints ("contest_id", "pro_id", "score_type", "order")
@@ -278,11 +279,17 @@ class ContestService:
                                 contest_problem_joints.score_type != EXCLUDED.score_type OR
                                 contest_problem_joints.order != EXCLUDED.order;
                         ''', contest.contest_id, pro_id, int(v['score_type']), order)
+                        order += 1
                     except asyncpg.ForeignKeyViolationError:
+                        failed.append(pro_id)
                         continue
+
                 await con.execute('DELETE FROM contest_problem_joints WHERE contest_id = $1 AND "order" > $2', contest.contest_id, order)
+                for failed_pro_id in failed:
+                    contest.pro_list.pop(failed_pro_id)
 
             if userlist_updated:
+                failed = []
                 for acct_id, v in contest.user_list.items():
                     try:
                         await con.execute('''
@@ -292,7 +299,11 @@ class ContestService:
                             WHERE contest_users.status != EXCLUDED.status;
                         ''', contest.contest_id, acct_id, int(v['status']))
                     except asyncpg.ForeignKeyViolationError:
+                        failed.append(acct_id)
                         continue
+
+                for failed_acct_id in failed:
+                    contest.user_list.pop(failed_acct_id)
 
         b_contest = pickle.dumps(contest)
         await self.rs.hset('contest', str(contest.contest_id), b_contest)

--- a/src/services/group.py
+++ b/src/services/group.py
@@ -137,8 +137,7 @@ class GroupService:
         if gname not in glist:
             return ('Enoext', GroupService.GROUP_NOT_FOUND)
 
-        err = await self._update_group(gname, int(gtype), int(gclas))
-        if err:
+        if err := await self._update_group(gname, int(gtype), int(gclas)):
             return err
 
         gacct = await self.list_acct_in_group(gname)

--- a/src/services/group.py
+++ b/src/services/group.py
@@ -98,12 +98,11 @@ class GroupService:
 
             await con.execute(
                 '''
-                    UPDATE "account" SET "group" = $1, "acct_type" = $2, "class" = $3
-                    WHERE "account"."acct_id" = $4;
+                    UPDATE "account" SET "group" = $1, "acct_type" = $2
+                    WHERE "account"."acct_id" = $3;
                 ''',
                 gname,
                 result['group_type'],
-                [result['group_class']],
                 acct_id,
             )
 

--- a/src/services/judge.py
+++ b/src/services/judge.py
@@ -205,8 +205,7 @@ class JudgeServerClusterService:
         if idx < 0 or idx >= len(self.servers):
             return ('Eparam', 'Invalid judge index')
 
-        err = await self.servers[idx].disconnect_server()
-        if err:
+        if err := await self.servers[idx].disconnect_server():
             return err
 
         return ('S', '')

--- a/src/services/ques.py
+++ b/src/services/ques.py
@@ -31,7 +31,7 @@ class QuestionService:
             await self.rs.set(f'{acct_id}_msg_list', packb([]))
 
         elif not active:
-            return 'Eacces'
+            return ('Eacces', 'What the heck is _msg_active')
 
         await self.rs.set(f'{acct_id}_msg_ask', packb(True))
         ques_list = unpackb((await self.rs.get(f'{acct_id}_msg_list')))

--- a/src/static/templ/contests/qa.html
+++ b/src/static/templ/contests/qa.html
@@ -38,17 +38,21 @@
         <h1>Announcement</h1>
 
         <!-- TODO: add a button to close collapse when col-12 -->
-        <div class="announce" style="overflow-y:scroll; max-height: 80vh;">
-            {% for announce in announces %}
-                <div class="card mt-2">
-                    <div class="card-body">
-                        <h4 class="card-title">{{ announce['subject'] }}</h4>
-                        <p class="card-text">{{ announce['content'] }}</p>
-                        <h6>{{ announce['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+        {% if contest.is_start() %}
+            <div class="announce" style="overflow-y:scroll; max-height: 80vh;">
+                {% for announce in announces %}
+                    <div class="card mt-2">
+                        <div class="card-body">
+                            <h4 class="card-title">{{ announce['subject'] }}</h4>
+                            <p class="card-text">{{ announce['content'] }}</p>
+                            <h6>{{ announce['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                        </div>
                     </div>
-                </div>
-            {% end %}
-        </div>
+                {% end %}
+            </div>
+        {% else %}
+            <h2>Contest not start</h2>
+        {% end %}
     </div>
 
     <div class="col-lg-7 col-12">

--- a/src/static/templ/contests/qa.html
+++ b/src/static/templ/contests/qa.html
@@ -1,3 +1,4 @@
+{% from services.contests import UserStatus %}
 <script>
     function init() {
         // TODO: markdown feature
@@ -56,6 +57,7 @@
     </div>
 
     <div class="col-lg-7 col-12">
+        {% if contest.is_member(user, UserStatus.APPROVED) %}
         <div class="row">
             <h1>Question</h1>
             <form>
@@ -114,5 +116,9 @@
                 </table>
             </div>
         </div>
+        {% else %}
+            <h1>Question</h1>
+            <h2>Only contestants can ask questions.</h2>
+        {% end %}
     </div>
 </div>

--- a/src/static/templ/index.html
+++ b/src/static/templ/index.html
@@ -147,9 +147,12 @@
         {% if is_in_contest %}
         <ul class="navbar-nav me-auto">
           <li class="nav-item info"><a class="nav-link" href="/oj/contests/{{ contest_id  }}/info/">Info</a></li>
-          <li class="nav-item proset"><a class="nav-link" href="/oj/contests/{{ contest_id }}/proset/">ProblemSet</a></li>
-          <li class="nav-item chal"><a class="nav-link" href="/oj/contests/{{ contest_id }}/chal/">Challenges</a></li>
-          <li class="nav-item scoreboard"><a class="nav-link" href="/oj/contests/{{ contest_id }}/scoreboard/">Scoreboard</a></li>
+
+          {% if contest_manage or contest.is_start() %}
+            <li class="nav-item proset"><a class="nav-link" href="/oj/contests/{{ contest_id }}/proset/">ProblemSet</a></li>
+            <li class="nav-item chal"><a class="nav-link" href="/oj/contests/{{ contest_id }}/chal/">Challenges</a></li>
+            <li class="nav-item scoreboard"><a class="nav-link" href="/oj/contests/{{ contest_id }}/scoreboard/">Scoreboard</a></li>
+          {% end %}
 
           {% if not contest_manage %}
             <li class="nav-item qa"></li>

--- a/src/static/templ/index.html
+++ b/src/static/templ/index.html
@@ -107,7 +107,10 @@
             let ws = index.get_ws("contests/{{ contest.contest_id }}/qasub");
             let contest_notification_cnt = parseInt("{{ contest_notification_cnt }}");
             ws.onopen = (e) => {
-                ws.send("{{ contest.contest_id }}");
+                ws.send(JSON.stringify({
+                    contest_id: "{{ contest.contest_id }}",
+                    acct_id: "{{ user.acct_id }}",
+                }));
             };
             ws.onmessage = (e) => {
                 e = JSON.parse(e.data);

--- a/src/static/templ/manage/question/reply.html
+++ b/src/static/templ/manage/question/reply.html
@@ -14,7 +14,7 @@
 		}, function(res) {
             res = JSON.parse(res);
             if (res.status == 'S') {
-                index.show_notify_dialog('Update Successfully', index.DIALOG_TYPE.success);
+                index.show_notify_dialog('Reply Successfully', index.DIALOG_TYPE.success);
 				setTimeout(() => index.reload(), 1000);
             } else {
                 index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
@@ -34,7 +34,7 @@
 		}, function(res) {
             res = JSON.parse(res);
             if (res.status == 'S') {
-                index.show_notify_dialog('Update Successfully', index.DIALOG_TYPE.success);
+                index.show_notify_dialog('Re-reply Successfully', index.DIALOG_TYPE.success);
 				setTimeout(() => index.reload(), 1000);
             } else {
                 index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);

--- a/src/static/templ/proset.html
+++ b/src/static/templ/proset.html
@@ -86,80 +86,92 @@
         let j_list_dialog = $(list_dialog);
 
         function render_proclass_list(proclass_type) {
-            let proclass_table = j_list_dialog.find("tbody");
-            let collected = new Set(proclass_cata.collection.map(proclass => proclass.proclass_id));
+            function _internal() {
+                let proclass_table = j_list_dialog.find("tbody");
+                let collected = new Set(proclass_cata.collection.map(proclass => proclass.proclass_id));
 
-            proclass_table.html("");
-            for (let proclass of proclass_cata[proclass_type]) {
-                let tr = $("<tr></tr>")
-                tr.append($("<td></td>").text(proclass.proclass_id));
-                tr.append($("<td></td>").text(proclass.name));
-                if (proclass.acct_id != null) {
-                    tr.append($("<td></td>").append($(`<a href="/oj/acct/${proclass.acct_id}/"></a>`).text(proclass.creator_name)));
-                } else {
-                    tr.append($("<td></td>").text("Official"));
-                }
+                proclass_table.html("");
+                for (let proclass of proclass_cata[proclass_type]) {
+                    let tr = $("<tr></tr>")
+                    tr.append($("<td></td>").text(proclass.proclass_id));
+                    tr.append($("<td></td>").text(proclass.name));
+                    tr.append($("<td></td>").text(`<a href="/oj/proset/?proclass_id=${proclass.proclass_id}&show=onlyac">${proclass.ac_cnt}</a> / ${proclass.total_cnt}`));
+                    if (proclass.acct_id != null) {
+                        tr.append($("<td></td>").append($(`<a href="/oj/acct/${proclass.acct_id}/"></a>`).text(proclass.creator_name)));
+                    } else {
+                        tr.append($("<td></td>").text("Official"));
+                    }
 
-                let collect_td = null;
-                if (collected.has(proclass.proclass_id)) {
-                    collect_td = $(`<td><button class="btn btn-success" actionType="decollect">Decollect</button></td>`);
-                } else {
-                    collect_td = $(`<td><button class="btn btn-success" actionType="collect">Collect</button></td>`);
-                }
-                collect_td.find("button").on('click', function (e) {
-                    let action = $(this).attr("actionType");
-                    let j_this = $(this);
-                    $.post("/oj/be/proset", data={
-                        'reqtype': action,
-                        'proclass_id': proclass.proclass_id,
-                    }, function(res) {
-                        res = JSON.parse(res);
-                        if (res.status == 'S') {
-                            if (action == "decollect") {
-                                j_this.attr("actionType", "collect");
-                                j_this.text("Collect");
+                    let collect_td = null;
+                    if (collected.has(proclass.proclass_id)) {
+                        collect_td = $(`<td><button class="btn btn-success" actionType="decollect">Decollect</button></td>`);
+                    } else {
+                        collect_td = $(`<td><button class="btn btn-success" actionType="collect">Collect</button></td>`);
+                    }
+                    collect_td.find("button").on('click', function (e) {
+                        let action = $(this).attr("actionType");
+                        let j_this = $(this);
+                        $.post("/oj/be/proset", data={
+                            'reqtype': action,
+                            'proclass_id': proclass.proclass_id,
+                        }, function(res) {
+                            res = JSON.parse(res);
+                            if (res.status == 'S') {
+                                if (action == "decollect") {
+                                    j_this.attr("actionType", "collect");
+                                    j_this.text("Collect");
+                                } else {
+                                    j_this.attr("actionType", 'decollect');
+                                    j_this.text("Decollect");
+                                }
+                                proclass_cata = null;
                             } else {
-                                j_this.attr("actionType", 'decollect');
-                                j_this.text("Decollect");
+                                index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
                             }
-                            proclass_cata = null;
-                        } else {
-                            index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
-                        }
+                        });
                     });
-                });
-                tr.append(collect_td);
+                    tr.append(collect_td);
 
-                let goto = $(`<td><button class="btn btn-primary">Goto!</button></td>`)
-                goto.find("button").on('click', function(e) {
-                    list_dialog_modal.hide();
-                    index.go(get_goto_url(proclass.proclass_id));
-                });
-                tr.append(goto);
+                    let goto = $(`<td><button class="btn btn-primary">Goto!</button></td>`)
+                    goto.find("button").on('click', function(e) {
+                        list_dialog_modal.hide();
+                        index.go(get_goto_url(proclass.proclass_id));
+                    });
+                    tr.append(goto);
 
-                proclass_table.append(tr);
-                // NOTE: close proclass list dialog before navigating to another page.
-                tr[0].querySelectorAll('a').forEach(el => {
-                    el.addEventListener('click', _ => list_dialog_modal.hide() && index.reload());
-                })
+                    proclass_table.append(tr);
+                    // NOTE: close proclass list dialog before navigating to another page.
+                    tr[0].querySelectorAll('a').forEach(el => {
+                        el.addEventListener('click', _ => list_dialog_modal.hide() && index.reload());
+                    })
+                }
+            }
+
+            if (proclass_cata[proclass_type] === undefined) {
+                $.post("/oj/be/proset", {
+                    "reqtype": "listproclass"
+                    "proclass_type": proclass_type,
+                }, function (e) {
+                    proclass_cata[proclass_type] = JSON.parse(e).data;
+                    _internal();
+                });
+            } else {
+                _internal();
             }
         }
 
         $("#switchProClass").on('click', function(e) {
             document.querySelectorAll('.proclass-tab').forEach(el => el.classList.remove('active'));
             document.querySelector('.proclass-tab[proclassType="official"]').classList.add('active');
-            if (proclass_cata == null) {
-                $.post("/oj/be/proset", {
-                    "reqtype": "listproclass"
-                }, function (e) {
-                    proclass_cata = JSON.parse(e).data;
-                    render_proclass_list("official");
-                });
-            } else {
+            proclass_cata = {};
+            $.post("/oj/be/proset", {
+                "reqtype": "listproclass"
+                "proclass_type": "collection",
+            }, function (e) {
+                proclass_cata["collection"] = JSON.parse(e).data;
                 render_proclass_list("official");
-            }
-
-            list_dialog_modal.show();
+                list_dialog_modal.show();
+            });
         });
 
         document.querySelectorAll('.proclass-tab').forEach(el => {
@@ -170,7 +182,7 @@
 
                 if (proclass_cata == null) {
                     $.post("/oj/be/proset", {
-                        "reqtype": "listproclass"
+                        "reqtype": "listproclass",
                     }, function (e) {
                         proclass_cata = JSON.parse(e).data;
                         render_proclass_list(proclass_type);
@@ -237,6 +249,7 @@
                 <thead>
                     <tr>
                         <th scope="col">#</th>
+                        <th>Progress</th>
                         <th>Name</th>
                         <th>Creator</th>
                         <th>Collect</th>

--- a/src/static/templ/proset.html
+++ b/src/static/templ/proset.html
@@ -363,7 +363,7 @@
                     {% if pro['state'] is None %}
                         <td>Todo</td>
                     {% else %}
-                        <td class="state-{{ pro['state'] }}">{{ChalConst.STATE_LONG_STR[pro['state']]}}</td>
+                        <td><a href="/oj/chal/?proid={{ pro['pro_id'] }}&acctid={{ user.acct_id }}" class="state-{{ pro['state'] }}">{{ChalConst.STATE_LONG_STR[pro['state']]}}</a></td>
                     {% end %}
                     <td class="name">
                         <a href="/oj/pro/{{ pro['pro_id'] }}/">{{ pro['name'] }}</a>

--- a/src/tests/e2e/bulletin.py
+++ b/src/tests/e2e/bulletin.py
@@ -59,7 +59,7 @@ class BulletinTest(AsyncTest):
                 'color': 'red',
                 'pinned': 'true',
             })
-            self.assertAPIReturnValue(res.text, ('Eparam', 'Desc too long'))
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Content too long'))
 
             # view info
             html = self.get_html('info', admin_session)

--- a/src/tests/e2e/contest.py
+++ b/src/tests/e2e/contest.py
@@ -496,25 +496,6 @@ class ContestTest(AsyncTest):
             self.assertEqual(chal_tr.select('td > a')[1].attrs.get('href'), '/oj/contests/1/pro/7/')
             self.assertEqual(chal_tr.select('td')[3].attrs.get('class')[0], 'state-1')
 
-        with AccountContext('admin@test', 'testtest') as admin_session:
-            contest_end = now - datetime.timedelta(days=1)
-            config = copy.deepcopy(default_config)
-            config['contest_end'] = self.get_isoformat(contest_end)
-            res = admin_session.post('contests/1/manage/general', data=config)
-            self.assertAPIReturnSuccess(res.text)
-
-            res = admin_session.post('contests/1/manage/pro', data={
-                'reqtype': 'public',
-                'pro_id': '7'
-            })
-            self.assertAPIReturnSuccess(res.text)
-
-        with AccountContext('test1@test', 'test') as user_session:
-            res = user_session.get('pro/7')
-            self.assertNotIn('Eacces', res.text)
-            res = user_session.get('pro/8')
-            self.assertAPIReturnValue(res.text, ('Enoext', 'Problem not found'))
-
         def _message(msg):
             if msg is None:
                 return
@@ -760,6 +741,26 @@ class ContestTest(AsyncTest):
 
             res = admin_session.get('contests/1/qa')
             self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
+
+        # NOTE: contest end
+        with AccountContext('admin@test', 'testtest') as admin_session:
+            contest_end = now - datetime.timedelta(days=1)
+            config = copy.deepcopy(default_config)
+            config['contest_end'] = self.get_isoformat(contest_end)
+            res = admin_session.post('contests/1/manage/general', data=config)
+            self.assertAPIReturnSuccess(res.text)
+
+            res = admin_session.post('contests/1/manage/pro', data={
+                'reqtype': 'public',
+                'pro_id': '7'
+            })
+            self.assertAPIReturnSuccess(res.text)
+
+        with AccountContext('test1@test', 'test') as user_session:
+            res = user_session.get('pro/7')
+            self.assertNotIn('Eacces', res.text)
+            res = user_session.get('pro/8')
+            self.assertAPIReturnValue(res.text, ('Enoext', 'Problem not found'))
 
         # freeze_scoreboard_period: int = 0
 

--- a/src/tests/e2e/contest.py
+++ b/src/tests/e2e/contest.py
@@ -33,7 +33,7 @@ class ContestTest(AsyncTest):
             # update general
             now = datetime.datetime.now()
             contest_start = now + datetime.timedelta(days=1)
-            contest_end = now + datetime.timedelta(days=2)
+            contest_end = now + datetime.timedelta(days=4)
             reg_end = now + datetime.timedelta(days=1) - datetime.timedelta(hours=8)
             default_config = {
                 'reqtype': 'update',
@@ -507,15 +507,18 @@ class ContestTest(AsyncTest):
             })
             self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
 
-        def _message(msg):
-            if msg is None:
-                return
-
-            self.assertEqual(int(msg), 1)
-        ws = await websocket_connect('ws://localhost:5501/contests/1/manage/qasub', on_message_callback=_message)
-        await ws.write_message("1")
-
         with AccountContext('contest1@test', 'test') as user_session:
+            def _message(msg):
+                if msg is None:
+                    return
+
+                self.assertEqual(int(msg), 1)
+            ws = await websocket_connect('ws://localhost:5501/contests/1/manage/qasub', on_message_callback=_message)
+            await ws.write_message(json.dumps({
+                "contest_id": 1,
+                "acct_id": 4,
+            }))
+
             res = user_session.post('contests/1/qa', data={
                 'reqtype': 'ask',
                 'subject': '',
@@ -594,8 +597,13 @@ class ContestTest(AsyncTest):
                 j = json.loads(msg)
                 self.assertEqual(j['contest_id'], 1)
                 self.assertEqual(j['type'], 'reply')
+                self.assertEqual(j['ask_acct_id'], 4)
             ws = await websocket_connect('ws://localhost:5501/contests/1/qasub', on_message_callback=_message)
-            await ws.write_message('1')
+            await ws.write_message(json.dumps({
+                "contest_id": 1,
+                "acct_id": 4,
+            }))
+
             res = admin_session.post('contests/1/manage/question', data={
                 'reqtype': 'reply',
                 'content': 'answer',
@@ -650,7 +658,10 @@ class ContestTest(AsyncTest):
                 self.assertEqual(j['type'], 'add-announce')
 
             ws = await websocket_connect('ws://localhost:5501/contests/1/qasub', on_message_callback=_message)
-            await ws.write_message("1")
+            await ws.write_message(json.dumps({
+                "contest_id": 1,
+                "acct_id": 4,
+            }))
             res = admin_session.post('contests/1/manage/announce', data={
                 'reqtype': 'add-announce',
                 'subject': 'subject',
@@ -710,7 +721,10 @@ class ContestTest(AsyncTest):
                 self.assertEqual(j['type'], 'edit-announce')
 
             ws = await websocket_connect('ws://localhost:5501/contests/1/qasub', on_message_callback=_message)
-            await ws.write_message("1")
+            await ws.write_message(json.dumps({
+                "contest_id": 1,
+                "acct_id": 4,
+            }))
             res = admin_session.post('contests/1/manage/announce', data={
                 'reqtype': 'edit-announce',
                 'subject': 'subject2',
@@ -742,7 +756,10 @@ class ContestTest(AsyncTest):
                 self.assertEqual(j['type'], 'popup-announce')
 
             ws = await websocket_connect('ws://localhost:5501/contests/1/qasub', on_message_callback=_message)
-            await ws.write_message("1")
+            await ws.write_message(json.dumps({
+                "contest_id": 1,
+                "acct_id": 4
+            }))
             res = admin_session.post('contests/1/manage/announce', data={
                 'reqtype': 'popup-announce',
                 'announce_id': 1,

--- a/src/tests/e2e/contest.py
+++ b/src/tests/e2e/contest.py
@@ -361,7 +361,17 @@ class ContestTest(AsyncTest):
             res = user_session.get('contests/1/pro/7/cont.pdf')
             self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
 
+            html = self.get_html('index/contests/1', user_session)
+            self.assertIsNone(html.select_one('li.nav-item.proset'))
+            self.assertIsNone(html.select_one('li.nav-item.chal'))
+            self.assertIsNone(html.select_one('li.nav-item.scoreboard'))
+
         with AccountContext('admin@test', 'testtest') as admin_session:
+            html = self.get_html('index/contests/1', admin_session)
+            self.assertIsNotNone(html.select_one('li.nav-item.proset'))
+            self.assertIsNotNone(html.select_one('li.nav-item.chal'))
+            self.assertIsNotNone(html.select_one('li.nav-item.scoreboard'))
+
             contest_start = now - datetime.timedelta(days=2)
             config = copy.deepcopy(default_config)
             config['contest_start'] = self.get_isoformat(contest_start)
@@ -373,6 +383,11 @@ class ContestTest(AsyncTest):
             # html = self.get_html('contests', user_session)
             # contest0 = html.select('tr')[1]
             # self.assertEqual(contest0.select('td')[0].text, 'Started')
+
+            html = self.get_html('index/contests/1', user_session)
+            self.assertIsNotNone(html.select_one('li.nav-item.proset'))
+            self.assertIsNotNone(html.select_one('li.nav-item.chal'))
+            self.assertIsNotNone(html.select_one('li.nav-item.scoreboard'))
 
             res = user_session.get('contests/1')
             self.assertEqual(re.findall(r'let desc_tex = `(.*)`', res.text, re.I)[0], 'desc during contest')

--- a/src/tests/e2e/contest.py
+++ b/src/tests/e2e/contest.py
@@ -496,14 +496,25 @@ class ContestTest(AsyncTest):
             self.assertEqual(chal_tr.select('td > a')[1].attrs.get('href'), '/oj/contests/1/pro/7/')
             self.assertEqual(chal_tr.select('td')[3].attrs.get('class')[0], 'state-1')
 
+        with AccountContext('test1@test', 'test') as user_session:
+            html = self.get_html('contests/1/qa', user_session)
+            self.assertEqual(html.select('div.row > div')[1].select_one('h2').text.strip(), 'Only contestants can ask questions.')
+
+            res = user_session.post('contests/1/qa', data={
+                'reqtype': 'ask',
+                'subject': 'subject',
+                'content': 'content',
+            })
+            self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
+
         def _message(msg):
             if msg is None:
                 return
 
             self.assertEqual(int(msg), 1)
-
         ws = await websocket_connect('ws://localhost:5501/contests/1/manage/qasub', on_message_callback=_message)
         await ws.write_message("1")
+
         with AccountContext('contest1@test', 'test') as user_session:
             res = user_session.post('contests/1/qa', data={
                 'reqtype': 'ask',

--- a/src/tests/e2e/proclass.py
+++ b/src/tests/e2e/proclass.py
@@ -29,25 +29,22 @@ class ProClassTest(AsyncTest):
             self.assertEqual(len(trs), 1)
 
             res = admin_session.post('proset', data={
-                'reqtype': 'listproclass'
+                'reqtype': 'listproclass',
+                'proclass_type': 'official'
             })
             res = json.loads(res.text)
-            proclass_cata = res['data']
-            self.assertNotEqual(proclass_cata['official'], [])
-            self.assertEqual(proclass_cata['shared'], [])
-            self.assertEqual(proclass_cata['own'], [])
-            self.assertEqual(proclass_cata['collection'], [])
+            proclass_list = res['data']
+            self.assertNotEqual(proclass_list, [])
 
             with AccountContext('test1@test', 'test') as user_session:
-                res = user_session.post('proset', data={
-                    'reqtype': 'listproclass'
-                })
-                res = json.loads(res.text)
-                proclass_cata = res['data']
-                self.assertEqual(proclass_cata['official'], [])
-                self.assertEqual(proclass_cata['shared'], [])
-                self.assertEqual(proclass_cata['own'], [])
-                self.assertEqual(proclass_cata['collection'], [])
+                for proclass_type in ['official', 'shared', 'own', 'collection']:
+                    res = user_session.post('proset', data={
+                        'reqtype': 'listproclass',
+                        'proclass_type': proclass_type
+                    })
+                    res = json.loads(res.text)
+                    proclass_list = res['data']
+                    self.assertEqual(proclass_list, [])
 
                 res = self.get_html('proset?proclass_id=1', user_session)
                 self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
@@ -135,13 +132,16 @@ class ProClassTest(AsyncTest):
             })
             self.assertAPIReturnValue(res.text, ('Eexist', 'Problem class is already collected'))
             res = admin_session.post('proset', data={
-                'reqtype': 'listproclass'
+                'reqtype': 'listproclass',
+                'proclass_type': 'collection',
             })
             res = json.loads(res.text)
-            proclass_cata = res['data']
-            self.assertNotEqual(proclass_cata['collection'], [])
-            self.assertEqual(len(proclass_cata['collection']), 1)
-            self.assertEqual(proclass_cata['collection'][0]['proclass_id'], 1)
+            proclass_list = res['data']
+            self.assertNotEqual(proclass_list, [])
+            self.assertEqual(len(proclass_list), 1)
+            self.assertEqual(proclass_list[0]['total_cnt'], 2)
+            self.assertEqual(proclass_list[0]['ac_cnt'], 2)
+            self.assertEqual(proclass_list[0]['proclass_id'], 1)
 
             res = admin_session.post('proset', data={
                 'reqtype': 'decollect',
@@ -154,12 +154,12 @@ class ProClassTest(AsyncTest):
             })
             self.assertAPIReturnValue(res.text, ('Enoext', 'Problem class is not in your collection'))
             res = admin_session.post('proset', data={
-                'reqtype': 'listproclass'
+                'reqtype': 'listproclass',
+                'proclass_type': 'collection'
             })
             res = json.loads(res.text)
-            proclass_cata = res['data']
-            self.assertEqual(proclass_cata['collection'], [])
-            self.assertEqual(len(proclass_cata['collection']), 0)
+            proclass_list = res['data']
+            self.assertEqual(proclass_list, [])
 
             res = admin_session.post('acct/proclass/1', data={
                 'reqtype': 'add',
@@ -179,25 +179,27 @@ class ProClassTest(AsyncTest):
             self.assertAPIReturnValue(res.text, ('Eparam', 'Invalid problem class type'))
 
             res = admin_session.post('proset', data={
-                'reqtype': 'listproclass'
+                'reqtype': 'listproclass',
+                'proclass_type': 'own',
             })
             res = json.loads(res.text)
-            proclass_cata = res['data']
-            self.assertNotEqual(proclass_cata['own'], [])
-            self.assertEqual(len(proclass_cata['own']), 1)
-            self.assertEqual(proclass_cata['own'][0]['proclass_id'], 2)
+            proclass_list = res['data']
+            self.assertNotEqual(proclass_list, [])
+            self.assertEqual(len(proclass_list), 1)
+            self.assertEqual(proclass_list[0]['proclass_id'], 2)
+            self.assertEqual(proclass_list[0]['total_cnt'], 1)
 
             with AccountContext('test1@test', 'test') as user_session:
                 res = user_session.get('proset?proclass_id=2')
                 self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
 
                 res = user_session.post('proset', data={
-                    'reqtype': 'listproclass'
+                    'reqtype': 'listproclass',
+                    'proclass_type': 'shared',
                 })
                 res = json.loads(res.text)
-                proclass_cata = res['data']
-                self.assertEqual(proclass_cata['shared'], [])
-                self.assertEqual(len(proclass_cata['shared']), 0)
+                proclass_list = res['data']
+                self.assertEqual(proclass_list, [])
 
 
             res = admin_session.post('proset', data={
@@ -206,13 +208,15 @@ class ProClassTest(AsyncTest):
             })
             self.assertAPIReturnSuccess(res.text)
             res = admin_session.post('proset', data={
-                'reqtype': 'listproclass'
+                'reqtype': 'listproclass',
+                'proclass_type': 'collection',
             })
             res = json.loads(res.text)
-            proclass_cata = res['data']
-            self.assertNotEqual(proclass_cata['collection'], [])
-            self.assertEqual(len(proclass_cata['collection']), 1)
-            self.assertEqual(proclass_cata['collection'][0]['proclass_id'], 2)
+            proclass_list = res['data']
+            self.assertNotEqual(proclass_list, [])
+            self.assertEqual(len(proclass_list), 1)
+            self.assertEqual(proclass_list[0]['proclass_id'], 2)
+            self.assertEqual(proclass_list[0]['total_cnt'], 1)
 
             res = admin_session.post('acct/proclass/1', data={
                 'reqtype': 'update',
@@ -250,13 +254,15 @@ class ProClassTest(AsyncTest):
             self.assertAPIReturnValue(res.text, ('Eparam', 'Desc too long'))
 
             res = admin_session.post('proset', data={
-                'reqtype': 'listproclass'
+                'reqtype': 'listproclass',
+                'proclass_type': 'shared',
             })
             res = json.loads(res.text)
-            proclass_cata = res['data']
-            self.assertNotEqual(proclass_cata['shared'], [])
-            self.assertEqual(len(proclass_cata['shared']), 1)
-            self.assertEqual(proclass_cata['shared'][0]['proclass_id'], 2)
+            proclass_list = res['data']
+            self.assertNotEqual(proclass_list, [])
+            self.assertEqual(len(proclass_list), 1)
+            self.assertEqual(proclass_list[0]['proclass_id'], 2)
+            self.assertEqual(proclass_list[0]['total_cnt'], 1)
 
             html = self.get_html('acct/proclass/1?page=update&proclassid=2', admin_session)
             self.assertEqual(html.select_one('input#name').attrs.get('value'), 'user shared')
@@ -270,13 +276,14 @@ class ProClassTest(AsyncTest):
                 self.assertNotIn('Eacces', res.text)
 
                 res = user_session.post('proset', data={
-                    'reqtype': 'listproclass'
+                    'reqtype': 'listproclass',
+                    'proclass_type': 'shared'
                 })
                 res = json.loads(res.text)
-                proclass_cata = res['data']
-                self.assertNotEqual(proclass_cata['shared'], [])
-                self.assertEqual(len(proclass_cata['shared']), 1)
-                self.assertEqual(proclass_cata['shared'][0]['proclass_id'], 2)
+                proclass_list = res['data']
+                self.assertNotEqual(proclass_list, [])
+                self.assertEqual(len(proclass_list), 1)
+                self.assertEqual(proclass_list[0]['proclass_id'], 2)
 
             html = self.get_html('manage/proclass', admin_session)
             trs = html.select('tbody > tr')

--- a/src/tests/e2e/ques.py
+++ b/src/tests/e2e/ques.py
@@ -14,13 +14,13 @@ class QuesTest(AsyncTest):
                 'reqtype': 'ask',
                 'qtext': ''
             })
-            self.assertAPIReturnValue(res.text, ('Equesmin', 'Question too short'))
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Question too short'))
 
             res = user_session.post('question', data={
                 'reqtype': 'ask',
                 'qtext': 'a' * 5000
             })
-            self.assertAPIReturnValue(res.text, ('Equesmax', 'Question too long'))
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Question too long'))
 
             html = self.get_html('question', user_session)
             self.assertEqual(html.select_one('p').text, 'Wait for Reply')
@@ -50,7 +50,7 @@ class QuesTest(AsyncTest):
                 'index': 0,
                 'rtext': ''
             })
-            self.assertAPIReturnValue(res.text, ('Erplmin', 'Reply too short'))
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Reply too short'))
 
             res = admin_session.post('manage/question/reply', data={
                 'reqtype': 'rpl',
@@ -58,7 +58,7 @@ class QuesTest(AsyncTest):
                 'index': 0,
                 'rtext': 'a' * 5000
             })
-            self.assertAPIReturnValue(res.text, ('Erplmax', 'Reply too long'))
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Reply too long'))
 
             html = self.get_html('manage/question/reply?qacct=2', admin_session)
             self.assertEqual(html.select('tr')[1:][0].select_one('td > textarea').text.strip(), 'reply question 1')


### PR DESCRIPTION
This PR includes a series of bug fixes, UI enhancements, and minor refactors to improve the reliability and usability of the contest and problem set (proset) management system.

# Features & Improvements
- feat(proset): Display proclass solving progress in the class list dialog.
- impr(proset): Add link to challenge filter page for problems marked as TODO.
- impr(contest): Show challenge, proset, and scoreboard links before contest starts.

# Bug Fixes
- fix(manage):
    - Fixed page load failure when adding a hidden problem.
    - Corrected incorrect info message.

- fix(group): Removed non-existent field class to prevent runtime issues.

- fix(contest):
    - Dropped failed inserts to maintain cache and DB consistency.
    - Fixed cache key typo.
    - Ensured notifications are only sent to the question asker.
    - Restricted question submission to contestants only.
    - Displayed newer questions first.
    - Allowed viewing announcements before the contest starts.

- fix(proset):
    - Show manage button for non-guest users.
    - Fixed issue where clicking links inside modals prevented page scrolling.


# Refactors
- Simplified error handling by directly returning self.error.
- Removed duplicate code for better maintainability.