### PR TITLE
Refactor and document ChalService; improve filtering and decouple logic

### DIFF
--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -34,7 +34,7 @@ class ChalListHandler(RequestHandler):
             contest_id = self.contest.contest_id
 
             # NOTE: if user is admin, specifying contest_id will list all challenges for that contest; there's no need to specify an account separately.
-            EMPTY = [-1]
+            EMPTY = []
             if not self.contest.is_admin(self.acct):
                 if not self.contest.is_start():
                     query_accts = EMPTY

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -5,7 +5,7 @@ import json
 from handlers.base import RequestHandler, WebSocketSubHandler, reqenv
 from handlers.contests.base import contest_require_permission
 from services.chal import ChalConst, ChalService, ChalSearchingParamBuilder
-from services.pro import ProService
+from services.pro import ProService, ProConst
 from services.user import UserService
 from services.contests import UserStatus
 from utils.numeric import parse_list_str
@@ -14,6 +14,8 @@ from utils.numeric import parse_list_str
 class ChalListHandler(RequestHandler):
     @reqenv
     async def get(self):
+        flt_builder = ChalSearchingParamBuilder()
+
         pageoff = int(self.get_argument('pageoff', default=0))
 
         ppro_id = str(self.get_argument('proid', default=''))
@@ -27,15 +29,23 @@ class ChalListHandler(RequestHandler):
             query_accts = None
 
         state = int(self.get_argument('state', default=0))
+        flt_builder.state(state)
+
         compiler_type = self.get_argument('compiler_type', default='all')
+        flt_builder.compiler(compiler_type)
 
-        contest_id = 0
+        isadmin = self.acct.is_kernel()
+        if isadmin:
+            flt_builder.pro_statuses([ProConst.STATUS_ONLINE, ProConst.STATUS_HIDDEN])
+
         if self.contest:
-            contest_id = self.contest.contest_id
+            isadmin = self.contest.is_admin(self.acct)
+            flt_builder.contest(self.contest.contest_id)
+            flt_builder.pro_statuses([ProConst.STATUS_ONLINE, ProConst.STATUS_CONTEST])
 
-            # NOTE: if user is admin, specifying contest_id will list all challenges for that contest; there's no need to specify an account separately.
             EMPTY = []
-            if not self.contest.is_admin(self.acct):
+            # NOTE: if user is admin, specifying contest_id will list all challenges for that contest; there's no need to specify an account separately.
+            if not isadmin:
                 if not self.contest.is_start():
                     query_accts = EMPTY
                 elif self.contest.is_running():
@@ -51,18 +61,10 @@ class ChalListHandler(RequestHandler):
                     else:
                         query_accts = [self.acct.acct_id]
 
-        flt = ChalSearchingParamBuilder().pro(query_pros).acct(query_accts).state(state).compiler(
-            compiler_type).contest(contest_id).build()
+        flt = flt_builder.pro(query_pros).acct(query_accts).build()
 
-        _, chalstat = await ChalService.inst.get_stat(self.acct, flt)
-
-        _, challist = await ChalService.inst.list_chal(pageoff, 20, self.acct, flt)
-
-        isadmin = self.acct.is_kernel()
-        if self.contest:
-            isadmin = self.acct.is_kernel() and self.contest.is_admin(self.acct)
-
-        chalids = [chal['chal_id'] for chal in challist]
+        _, chalstat = await ChalService.inst.get_chals_count(flt)
+        _, challist = await ChalService.inst.list_chal(pageoff, 20, flt)
 
         await self.render(
             'challist',
@@ -72,7 +74,6 @@ class ChalListHandler(RequestHandler):
             pageoff=pageoff,
             ppro_id=ppro_id,
             pacct_id=pacct_id,
-            chalids=json.dumps(chalids),
             isadmin=isadmin,
             contest=self.contest,
         )
@@ -140,20 +141,23 @@ class ChalListNewStateHandler(WebSocketSubHandler):
 
             chal_id = int(msg['data'])
             if self.first_chal_id <= chal_id <= self.last_chal_id:
-                _, new_state = await ChalService.inst.get_single_chal_state_in_list(chal_id, self.acct)
+                _, new_state = await ChalService.inst.get_calculated_chal_state(chal_id, self.allow_pro_statuses)
                 await self.write_message(json.dumps(new_state, cls=_Encoder))
 
     async def open(self):
         self.first_chal_id = -1
         self.last_chal_id = -1
-        self.acct = None
+        self.allow_pro_statuses = [ProConst.STATUS_ONLINE]
 
         await self.p.subscribe('challiststatesub')
 
         self.task = asyncio.tasks.Task(self.listen_challiststate())
 
     async def on_message(self, msg):
-        if self.acct is None:
+        # TODO: contest challist
+        # TODO: user authentication
+
+        if self.first_chal_id == -1:
             j = json.loads(msg)
 
             self.first_chal_id = int(j["first_chal_id"])
@@ -162,7 +166,8 @@ class ChalListNewStateHandler(WebSocketSubHandler):
             if err:
                 self.on_close()
 
-            self.acct = acct
+            if acct.is_kernel():
+                self.allow_pro_statuses.append(ProConst.STATUS_HIDDEN)
 
 
 class ChalNewStateHandler(WebSocketSubHandler):

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -85,7 +85,7 @@ class ChalHandler(RequestHandler):
     async def get(self, chal_id):
         chal_id = int(chal_id)
 
