### PR TITLE
refactor(handlers): use `self.get_argument(default=)` to reduce error handling

### DIFF
--- a/src/handlers/acct.py
+++ b/src/handlers/acct.py
@@ -3,7 +3,6 @@ import time
 import math
 import hashlib
 
-import tornado.web
 from msgpack import packb, unpackb
 
 from handlers.base import RequestHandler, reqenv, require_permission
@@ -168,10 +167,7 @@ class AcctProClassHandler(RequestHandler):
     @require_permission([UserConst.ACCTTYPE_USER, UserConst.ACCTTYPE_KERNEL])
     async def get(self, acct_id):
         acct_id = int(acct_id)
-        try:
-            page = self.get_argument('page')
-        except tornado.web.HTTPError:
-            page = None
+        page = self.get_argument('page', default=None)
 
         if page is None:
             _, proclass_list = await ProClassService.inst.get_proclass_list()

--- a/src/handlers/base.py
+++ b/src/handlers/base.py
@@ -35,7 +35,7 @@ class RequestHandler(tornado.web.RequestHandler):
             self.get_argument('json')
             self.res_json = True
 
-        except tornado.web.HTTPError:
+        except tornado.web.MissingArgumentError:
             self.res_json = False
 
     def error(self, err: tuple[str, Any], encoder=None):

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -2,8 +2,6 @@ import asyncio
 import decimal
 import json
 
-import tornado.web
-
 from handlers.base import RequestHandler, WebSocketSubHandler, reqenv
 from handlers.contests.base import contest_require_permission
 from services.chal import ChalConst, ChalService, ChalSearchingParamBuilder
@@ -16,42 +14,20 @@ from utils.numeric import parse_list_str
 class ChalListHandler(RequestHandler):
     @reqenv
     async def get(self):
-        try:
-            pageoff = int(self.get_argument('pageoff'))
+        pageoff = int(self.get_argument('pageoff', default=0))
 
-        except tornado.web.HTTPError:
-            pageoff = 0
-
-        try:
-            ppro_id = str(self.get_argument('proid'))
-            query_pros = parse_list_str(ppro_id)
-            if len(query_pros) == 0:
-                query_pros = None
-
-        except tornado.web.HTTPError:
+        ppro_id = str(self.get_argument('proid', default=''))
+        query_pros = parse_list_str(ppro_id)
+        if len(query_pros) == 0:
             query_pros = None
-            ppro_id = ''
 
-        try:
-            pacct_id = str(self.get_argument('acctid'))
-            query_accts = parse_list_str(pacct_id)
-            if len(query_accts) == 0:
-                query_accts = None
-
-        except tornado.web.HTTPError:
+        pacct_id = str(self.get_argument('acctid', default=''))
+        query_accts = parse_list_str(pacct_id)
+        if len(query_accts) == 0:
             query_accts = None
-            pacct_id = ''
 
-        try:
-            state = int(self.get_argument('state'))
-
-        except (tornado.web.HTTPError, ValueError):
-            state = 0
-
-        try:
-            compiler_type = self.get_argument('compiler_type')
-        except tornado.web.HTTPError:
-            compiler_type = 'all'
+        state = int(self.get_argument('state', default=0))
+        compiler_type = self.get_argument('compiler_type', default='all')
 
         contest_id = 0
         if self.contest:

--- a/src/handlers/contests/proset.py
+++ b/src/handlers/contests/proset.py
@@ -8,10 +8,7 @@ from services.rate import RateService
 class ContestProsetHandler(RequestHandler):
     @reqenv
     async def get(self):
-        try:
-            pageoff = int(self.get_argument('pageoff'))
-        except tornado.web.HTTPError:
-            pageoff = 0
+        pageoff = int(self.get_argument('pageoff', default=0))
 
         show_ac_ratio = False
         if not self.contest.is_start() and not self.contest.is_admin(self.acct):

--- a/src/handlers/contests/scoreboard.py
+++ b/src/handlers/contests/scoreboard.py
@@ -56,7 +56,7 @@ class ContestScoreboardHandler(RequestHandler):
         start_time = self.contest.contest_start
         try:
             end_time = datetime.datetime.fromisoformat(self.get_argument('display_time'))
