### PR TITLE
perf: cache js file

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -91,11 +91,15 @@ var index = new function() {
             j_cont.html(res).ready(function() {
                 var defer;
 
-                if (typeof(init) == 'function') {
-                    init();
-                }
-
                 defer = Array();
+                j_cont.find('script').each(function(i, e) {
+                    defer[i] = $.Deferred();
+
+                    $(e).on('load', function() {
+                        defer[i].resolve();
+                    });
+                });
+
                 j_cont.find('link').each(function(i, e) {
                     defer[i] = $.Deferred();
 
@@ -103,6 +107,10 @@ var index = new function() {
                         defer[i].resolve();
                     });
                 });
+
+                if (typeof(init) == 'function') {
+                    init();
+                }
 
                 $.when.apply($, defer).done(function() {
                     j_cont.stop().fadeIn(100);

--- a/src/static/templ/chal.html
+++ b/src/static/templ/chal.html
@@ -1,4 +1,5 @@
 {% from services.chal import ChalConst %}
+<script src="/oj/third/prism.js"></script>
 <link rel="stylesheet" href="/oj/third/prism.css">
 
 <script type="text/javascript">
@@ -72,8 +73,7 @@
             code.attr("data-language", res.data.comp_type);
             code.find("code").addClass(`language-${res.data.comp_type}`);
             code.find("code").html(res.data.code);
-
-            $.getScript('/oj/third/prism.js');
+            Prism.highlightAll();
 	    });
 
         {% if user.acct_id == chal['acct_id'] %}

--- a/src/static/templ/contests/manage/general.html
+++ b/src/static/templ/contests/manage/general.html
@@ -1,6 +1,7 @@
 {% extends 'manage.html' %}
 
 {% block head %}
+<script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.9.4/dist/js/tempus-dominus.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.9.4/dist/css/tempus-dominus.min.css" crossorigin="anonymous">
 
 <style>
@@ -17,21 +18,20 @@
     function init() {
         let contest_id = "{{ contest_id }}";
 
-        $.getScript('https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.9.4/dist/js/tempus-dominus.min.js', () => {
-            const options = {
-                display: {
-                    calendarWeeks: true,
-                },
+        const options = {
+            display: {
+                calendarWeeks: true,
+            },
 
-                localization: {
-                    locale: 'zh-tw',
-                    format: 'yyyy/MM/dd HH:mm',
-                },
-            };
-            contest_start_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerContestStart'), options);
-            contest_end_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerContestEnd'), options);
-            reg_end_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerRegEnd'), options);
-        });
+            localization: {
+                locale: 'zh-tw',
+                format: 'yyyy/MM/dd HH:mm',
+            },
+        };
+        contest_start_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerContestStart'), options);
+        contest_end_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerContestEnd'), options);
+        reg_end_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerRegEnd'), options);
+
         $("button.submit").on('click', function(e) {
             let start_time = null, end_time = null, reg_end_time = null;
             let contest_name = $("#contestName").val();

--- a/src/static/templ/manage/board/add.html
+++ b/src/static/templ/manage/board/add.html
@@ -1,5 +1,6 @@
 {% extends '../manage.html' %}
 {% block head %}
+<script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.9.4/dist/js/tempus-dominus.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.9.4/dist/css/tempus-dominus.min.css" crossorigin="anonymous">
 
 <style>
@@ -13,20 +14,18 @@
     var start_date_picker = null;
     var end_date_picker = null;
     function init() {
-        $.getScript('https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.9.4/dist/js/tempus-dominus.min.js', () => {
-            const options = {
-                display: {
-                    calendarWeeks: true,
-                },
+        const options = {
+            display: {
+                calendarWeeks: true,
+            },
 
-                localization: {
-                    locale: 'zh-tw',
-                    format: 'yyyy/MM/dd HH:mm',
-                },
-            };
-            start_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerStart'), options);
-            end_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerEnd'), options);
-        });
+            localization: {
+                locale: 'zh-tw',
+                format: 'yyyy/MM/dd HH:mm',
+            },
+        };
+        start_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerStart'), options);
+        end_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerEnd'), options);
 
         let j_form = $("#form");
         let re = /[^0-9,\ ]/;

--- a/src/static/templ/manage/board/update.html
+++ b/src/static/templ/manage/board/update.html
@@ -1,5 +1,6 @@
 {% extends '../manage.html' %}
 {% block head %}
+<script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.9.4/dist/js/tempus-dominus.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.9.4/dist/css/tempus-dominus.min.css" crossorigin="anonymous">
 
 <style>
@@ -13,20 +14,18 @@
     var start_date_picker = null;
     var end_date_picker = null;
     function init() {
-        $.getScript('https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.9.4/dist/js/tempus-dominus.min.js', () => {
-            const options = {
-                display: {
-                    calendarWeeks: true,
-                },
+        const options = {
+            display: {
+                calendarWeeks: true,
+            },
 
-                localization: {
-                    locale: 'zh-tw',
-                    format: 'yyyy/MM/dd HH:mm',
-                },
-            };
-            start_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerStart'), options);
-            end_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerEnd'), options);
-        });
+            localization: {
+                locale: 'zh-tw',
+                format: 'yyyy/MM/dd HH:mm',
+            },
+        };
+        start_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerStart'), options);
+        end_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerEnd'), options);
 
         let j_form = $("#form");
         let re = /[^0-9,\ ]/;

--- a/src/static/templ/manage/pro/filemanager.html
+++ b/src/static/templ/manage/pro/filemanager.html
@@ -1,12 +1,11 @@
 {% extends '../manage.html' %}
 {% block head %}
+<script src="/oj/third/prism.js"></script>
 <link rel="stylesheet" type="text/css" href="/oj/manage-pro.css">
 <link rel="stylesheet" href="/oj/third/prism.css">
 
 <script type="text/javascript" id="contjs">
 	function init() {
-		$.getScript('/oj/third/prism.js');
-
 		let pro_id = "{{ pro_id }}";
 		let preview_modal = new bootstrap.Modal(document.getElementById('previewModal'));
         let add_single_file_modal = new bootstrap.Modal(document.getElementById('addSingleFileModal'));
@@ -29,6 +28,7 @@
 
 					$("#code").find("code").html(file_content);
                     $("#preview-title").text(filename);
+                    Prism.highlightAll();
 					preview_modal.show();
 				});
 			});

--- a/src/static/templ/manage/pro/updatetests.html
+++ b/src/static/templ/manage/pro/updatetests.html
@@ -1,12 +1,11 @@
 {% extends '../manage.html' %}
 {% block head %}
+<script src="/oj/third/prism.js"></script>
 <link rel="stylesheet" type="text/css" href="/oj/manage-pro.css">
 <link rel="stylesheet" href="/oj/third/prism.css">
 
 <script type="text/javascript" id="contjs">
 	function init() {
-		$.getScript('/oj/third/prism.js');
-
 		let pro_id = "{{ pro_id }}";
 		let preview_modal = new bootstrap.Modal(document.getElementById('previewModal'));
         let add_single_file_modal = new bootstrap.Modal(document.getElementById('addSingleFileModal'));
@@ -34,6 +33,7 @@
 
 					$("#code").find("code").html(file_content);
                     $("#preview-title").text(`${filename}.${type}`);
+                    Prism.highlightAll();
 					preview_modal.show();
 				});
 			});


### PR DESCRIPTION
Load JS files before calling init(), so we don't need to use getScript() to load them. This also allows the browser to cache the JS files, reducing transfer time. [skip ci]