-        err, chal = await ChalService.inst.get_chal(chal_id)
+        err, chal = await ChalService.inst.get_chal(chal_id, with_test=True)
         if err:
             return self.error(err)
 
@@ -110,7 +110,12 @@ class ChalHandler(RequestHandler):
         if self.contest:
             rechal = rechal and self.contest.is_admin(self.acct)
 
-        await self.render('chal', pro=pro, chal=chal, rechal=rechal)
+        final_response = []
+        for idx, test in enumerate(chal['testl'], start=1):
+            response = test['response']
+            final_response.append(f"Task {idx}: {response}")
+
+        await self.render('chal', pro=pro, chal=chal, rechal=rechal, response='\n'.join(final_response))
         return
 
 class _Encoder(json.JSONEncoder):

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -168,10 +168,7 @@ class ChalListNewStateHandler(WebSocketSubHandler):
             self.first_chal_id = int(j["first_chal_id"])
             self.last_chal_id = int(j["last_chal_id"])
             err, acct = await UserService.inst.info_acct(acct_id=int(j["acct_id"]))
-            if err:
-                self.on_close()
-
-            if acct.is_kernel():
+            if not err and acct.is_kernel():
                 self.allow_pro_statuses.append(ProConst.STATUS_HIDDEN)
 
 

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -99,10 +99,14 @@ class ChalSearchingParam:
         if self.pro is not None:
             if len(self.pro):
                 query.append(f' AND "challenge"."pro_id" IN ({",".join(map(str, self.pro))}) ')
+            else:
+                query.append(' AND "challenge"."pro_id" IS NULL ')
 
         if self.acct is not None:
             if len(self.acct):
                 query.append(f' AND "challenge"."acct_id" IN ({",".join(map(str, self.acct))}) ')
+            else:
+                query.append(' AND "challenge"."acct_id" IS NULL ')
 
         if self.state != 0:
             if self.state == ChalConst.STATE_NOTSTARTED:

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -4,8 +4,7 @@ import os
 
 import config
 from services.judge import JudgeServerClusterService
-from services.pro import ProService
-from services.user import Account
+from services.pro import ProConst
 
 TZ = datetime.timezone(datetime.timedelta(hours=+8))
 
@@ -111,6 +110,11 @@ class ChalSearchingParam:
             - Otherwise, matches the exact compiler string.
             - Valid values are defined in `ChalConst.COMPILER_NAME`.
 
+        allow_pro_statuses (list[int] | None): A list of allowed problem statuses to include.
+            - If None or empty: defaults to `[ProConst.STATUS_ONLINE]` only.
+            - Otherwise: filters by `problem.status IN (...)`.
+            - Valid values are defined in the range `ProConst.STATUS_ONLINE` to `ProConst.STATUS_HIDDEN`.
+
         contest (int): Contest ID to filter. Defaults to 0.
             - If set to 0: matches only non-contest challenges.
             - Otherwise: filters by contest ID.
@@ -120,6 +124,7 @@ class ChalSearchingParam:
     acct: list[int] | None
     state: int | None
     compiler: str | None
+    allow_pro_statuses: list[int] | None
     contest: int = 0
 
     def get_sql_query_str(self):
@@ -157,6 +162,11 @@ class ChalSearchingParam:
         else:
             query.append(' AND "challenge"."contest_id"=0 ')
 
+        if not self.allow_pro_statuses:
+            query.append(f' AND "problem"."status" IN ({",".join(map(str, [ProConst.STATUS_ONLINE]))}) ')
+        else:
+            query.append(f' AND "problem"."status" IN ({",".join(map(str, self.allow_pro_statuses))}) ')
+
         return ''.join(query)
 
 
@@ -172,6 +182,7 @@ class ChalSearchingParamBuilder:
                    .acct([3227, 6057, 8199, 9787])
                    .state(ChalConst.STATE_AC)
                    .compiler("gcc")
+                   .pro_statuses([ProConst.STATUS_ONLINE, ProConst.STATUS_HIDDEN])
                    .contest(0)
                    .build()
         )
@@ -182,10 +193,12 @@ class ChalSearchingParamBuilder:
           which will **exclude all challenges**.
         - `compiler` values must match one of `ChalConst.COMPILER_NAME`.
         - `state` values should be selected from `ChalConst.STATE_*`.