-        except (tornado.web.HTTPError, ValueError):
+        except (tornado.web.MissingArgumentError, ValueError):
             has_end_time = False
             end_time = self.contest.contest_end
 

--- a/src/handlers/log.py
+++ b/src/handlers/log.py
@@ -1,5 +1,3 @@
-import tornado.web
-
 from handlers.base import RequestHandler, reqenv, require_permission
 from services.log import LogService
 
@@ -11,14 +9,10 @@ class LogHandler(RequestHandler):
     @require_permission(UserConst.ACCTTYPE_KERNEL)
     async def get(self, log_id=None):
         if log_id is None:
-            try:
-                pageoff = int(self.get_argument('pageoff'))
-            except tornado.web.HTTPError:
-                pageoff = 0
+            pageoff = int(self.get_argument('pageoff', default=0))
 
-            try:
-                logtype = str(self.get_argument('logtype'))
-            except tornado.web.HTTPError:
+            logtype = str(self.get_argument('logtype', default=''))
+            if not logtype:
                 logtype = None
 
             err, logtype_list = await LogService.inst.get_log_type()

--- a/src/handlers/manage/acct.py
+++ b/src/handlers/manage/acct.py
@@ -10,10 +10,7 @@ class ManageAcctHandler(RequestHandler):
     @require_permission(UserConst.ACCTTYPE_KERNEL)
     async def get(self, page=None):
         if page is None:
-            try:
-                pageoff = int(self.get_argument('pageoff'))
-            except tornado.web.HTTPError:
-                pageoff = 0
+            pageoff = int(self.get_argument('pageoff', default=0))
 
             _, acctlist = await UserService.inst.list_acct(UserConst.ACCTTYPE_KERNEL, True)
             acct_total_cnt = len(acctlist)

--- a/src/handlers/manage/pro.py
+++ b/src/handlers/manage/pro.py
@@ -3,7 +3,6 @@ import base64
 import json
 import os
 
-import tornado.web
 import tornado.escape
 from msgpack import packb, unpackb
 from natsort import natsorted
@@ -24,10 +23,7 @@ class ManageProHandler(RequestHandler):
     @require_permission(UserConst.ACCTTYPE_KERNEL)
     async def get(self, page=None):
         if page is None:
-            try:
-                pageoff = int(self.get_argument('pageoff'))
-            except tornado.web.HTTPError:
-                pageoff = 0
+            pageoff = int(self.get_argument('pageoff', default=0))
 
             err, prolist = await ProService.inst.list_pro(self.acct)
             pro_total_cnt = len(prolist)
@@ -83,10 +79,7 @@ class ManageProHandler(RequestHandler):
         elif page == "updatetests":
             pro_id = int(self.get_argument('proid'))
 
-            try:
-                download = self.get_argument('download')
-            except tornado.web.HTTPError:
-                download = None
+            download = self.get_argument('download', default=None)
 
             if download:
                 return NotImplemented

--- a/src/handlers/manage/proclass.py
+++ b/src/handlers/manage/proclass.py
@@ -13,10 +13,7 @@ class ManageProClassHandler(RequestHandler):
     @require_permission(UserConst.ACCTTYPE_KERNEL)
     async def get(self, page=None):
         if page is None:
