### PR TITLE
fix: small bug

### DIFF
--- a/scripts/add_admin.py
+++ b/scripts/add_admin.py
@@ -55,7 +55,7 @@ async def sign_up(mail, pw, name, db, rs):
                 '''
                     INSERT INTO "account"
                     ("mail", "password", "name", "acct_type")
-                    VALUES ($1, $2, $3, $4, $5) RETURNING "acct_id";
+                    VALUES ($1, $2, $3, $4) RETURNING "acct_id";
                 ''',
                 mail,
                 base64.b64encode(hpw).decode('utf-8'),

--- a/src/handlers/manage/pro.py
+++ b/src/handlers/manage/pro.py
@@ -750,24 +750,30 @@ class ManageProHandler(RequestHandler):
                 if err:
                     return self.error(err)
 
-                old_is_makefile = pro['testm_conf']['is_makefile']
-                old_check_type = pro['testm_conf']['check_type']
-                custom_check_type = [ProConst.CHECKER_IOREDIR, ProConst.CHECKER_CMS]
-                if not old_is_makefile and is_makefile:
-                    if not os.path.exists(f'problem/{pro_id}/res/make'):
-                        os.mkdir(f'problem/{pro_id}/res/make')
-                pro['testm_conf']['is_makefile'] = is_makefile
+                conf = pro['testm_conf']
+                if (
+                    conf['is_makefile'] != is_makefile
+                    or conf['check_type'] != check_type
+                    or conf['rate_precision'] != rate_precision
+                ):
+                    old_is_makefile = conf['is_makefile']
+                    old_check_type = conf['check_type']
+                    custom_check_type = [ProConst.CHECKER_IOREDIR, ProConst.CHECKER_CMS]
+                    if not old_is_makefile and is_makefile:
+                        if not os.path.exists(f'problem/{pro_id}/res/make'):
+                            os.mkdir(f'problem/{pro_id}/res/make')
+                    conf['is_makefile'] = is_makefile
 
-                if old_check_type not in custom_check_type and check_type in custom_check_type:
-                    if not os.path.exists(f'problem/{pro_id}/res/check'):
-                        os.mkdir(f'problem/{pro_id}/res/check')
-                pro['testm_conf']['check_type'] = check_type
+                    if old_check_type not in custom_check_type and check_type in custom_check_type:
+                        if not os.path.exists(f'problem/{pro_id}/res/check'):
+                            os.mkdir(f'problem/{pro_id}/res/check')
+                    conf['check_type'] = check_type
 
-                if check_type == ProConst.CHECKER_IOREDIR:
-                    chalmeta = json.dumps(chalmeta)
+                    if check_type == ProConst.CHECKER_IOREDIR:
+                        chalmeta = json.dumps(chalmeta)
 
-                pro['testm_conf']['rate_precision'] = rate_precision
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+                    conf['rate_precision'] = rate_precision
+                    await ProService.inst.update_test_config(pro_id, conf)
                 await LogService.inst.add_log(
                     f"{self.acct.name} has sent a request to update the problem #{pro_id}", 'manage.pro.update.pro',
                     {

--- a/src/handlers/rank.py
+++ b/src/handlers/rank.py
@@ -18,9 +18,9 @@ class ProRankHandler(RequestHandler):
         if err:
             return self.error(err)
 
-        if pro['status'] in [ProConst.STATUS_OFFLINE,ProConst.STATUS_CONTEST]:
+        if pro['status'] == ProConst.STATUS_CONTEST:
             return self.error(PERMISSION_DENIED_ERROR)
-        
+
         try:
             pageoff = int(self.get_argument('pageoff'))
 

--- a/src/services/rate.py
+++ b/src/services/rate.py
@@ -272,7 +272,7 @@ class RateService:
 
         return None, statemap
 
-    async def map_rate(self, starttime='1970-01-01 00:00:00.000', endtime='2100-01-01 00:00:00.000'):
+    async def map_rate(self, contest_id: int = 0, starttime='1970-01-01 00:00:00.000', endtime='2100-01-01 00:00:00.000'):
         if isinstance(starttime, str):
             starttime = datetime.datetime.fromisoformat(starttime)
 
@@ -291,11 +291,12 @@ class RateService:
                     ON "challenge"."chal_id" = "challenge_state"."chal_id"
                     INNER JOIN "problem"
                     ON "challenge"."pro_id" = "problem"."pro_id"
-                    WHERE "challenge"."timestamp" >= $1 AND "challenge"."timestamp" <= $2
+                    WHERE "challenge"."timestamp" >= $1 AND "challenge"."timestamp" <= $2 AND "challenge"."contest_id" = $3
                     GROUP BY "challenge"."acct_id", "challenge"."pro_id";
                 ''',
                 starttime,
                 endtime,
+                contest_id,
             )
 
         statemap = defaultdict(dict)

--- a/src/static/templ/pagination.html
+++ b/src/static/templ/pagination.html
@@ -1,6 +1,6 @@
 {% import math %}
 
-{% set _p_pageoff = min(_p_total_cnt - 1,_p_pageoff) %}
+{% set _p_pageoff = max(0, min(_p_total_cnt - 1, _p_pageoff)) %}
 {% set _p_pagenum = _p_pagenum %}
 {% set _p_total_cnt = _p_total_cnt %}
 {% set _p_postfix = _p_postfix %}
@@ -13,7 +13,7 @@
       <li class="page-item"><a class="page-link" href="?pageoff=0{{ _p_postfix }}">&#x21e4;</a></li>
       <!-- Calculate the number of pages to show on each side of the current page -->
       {% set l_num = center_page.bit_length() %}
-      {% set r_num = (math.ceil(_p_total_cnt / _p_pagenum) - center_page - 1).bit_length() %}
+      {% set r_num = max(0, (math.ceil(_p_total_cnt / _p_pagenum) - center_page - 1)).bit_length() %}
       {% if l_num < LI_ITEM_CNT//2%}
           {% set r_num = min(LI_ITEM_CNT - 1 - l_num, r_num) %}
       {% elif r_num < LI_ITEM_CNT//2 %}

--- a/src/tests/e2e/rank.py
+++ b/src/tests/e2e/rank.py
@@ -36,7 +36,7 @@ class ProRankTest(AsyncTest):
 
             with AccountContext('test1@test', 'test') as user_session:
                 res = user_session.get('rank/1')
-                self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
+                self.assertAPIReturnValue(res.text, ('Enoext', 'Problem not found'))
 
             admin_session.post('manage/pro/update', data={
                 'reqtype': 'updatepro',


### PR DESCRIPTION
This PR addresses several regressions introduced by recent refactoring efforts across different modules. The following issues have been fixed:

- **install**: Fixed a regression caused by removing the legacy group system, which broke part of the installation flow.
- **rank**: Fixed an issue where the removal of the unused `OFFLINE` status led to unexpected behavior in rank handling.
- **pagination**: Prevented pagination from displaying a `-1` link when there are no items to paginate.
- **rate**: Updated `map_rate()` to correctly distinguish between different contests, avoiding rating miscalculations.
- **manage**: Fixed a logic error where challenges were incorrectly reset to `'NotStart'` when the problem configuration was not updated.

Each of these fixes restores intended behavior and improves stability post-refactor. Tests have been adjusted (if applicable) to ensure these edge cases are covered.