+        - If `pro_statuses()` is not called, only problems with `ProConst.STATUS_ONLINE` are included by default.
+          You can override this to include more statuses (e.g., `ProConst.STATUS_HIDDEN`).
     """
 
     def __init__(self):
-        self.param = ChalSearchingParam([], [], 0, "all", 0)
+        self.param = ChalSearchingParam([], [], 0, "all", [ProConst.STATUS_ONLINE], 0)
 
     def pro(self, pro: list[int] | None):
         """Sets the list of problem IDs to filter."""
@@ -215,6 +228,21 @@ class ChalSearchingParamBuilder:
         if contest is not None:
             self.param.contest = contest
         return self
+
+    def pro_statuses(self, pro_statuses: list[int]):
+        """
+        Sets the allowed problem statuses for filtering.
+
+        Args:
+            pro_statuses (list[int]): List of `ProConst.STATUS_*` values to include.
+
+        Raises:
+            AssertionError: If any status is outside the valid range
+                            `ProConst.STATUS_ONLINE` to `ProConst.STATUS_HIDDEN`.
+        """
+        for status in pro_statuses:
+            assert ProConst.STATUS_ONLINE <= status <= ProConst.STATUS_HIDDEN
+        self.param.allow_pro_statuses = pro_statuses
 
     def build(self) -> ChalSearchingParam:
         """Returns the constructed `ChalSearchingParam` object."""
@@ -459,11 +487,8 @@ class ChalService:
 
         return None, None
 
-    async def list_chal(self, off, num, acct: Account, flt: ChalSearchingParam):
-
+    async def list_chal(self, off: int, num: int, flt: ChalSearchingParam):
         fltquery = flt.get_sql_query_str()
-
-        max_status = ProService.inst.get_acct_limit(acct, contest=flt.contest != 0)
 
         async with self.db.acquire() as con:
             result = await con.fetch(
@@ -476,13 +501,10 @@ class ChalService:
                     INNER JOIN "account"
                     ON "challenge"."acct_id" = "account"."acct_id"
                     INNER JOIN "problem"
-                    ON "challenge"."pro_id" = "problem"."pro_id" AND "problem"."status" <= {max_status}
+                    ON "challenge"."pro_id" = "problem"."pro_id"
                     LEFT JOIN "challenge_state"
                     ON "challenge"."chal_id" = "challenge_state"."chal_id"
-                    WHERE 1=1
-                '''
-                + fltquery
-                + f'''
+                    WHERE 1=1 {fltquery}
                     ORDER BY "challenge"."chal_id" DESC OFFSET {off} LIMIT {num};
                 '''
             )
@@ -522,17 +544,16 @@ class ChalService:
 
         return None, challist
 
-    async def get_single_chal_state_in_list(
-            self,
-            chal_id: int,
-            acct: Account,
-    ):
+    async def get_calculated_chal_state(self, chal_id: int, allow_pro_statuses: list[int]):
+        assert len(allow_pro_statuses)
+        for status in allow_pro_statuses:
+            assert ProConst.STATUS_ONLINE <= status <= ProConst.STATUS_HIDDEN
+
         chal_id = int(chal_id)
-        max_status = ProService.inst.get_acct_limit(acct)
 
         async with self.db.acquire() as con:
             result = await con.fetch(
-                '''
+                f'''
                     SELECT "challenge"."chal_id",
                     "challenge_state"."state", "challenge_state"."runtime", "challenge_state"."memory",
                     ROUND("challenge_state"."rate", problem.rate_precision) AS "rate"
@@ -540,9 +561,8 @@ class ChalService:
                     INNER JOIN "account" ON "challenge"."acct_id" = "account"."acct_id"
                     INNER JOIN "problem" ON "challenge"."pro_id" = "problem"."pro_id"
                     INNER JOIN "challenge_state" ON "challenge"."chal_id" = "challenge_state"."chal_id"
-                    WHERE "problem"."status" <= $1 AND "challenge_state"."chal_id" = $2;
+                    WHERE "problem"."status" IN ({",".join(map(str, allow_pro_statuses))}) AND "challenge_state"."chal_id" = $1;
                 ''',
-                max_status,
                 chal_id,
             )
 
@@ -558,18 +578,22 @@ class ChalService:
             'rate': result['rate'],
         }
 
-    async def get_stat(self, acct: Account, flt: ChalSearchingParam):
+    async def get_chals_count(self, flt: ChalSearchingParam):
         fltquery = flt.get_sql_query_str()
 
         async with self.db.acquire() as con:
             result = await con.fetch(
                 (
-                        'SELECT COUNT(1) FROM "challenge" '
-                        'INNER JOIN "account" '
-                        'ON "challenge"."acct_id" = "account"."acct_id" '
-                        'LEFT JOIN "challenge_state" '
-                        'ON "challenge"."chal_id"="challenge_state"."chal_id" '
-                        'WHERE 1=1' + fltquery + ';'
+                    f'''
+                        SELECT COUNT(1) FROM "challenge"
+                        INNER JOIN "account"
+                        ON "challenge"."acct_id" = "account"."acct_id"
+                        INNER JOIN "problem"
+                        ON "challenge"."pro_id" = "problem"."pro_id"
+                        LEFT JOIN "challenge_state"
+                        ON "challenge"."chal_id"="challenge_state"."chal_id"
+                        WHERE 1=1 {fltquery};
+                    '''
                 )
             )
 

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -259,6 +259,22 @@ class ChalService:
         ChalService.inst = self
 
     async def add_chal(self, pro_id: int, acct_id: int, contest_id: int, comp_type: str, code: str):
+        """
+        Add a new challenge entry and save the submitted source code.
+
+        Args:
+            pro_id (int): Problem ID.
+            acct_id (int): Account ID (user submitting the challenge).
+            contest_id (int): Contest ID.
+            comp_type (str): Compiler type (must be in ChalConst.ALLOW_COMPILERS).
+            code (str): Source code content as string.
+
+        Returns:
+            tuple[Optional[tuple[str, str]], Optional[int]]:
+                On success, (None, chal_id).
+                On failure, (error_code, None).
+        """
+
         assert comp_type in ChalConst.ALLOW_COMPILERS
 
         pro_id = int(pro_id)
@@ -290,6 +306,16 @@ class ChalService:
         return None, chal_id
 
     async def reset_chal(self, chal_id: int):
+        """
+        Reset a challenge by deleting all its associated tests and updating its state.
+
+        Args:
+            chal_id (int): Challenge ID to reset.
+
+        Returns:
+            tuple[None, None]: Always returns (None, None).
+        """
+
         chal_id = int(chal_id)
         async with self.db.acquire() as con:
             await con.execute('DELETE FROM "test" WHERE "chal_id" = $1;', chal_id)
@@ -298,6 +324,23 @@ class ChalService:
         return None, None
 
     async def get_chal_state(self, chal_id: int):
+        """
+        Retrieve detailed test results of a challenge.
+
+        Args:
+            chal_id (int): Challenge ID.
+
+        Returns:
+            tuple[Optional[tuple[str, str]], Optional[list[dict]]]:
+                On success, (None, list) where each dict represents a test with keys:
+                    - 'test_idx' (int): Test index.
+                    - 'state' (int): Challenge state, between ChalConst.STATE_AC and ChalConst.STATE_NOTSTARTED.
+                    - 'runtime' (int): Total runtime in milliseconds.
+                    - 'memory' (int): Memory usage in kilobytes.
+                    - 'response' (str): Compiler or checker message.
+                    - 'rate' (decimal.Decimal), rounded by problem.rate_precision
+                On failure, (error_code, None).
+        """
         chal_id = int(chal_id)
         async with self.db.acquire() as con:
             result = await con.fetch(
@@ -334,6 +377,27 @@ class ChalService:
         return None, tests
 
     async def get_chal(self, chal_id: int, with_test=False) -> ReturnType:
+        """
+        Retrieve challenge info with optional test details.
+
+        Args:
+            chal_id (int): Challenge ID.
+            with_test (bool): Whether to include detailed test results.
+
+        Returns:
+            tuple[Optional[tuple[str, str]], Optional[dict]]:
+                On success, (None, dict) where dict contains:
+                    - 'chal_id' (int): Challenge ID.
+                    - 'pro_id' (int): Problem ID.
+                    - 'acct_id' (int): Account ID.
+                    - 'contest_id' (int): Contest ID.
+                    - 'comp_type' (str): Compiler type, must be in ChalConst.ALLOW_COMPILER.
+                    - 'timestamp' (datetime.datetime): Timestamp of challenge submission.
+                    - 'acct_name' (str): Account name of submitter.
+                    - 'testl' (list[dict], optional): Please see `get_chal_state()`
+                On failure, (error_code, None).
+        """
+
         chal_id = int(chal_id)
         async with self.db.acquire() as con:
             result = await con.fetch(
@@ -379,6 +443,21 @@ class ChalService:
         )
 
     async def emit_chal(self, chal_id: int, pro_id: int, testm_conf: dict, comp_type: str, pri: int):
+        """
+        Create and submit tests for a challenge based on the test metadata configuration,
+        then send the challenge to the judging cluster.
+
+        Args:
+            chal_id (int): Challenge ID.
+            pro_id (int): Problem ID.
+            testm_conf (dict): Test metadata configuration.
+            comp_type (str): Compiler type (must be in ChalConst.ALLOW_COMPILERS).
+            pri (int): Priority level (within ChalConst.NORMAL_PRI and ChalConst.NORMAL_REJUDGE_PRI).
+
+        Returns:
+            tuple[None, None]: Always returns (None, None) on completion.
+        """
+
         assert comp_type in ChalConst.ALLOW_COMPILERS
         assert ChalConst.NORMAL_PRI <= pri <= ChalConst.NORMAL_REJUDGE_PRI
 
@@ -429,7 +508,7 @@ class ChalService:
 
         if not os.path.isfile(f"code/{chal_id}/main.{file_ext}"):
             for test in testl:
-                await self.update_test(chal_id, test['test_idx'], ChalConst.STATE_ERR, 0, 0, None, '', refresh_db=False)
+                await self.update_test(chal_id, test['test_idx'], ChalConst.STATE_ERR, 0, 0, None, '', rate_is_cms_type=False, refresh_db=False)
                 await self.update_challenge_state(chal_id)
             return None, None
 
@@ -458,6 +537,28 @@ class ChalService:
         return None, None
 
     async def list_chal(self, off: int, num: int, flt: ChalSearchingParam):
+        """
+        List challenges with filtering, pagination, and joined related info.
+
+        Args:
+            off (int): Offset for pagination.
+            num (int): Number of challenges to return.
+            flt (ChalSearchingParam): Filter parameters.
+
+        Returns:
+            tuple[None, list[dict]]: On success, returns (None, challist) where each item is a dict with keys:
+                - 'chal_id' (int): Challenge ID.
+                - 'pro_id' (int): Problem ID.
+                - 'acct_id' (int): Account ID.
+                - 'contest_id' (int): Contest ID.
+                - 'comp_type' (str): Compiler type, must be in ChalConst.ALLOW_COMPILER.
+                - 'timestamp' (datetime.datetime): Timestamp of challenge submission.
+                - 'acct_name' (str): Account name of submitter.
+                - 'state' (int): Challenge state, between ChalConst.STATE_AC and ChalConst.STATE_NOTSTARTED.
+                - 'runtime' (int): Total runtime in milliseconds.
+                - 'memory' (int): Memory usage in kilobytes.
+                - 'rate' (decimal.Decimal): Score or rate of the challenge, rounded by `problem.rate_precision`.
+        """
         fltquery = flt.get_sql_query_str()
 
         async with self.db.acquire() as con:
@@ -515,6 +616,28 @@ class ChalService:
         return None, challist
 
     async def get_calculated_chal_state(self, chal_id: int, allow_pro_statuses: list[int]):
+        """
+        Retrieve the aggregated state of a challenge filtered by allowed problem statuses.
+
+        This method queries the `challenge_state` table joined with `problem` to ensure
+        that only challenges related to problems with statuses in `allow_pro_statuses` are considered.
+
+        Args:
+            chal_id (int): The ID of the challenge to retrieve.
+            allow_pro_statuses (list[int]): List of allowed problem status codes to filter by.
+                Each status should be between `ProConst.STATUS_ONLINE` and `ProConst.STATUS_HIDDEN`.
+
+        Returns:
+            tuple[Optional[tuple[str, str]], Optional[dict]]:
+                On success, returns (None, dict) where dict contains:
+                    - 'chal_id' (int): Challenge ID.
+                    - 'state' (int): Aggregated state of the challenge.
+                    - 'runtime' (int): Total runtime in milliseconds.
+                    - 'memory' (int): Total memory usage in kilobytes.
+                    - 'rate' (Decimal): Aggregated rate/score.
+                On failure (e.g., challenge not found), returns (error_code, None).
+        """
+
         assert len(allow_pro_statuses)
         for status in allow_pro_statuses:
             assert ProConst.STATUS_ONLINE <= status <= ProConst.STATUS_HIDDEN
@@ -549,6 +672,18 @@ class ChalService:
         }
 
     async def get_chals_count(self, flt: ChalSearchingParam):
+        """
+        Get the total count of challenges matching a filter.
+
+        Args:
+            flt (ChalSearchingParam): Filter parameters.
+
+        Returns:
+            tuple[Optional[tuple[str, str]], Optional[dict]]:
+                On success, (None, {'total_chal': int}).
+                On failure, (error_code, None).
+        """
+
         fltquery = flt.get_sql_query_str()
 
         async with self.db.acquire() as con:
@@ -575,6 +710,23 @@ class ChalService:
 
     async def update_test(self, chal_id: int, test_idx: int, state: int, runtime: int, memory: int,
                           rate: decimal.Decimal, response: str, rate_is_cms_type=False, refresh_db=True):
+        """
+        Update a single test entry with state, runtime, memory, response, and rate information.
+
+        Args:
+            chal_id (int): Challenge ID.
+            test_idx (int): Test index.
+            state (int): Test state (must be within ChalConst.STATE_AC and ChalConst.STATE_NOTSTARTED).
+            runtime (int): Runtime in milliseconds.
+            memory (int): Memory usage in kilobytes.
+            rate (decimal.Decimal): Rate/score value.
+            response (str): Compiler or checker message.
+            rate_is_cms_type (bool): If True, apply weighted rate calculation.
+            refresh_db (bool): If True, refresh challenge state after updating.
+
+        Returns:
+            tuple[None, None]: Always returns (None, None).
+        """
 
         assert ChalConst.STATE_AC <= state <= ChalConst.STATE_NOTSTARTED
 
@@ -615,4 +767,24 @@ class ChalService:
         return None, None
 
     async def update_challenge_state(self, chal_id: int):
+        """
+        Trigger the database function to aggregate and update the overall state of a challenge.
+
+        This function calls the PostgreSQL stored procedure `update_challenge_state(p_chal_id INTEGER)`
+        which calculates the following aggregates from all tests belonging to the challenge:
+        - The maximum test state (indicating the overall challenge status).
+        - The sum of runtimes across tests.
+        - The sum of memory usage across tests.
+        - The sum of rates/scores, considering special scores or default rates.
+
+        The aggregated results are then upserted into the `challenge_state` table,
+        updating only when values have changed to avoid unnecessary writes.
+
+        Args:
+            chal_id (int): The challenge ID to update.
+
+        Returns:
+            None
+        """
+
         await self.db.execute(f'SELECT update_challenge_state({chal_id});')

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -37,7 +37,8 @@ class ChalConst:
         STATE_OLE: 'OLE',
         STATE_SJE: 'SJE',
         STATE_ERR: 'IE',
-        STATE_JUDGE: 'JDG',
+        STATE_JUDGE: 'Challenging',
+        STATE_NOTSTARTED: 'Not Started'
     }
 
     STATE_LONG_STR = {
@@ -78,6 +79,9 @@ class ChalConst:
         'python3': 'CPython 3.11.2',
         'java': 'OpenJDK 17.0.8',
     }
+
+    assert len(FILE_EXTENSION) == len(COMPILER_NAME)
+    assert sorted(FILE_EXTENSION.keys()) == sorted(COMPILER_NAME.keys())
 
     NORMAL_PRI = 0
     CONTEST_PRI = 1

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import datetime
 import os
+import decimal
 
 from services.judge import JudgeServerClusterService
 from services.pro import ProConst
@@ -258,6 +259,8 @@ class ChalService:
         ChalService.inst = self
 
     async def add_chal(self, pro_id: int, acct_id: int, contest_id: int, comp_type: str, code: str):
+        assert comp_type in ChalConst.ALLOW_COMPILERS
+
         pro_id = int(pro_id)
         acct_id = int(acct_id)
 
@@ -286,7 +289,7 @@ class ChalService:
 
         return None, chal_id
 
-    async def reset_chal(self, chal_id):
+    async def reset_chal(self, chal_id: int):
         chal_id = int(chal_id)
         async with self.db.acquire() as con:
             await con.execute('DELETE FROM "test" WHERE "chal_id" = $1;', chal_id)
@@ -375,8 +378,10 @@ class ChalService:
             },
         )
 
-    async def emit_chal(self, chal_id, pro_id, testm_conf, comp_type, pri: int):
-        from services.pro import ProConst
+    async def emit_chal(self, chal_id: int, pro_id: int, testm_conf: dict, comp_type: str, pri: int):
+        assert comp_type in ChalConst.ALLOW_COMPILERS
+        assert ChalConst.NORMAL_PRI <= pri <= ChalConst.NORMAL_REJUDGE_PRI
+
         chal_id = int(chal_id)
         pro_id = int(pro_id)
 
@@ -568,7 +573,11 @@ class ChalService:
         total_chal = result[0]['count']
         return None, {'total_chal': total_chal}
 
-    async def update_test(self, chal_id, test_idx, state, runtime, memory, rate, response, rate_is_cms_type=False, refresh_db=True):
+    async def update_test(self, chal_id: int, test_idx: int, state: int, runtime: int, memory: int,
+                          rate: decimal.Decimal, response: str, rate_is_cms_type=False, refresh_db=True):
+
+        assert ChalConst.STATE_AC <= state <= ChalConst.STATE_NOTSTARTED
+
         chal_id = int(chal_id)
         async with self.db.acquire() as con:
             await con.execute(

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 import datetime
 import os
 
-import config
 from services.judge import JudgeServerClusterService
 from services.pro import ProConst
 
@@ -295,7 +294,7 @@ class ChalService:
         await self.update_challenge_state(chal_id)
         return None, None
 
-    async def get_chal_state(self, chal_id):
+    async def get_chal_state(self, chal_id: int):
         chal_id = int(chal_id)
         async with self.db.acquire() as con:
             result = await con.fetch(
@@ -331,7 +330,7 @@ class ChalService:
 
         return None, tests
 
-    async def get_chal(self, chal_id) -> ReturnType:
+    async def get_chal(self, chal_id: int, with_test=False) -> ReturnType:
         chal_id = int(chal_id)
         async with self.db.acquire() as con:
             result = await con.fetch(
@@ -347,7 +346,6 @@ class ChalService:
             )
         if len(result) != 1:
             return ('Enoext', 'Challenge Not Found'), None
-
         result = result[0]
 
         pro_id, acct_id, timestamp, comp_type, contest_id, acct_name = (
@@ -358,42 +356,10 @@ class ChalService:
             result['contest_id'],
             result['acct_name'],
         )
-        final_response = []
-
-        async with self.db.acquire() as con:
-            result = await con.fetch(
-                '''
-                    SELECT "test"."test_idx", "state", "runtime", "memory", "response",
-                    ROUND(COALESCE(test.rate, tvr.rate), problem.rate_precision)
-                    FROM "test"
-                    INNER JOIN test_valid_rate AS tvr
-                    ON test.pro_id = tvr.pro_id AND test.test_idx = tvr.test_idx
-                    INNER JOIN problem
-                    ON test.pro_id = problem.pro_id
-                    WHERE "chal_id" = $1 ORDER BY "test_idx" ASC;
-                ''',
-                chal_id,
-            )
 
         testl = []
-        for test_idx, state, runtime, memory, response, rate in result:
-            if response:
-                final_response.append(f"Task {test_idx + 1}: {response}")
-
-            r = 0
-            if state in [ChalConst.STATE_AC, ChalConst.STATE_PC]:
-                r = rate
-
-            testl.append(
-                {
-                    'test_idx': test_idx,
-                    'state': state,
-                    'runtime': int(runtime),
-                    'memory': int(memory),
-                    'rate': r,
-                }
-            )
-
+        if with_test:
+            _, testl = await self.get_chal_state(chal_id)
 
         return (
             None,
@@ -405,7 +371,6 @@ class ChalService:
                 'acct_name': acct_name,
                 'timestamp': timestamp.astimezone(TZ),
                 'testl': testl,
-                'response': '\n'.join(final_response),
                 'comp_type': comp_type,
             },
         )

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -95,34 +95,30 @@ class ChalSearchingParam:
     contest: int = 0
 
     def get_sql_query_str(self):
-        query = ' '
-        if self.pro:
-            query += 'AND ( "challenge"."pro_id" = 0 '
-            for pro_id in self.pro:
-                query += f' OR "challenge"."pro_id" = {pro_id} '
-            query += ')'
+        query = [' ']
+        if self.pro is not None:
+            if len(self.pro):
+                query.append(f' AND "challenge"."pro_id" IN ({",".join(map(str, self.pro))}) ')
 
-        if self.acct:
-            query += 'AND ( "challenge"."acct_id" = 0 '
-            for acct_id in self.acct:
-                query += f' OR "challenge"."acct_id" = {acct_id} '
-            query += ')'
+        if self.acct is not None:
+            if len(self.acct):
+                query.append(f' AND "challenge"."acct_id" IN ({",".join(map(str, self.acct))}) ')
 
         if self.state != 0:
             if self.state == ChalConst.STATE_NOTSTARTED:
-                query += ' AND "challenge_state"."state" IS NULL '
+                query.append(' AND "challenge_state"."state" IS NULL ')
             else:
-                query += f' AND "challenge_state"."state" = {self.state} '
+                query.append(f' AND "challenge_state"."state" = {self.state} ')
 
         if self.compiler != 'all':
-            query += f' AND "challenge"."compiler_type"=\'{self.compiler}\' '
+            query.append(f' AND "challenge"."compiler_type"=\'{self.compiler}\' ')
 
         if self.contest != 0:
-            query += f' AND "challenge"."contest_id"={self.contest} '
+            query.append(f' AND "challenge"."contest_id"={self.contest} ')
         else:
-            query += ' AND "challenge"."contest_id"=0 '
+            query.append(' AND "challenge"."contest_id"=0 ')
 
-        return query
+        return ''.join(query)
 
 
 class ChalSearchingParamBuilder:

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -88,6 +88,34 @@ class ChalConst:
 
 @dataclass
 class ChalSearchingParam:
+    """
+    A parameter container for building SQL WHERE clauses when filtering challenges.
+
+    Attributes:
+        pro (list[int] | None): A list of problem IDs to filter.
+            - If None: no filter is applied.
+            - If empty list: filters with `pro_id IS NULL`, which effectively excludes all challenges.
+
+        acct (list[int] | None): A list of account IDs to filter.
+            - If None: no filter is applied.
+            - If empty list: filters with `acct_id IS NULL`, which effectively excludes all challenges.
+
+        state (int | None): Challenge state to filter.
+            - If 0 or None: no filtering.
+            - If `ChalConst.STATE_NOTSTARTED`: adds `state IS NULL` to the filter.
+            - Other values: exact match (e.g., `ChalConst.STATE_AC`, `ChalConst.STATE_WA`, etc.).
+            - See `ChalConst.STATE_*` for available state constants.
+
+        compiler (str | None): Compiler type to filter.
+            - If "all": no filtering is applied.
+            - Otherwise, matches the exact compiler string.
+            - Valid values are defined in `ChalConst.COMPILER_NAME`.
+
+        contest (int): Contest ID to filter. Defaults to 0.
+            - If set to 0: matches only non-contest challenges.
+            - Otherwise: filters by contest ID.
+    """
+
     pro: list[int] | None
     acct: list[int] | None
     state: int | None
@@ -95,6 +123,13 @@ class ChalSearchingParam:
     contest: int = 0
 
     def get_sql_query_str(self):
+        """
+        Constructs the SQL query string fragment based on the parameter values.
+
+        Returns:
+            str: A SQL condition string suitable for use in a WHERE clause.
+        """
+
         query = [' ']
         if self.pro is not None:
             if len(self.pro):
@@ -126,31 +161,63 @@ class ChalSearchingParam:
 
 
 class ChalSearchingParamBuilder:
+    """
+    A builder class for incrementally constructing a `ChalSearchingParam` instance
+    using a fluent interface.
+
+    Example:
+        builder = ChalSearchingParamBuilder()
+        param = (
+            builder.pro([756, 1015, 1016, 1017])
+                   .acct([3227, 6057, 8199, 9787])
+                   .state(ChalConst.STATE_AC)
+                   .compiler("gcc")
+                   .contest(0)
+                   .build()
+        )
+
+    Notes:
+        - If `pro([])` or `acct([])` is passed an empty list,
+          the resulting SQL will include `IS NULL` filters,
+          which will **exclude all challenges**.
+        - `compiler` values must match one of `ChalConst.COMPILER_NAME`.
+        - `state` values should be selected from `ChalConst.STATE_*`.
+    """
+
     def __init__(self):
         self.param = ChalSearchingParam([], [], 0, "all", 0)
 
     def pro(self, pro: list[int] | None):
+        """Sets the list of problem IDs to filter."""
         self.param.pro = pro
         return self
 
     def acct(self, acct: list[int] | None):
+        """Sets the list of account IDs to filter."""
         self.param.acct = acct
         return self
 
     def state(self, state: int | None):
-        self.param.state = state
+        """Sets the challenge state to filter."""
+        if state is None:
+            self.param.state = 0
+        else:
+            self.param.state = state
         return self
 
     def compiler(self, compiler: str | None):
+        """Sets the compiler type to filter."""
         self.param.compiler = compiler
         return self
 
     def contest(self, contest: int | None):
+        """Sets the contest ID to filter."""
         if contest is not None:
             self.param.contest = contest
         return self
 
     def build(self) -> ChalSearchingParam:
+        """Returns the constructed `ChalSearchingParam` object."""
         return self.param
 
 from typing import Any

--- a/src/static/templ/chal.html
+++ b/src/static/templ/chal.html
@@ -160,7 +160,7 @@
             <tbody>
             {% for test in chal['testl'] %}
                 <tr class="states">
-                    <td class="idx">{{ '%04d'%(test['test_idx'] + 1) }}</td>
+                    <td class="idx">{{ '%04d' % (test['test_idx'] + 1) }}</td>
                     <td class="state state-{{ test['state'] }}">{{ ChalConst.STATE_LONG_STR[test['state']] }}</td>
                     <td class="runtime">{{ test['runtime'] }}</td>
                     <td class="memory">{{ round(test['memory'] / 1024) }}</td>
@@ -173,7 +173,7 @@
 </div>
 
 
-{% if chal['response'] != '' and (user.is_kernel() or chal['acct_id'] == user.acct_id) %}
+{% if response != '' and (user.is_kernel() or chal['acct_id'] == user.acct_id) %}
     <div class="panel panel-default mt-3" id="response">
         <div class="panel-heading">
             <span>Compilation Error Message</span>
@@ -183,7 +183,7 @@
         </div>
         <div class="panel-body">
             <pre class="collapse show" id="challengeResponseInfo" style="margin-top: 32px;">
-                {{ chal['response'] }}
+                {{ response }}
             </pre>
         </div>
     </div>

--- a/src/static/templ/challist.html
+++ b/src/static/templ/challist.html
@@ -187,27 +187,18 @@
                 <select id="state" class="form-select">
                     <option value=0 {% if flt.state == 0 %}selected{% end %}>All</option>
                     {% for state, desc in ChalConst.STATE_STR.items() %}
-                        {% if state == ChalConst.STATE_JUDGE %}
-                            {% set desc = "Challenging" %}
-                        {% end %}
                         {% raw f'<option value="{ state }" { "selected" if flt.state == state else "" }>{ desc }</option>' %}
                     {% end %}
-                    <option value="{{ ChalConst.STATE_NOTSTARTED }}" {% if flt.state == ChalConst.STATE_NOTSTARTED %} selected {% end %}">Not Started</option>
                 </select>
             </div>
 
             <div class="mb-1">
                 <label class="form-label">Compiler</label>
                 <select id="compiler" class="form-select">
-                    <!-- %2B means '+' -->
                     <option value="all" {% if flt.compiler == 'all' %}selected{% end %}>All</option>
-                    <option value="gcc" {% if flt.compiler == 'gcc' %}selected{% end %}>GCC 12.2.0 GNU11</option>
-                    <option value="g%2B%2B" {% if flt.compiler == 'g++' %}selected{% end %}>G++ 9.4.0 GNU++17</option>
-                    <option value="clang" {% if flt.compiler == 'clang' %}selected{% end %}>Clang 15.0.6 C11</option>
-                    <option value="clang%2B%2B" {% if flt.compiler == 'clang++' %}selected{% end %}>Clang++ 15.0.6 C++17</option>
-                    <option value="rustc" {% if flt.compiler == 'rustc' %}selected{% end %}>Rustc 1.63</option>
-                    <option value="python3" {% if flt.compiler == 'python3' %}selected{% end %}>CPython 3.11.2</option>
-                    <option value="java" {% if flt.compiler == 'java' %}selected{% end %}>OpenJDK 17.0.6</option>
+                    {% for compiler, version in ChalConst.COMPILER_NAME.items() %}
+                        {% raw f'<option value="{ compiler }" { "selected" if flt.compiler == compiler else "" }>{ version }</option>' %}
+                    {% end %}
                 </select>
             </div>
 

--- a/src/static/templ/challist.html
+++ b/src/static/templ/challist.html
@@ -138,7 +138,11 @@
         })();
 
         {% if (flt.state == 100 or flt.state == 101) and isadmin %}
-            var chalids = {{ chalids }};
+            let chalids = [
+                {% for chal in challist %}
+                    {{ chal['chal_id'] }},
+                {% end %}
+            ];
             $('#rechalall').on('click', function(e) {
                 chalids.forEach(function(chalid) {
                     $.post('/oj/be/submit', {


### PR DESCRIPTION
## Improvements
- perf(chal): Replace multiple OR conditions with IN for filtering pro_id/acct_id.
    Improves SQL performance significantly when dealing with large ID lists.

- fix(chal): Empty pro/acct list now correctly filters out all challenges.
    This replaces the awkward workaround of passing [-1].

## Refactors
- refactor(chal): Remove dependency on ProService.get_acct_limit() to simplify logic.
- refactor(chal): Eliminate duplicated logic by reusing get_chal_state().
- refactor(chal): Add assertions for comp_type, state, and pri to catch invalid usage early.
- refactor(challist): Use constant values instead of hardcoded strings.

## Documentation
- docs(chal): Add complete docstrings for all public methods in ChalService.
- docs(chal): Document ChalSearchingParam and ChalSearchingParamBuilder usage and behavior.

## BugFix
- fix(chal): Allow guest users to retrieve updated challenge state messages.