-            try:
-                pageoff = int(self.get_argument('pageoff'))
-            except tornado.web.HTTPError:
-                pageoff = 0
+            pageoff = int(self.get_argument('pageoff', default=0))
 
             _, proclass_list = await ProClassService.inst.get_proclass_list()
             proclass_list = list(filter(lambda proclass: proclass['type'] in [ProClassConst.OFFICIAL_PUBLIC, ProClassConst.OFFICIAL_HIDDEN],

--- a/src/handlers/pro.py
+++ b/src/handlers/pro.py
@@ -1,7 +1,3 @@
-import json
-
-import tornado.web
-
 from handlers.base import RequestHandler, reqenv, require_permission
 from services.chal import ChalConst
 from services.judge import JudgeServerClusterService
@@ -37,35 +33,12 @@ def chal_ac_cmp(pro):
 class ProsetHandler(RequestHandler):
     @reqenv
     async def get(self):
-        try:
-            pageoff = int(self.get_argument('pageoff'))
-        except tornado.web.HTTPError:
-            pageoff = 0
-
-        try:
-            order = self.get_argument('order')
-        except tornado.web.HTTPError:
-            order = None
-
-        try:
-            problem_show = self.get_argument('show')
-        except tornado.web.HTTPError:
-            problem_show = 'all'
-
-        try:
-            show_only_online_pro = self.get_argument('online')
-        except tornado.web.HTTPError:
-            show_only_online_pro = False
-
-        try:
-            order_reverse = self.get_argument('reverse')
-        except tornado.web.HTTPError:
-            order_reverse = False
-
-        try:
-            search_name = self.get_argument('name')
-        except tornado.web.HTTPError:
-            search_name = None
+        pageoff = int(self.get_argument('pageoff', default=0))
+        order = self.get_argument('order', default=None)
+        problem_show = self.get_argument('show', default='all')
+        show_only_online_pro = self.get_argument('online', default=False)
+        order_reverse = self.get_argument('reverse', default=False)
+        search_name = self.get_argument('name', default=None)
 
         flt = {
             'order': order,
@@ -75,9 +48,8 @@ class ProsetHandler(RequestHandler):
             'name': search_name,
         }
 
-        try:
-            proclass_id = int(self.get_argument('proclass_id'))
-        except tornado.web.HTTPError:
+        proclass_id = int(self.get_argument('proclass_id', default=0))
+        if proclass_id == 0:
             proclass_id = None
 
         err, prolist = await ProService.inst.list_pro(self.acct)
@@ -126,6 +98,7 @@ class ProsetHandler(RequestHandler):
             return pro
 
         prolist = map(lambda pro: _set_pro_state_and_tags(pro), prolist)
+
 
         if problem_show == "onlyac":
             prolist = filter(lambda pro: pro['state'] == ChalConst.STATE_AC, prolist)
@@ -275,11 +248,7 @@ class ProStaticHandler(RequestHandler):
             self.set_header('Cache-Control', 'must-revalidate, post-check=0, pre-check=0')
             self.set_header('Content-Type', 'application/pdf')
 
-            try:
-                download = self.get_argument('download')
-            except tornado.web.HTTPError:
-                download = None
-
+            download = self.get_argument('download', default=None)
             if download:
                 self.set_header('Content-Disposition', f'attachment; filename="pro{pro_id}.pdf"')
             else:

--- a/src/handlers/rank.py
+++ b/src/handlers/rank.py
@@ -1,7 +1,5 @@
 import datetime
 
-import tornado.web
-
 from handlers.base import RequestHandler, reqenv
 from services.user import Account
 from services.chal import ChalConst
@@ -12,6 +10,9 @@ PERMISSION_DENIED_ERROR = (('Eacces', 'Permission denied'))
 class ProRankHandler(RequestHandler):
     @reqenv
     async def get(self, pro_id):
+        pageoff = int(self.get_argument('pageoff', default=0))
+        pagenum = int(self.get_argument('pagenum', default=20))
+
         tz = datetime.timezone(datetime.timedelta(hours=+8))
         pro_id = int(pro_id)
         err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
@@ -20,18 +21,6 @@ class ProRankHandler(RequestHandler):
 
         if pro['status'] == ProConst.STATUS_CONTEST:
             return self.error(PERMISSION_DENIED_ERROR)
-
-        try:
-            pageoff = int(self.get_argument('pageoff'))
-
-        except tornado.web.HTTPError:
-            pageoff = 0
-
-        try:
-            pagenum = int(self.get_argument('pagenum'))
-
-        except tornado.web.HTTPError:
-            pagenum = 20
 
         async with self.db.acquire() as con:
             result = await con.fetch(
@@ -112,17 +101,8 @@ class ProRankHandler(RequestHandler):
 class UserRankHandler(RequestHandler):
     @reqenv
     async def get(self):
-        try:
-            pageoff = int(self.get_argument('pageoff'))
-
-        except tornado.web.HTTPError:
-            pageoff = 0
-
-        try:
-            pagenum = int(self.get_argument('pagenum'))
-
-        except tornado.web.HTTPError:
-            pagenum = 20
+        pageoff = int(self.get_argument('pageoff', default=0))
+        pagenum = int(self.get_argument('pagenum', default=20))
 
         res = await self.db.fetch(
             f'''


### PR DESCRIPTION
Also rename HTTPError to MissingArgumentError for clarity