### PR TITLE
Refactor and document ProService; decouple logic

### DIFF
--- a/src/handlers/acct.py
+++ b/src/handlers/acct.py
@@ -7,7 +7,7 @@ from msgpack import packb, unpackb
 
 from handlers.base import RequestHandler, reqenv, require_permission
 from services.log import LogService
-from services.pro import ProService, ProClassService, ProClassConst
+from services.pro import ProClassService, ProClassConst
 from services.rate import RateService
 from services.user import UserConst, UserService
 from services.chal import ChalConst
@@ -28,7 +28,6 @@ class AcctHandler(RequestHandler):
         if err:
             return self.error(err)
 
-        max_status = ProService.inst.get_acct_limit(self.acct)
         async with self.db.acquire() as con:
             prolist = await con.fetch(
                 '''
@@ -36,7 +35,7 @@ class AcctHandler(RequestHandler):
                     WHERE "status" <= $1
                     ORDER BY "pro_id" ASC;
                 ''',
-                max_status,
+                UserConst.ACCTTYPE_USER,
             )
 
         err, ratemap = await RateService.inst.map_rate_acct(acct)

--- a/src/handlers/board.py
+++ b/src/handlers/board.py
@@ -2,7 +2,7 @@ import time
 
 from handlers.base import RequestHandler, reqenv
 from services.board import BoardConst, BoardService
-from services.pro import ProService
+from services.pro import ProService, ProConst
 from services.rate import RateService
 from services.user import UserConst, UserService
 
@@ -27,7 +27,7 @@ class BoardHandler(RequestHandler):
         if self.acct.is_kernel():
             min_type = UserConst.ACCTTYPE_KERNEL
 
-        err, prolist = await ProService.inst.list_pro(acct=self.acct)
+        err, prolist = await ProService.inst.list_pro(ProConst.PRO_STATUS_NORMAL_USER)
         err, acctlist = await UserService.inst.list_acct(min_type=min_type)
         err, ratemap = await RateService.inst.map_rate(starttime=meta['start'], endtime=meta['end'])
 

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -36,12 +36,12 @@ class ChalListHandler(RequestHandler):
 
         isadmin = self.acct.is_kernel()
         if isadmin:
-            flt_builder.pro_statuses([ProConst.STATUS_ONLINE, ProConst.STATUS_HIDDEN])
+            flt_builder.pro_statuses(ProConst.PRO_STATUS_KERNEL_USER)
 
         if self.contest:
             isadmin = self.contest.is_admin(self.acct)
             flt_builder.contest(self.contest.contest_id)
-            flt_builder.pro_statuses([ProConst.STATUS_ONLINE, ProConst.STATUS_CONTEST])
+            flt_builder.pro_statuses(ProConst.PRO_STATUS_CONTEST_USER)
 
             EMPTY = []
             # NOTE: if user is admin, specifying contest_id will list all challenges for that contest; there's no need to specify an account separately.

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -89,8 +89,10 @@ class ChalHandler(RequestHandler):
         if err:
             return self.error(err)
 
+        allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
         if chal['contest_id'] and not self.contest:
             return self.error(('Enoext', 'Contest not found'))
+
         elif self.contest:
             if not self.contest.is_start():
                 if self.contest.is_admin(acct_id=chal['acct_id']) and not self.contest.is_admin(self.acct):
@@ -100,7 +102,12 @@ class ChalHandler(RequestHandler):
                 if self.contest.hide_admin and self.contest.is_admin(acct_id=chal['acct_id']) and not self.contest.is_admin(self.acct):
                     return self.error(('Eacces', 'Permission denied'))
 
-        err, pro = await ProService.inst.get_pro(chal['pro_id'], self.acct, is_contest=self.contest is not None)
+            allow_statuses = ProConst.PRO_STATUS_CONTEST_USER
+
+        elif self.acct.is_kernel():
+            allow_statuses = ProConst.PRO_STATUS_KERNEL_USER
+
+        err, pro = await ProService.inst.get_pro(chal['pro_id'], allow_statuses)
         if err:
             return self.error(err)
 

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -88,7 +88,7 @@ class ContestManageProHandler(RequestHandler):
             if not can_submit:
                 return self.error(('Ejudge', 'No judge available'))
 
-            err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=True)
+            err, pro = await ProService.inst.get_pro(pro_id, ProConst.PRO_STATUS_CONTEST_USER)
             if err:
                 return self.error(err)
 
@@ -131,11 +131,11 @@ class ContestManageProHandler(RequestHandler):
             if not self.contest.is_end():
                 return self.error(('Etime', 'Contest is not over yet'))
 
-            err, pro = await ProService.inst.get_pro(pro_id, is_contest=True)
+            err, pro = await ProService.inst.get_pro(pro_id, ProConst.PRO_STATUS_CONTEST_USER)
             if err:
                 return self.error(err)
 
-            err, _ = await ProService.inst.update_pro(pro_id, pro['name'], ProConst.STATUS_ONLINE, None, None, pro['tags'])
+            err, _ = await ProService.inst.update_pro(pro_id, pro['name'], ProConst.STATUS_ONLINE, pro['tags'])
             if err:
                 return self.error(err)
 

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -15,7 +15,7 @@ class ContestManageProHandler(RequestHandler):
     async def get(self):
         pro_list = []
         for pro_id in self.contest.pro_list.keys():
-            err, pro = await ProService.inst.get_pro(pro_id, is_contest=True)
+            err, pro = await ProService.inst.get_pro(pro_id, ProConst.PRO_STATUS_CONTEST_USER)
             if err:
                 continue
             pro_list.append(pro)

--- a/src/handlers/contests/proset.py
+++ b/src/handlers/contests/proset.py
@@ -1,7 +1,7 @@
 import tornado
 
 from handlers.base import reqenv, RequestHandler
-from services.pro import ProService
+from services.pro import ProConst, ProService
 from services.rate import RateService
 
 
@@ -19,7 +19,7 @@ class ContestProsetHandler(RequestHandler):
 
         else:
             _, acct_rates = await RateService.inst.map_rate_acct(self.acct, contest_id=self.contest.contest_id)
-            _, prolist = await ProService.inst.list_pro(self.acct, is_contest=True)
+            _, prolist = await ProService.inst.list_pro(ProConst.PRO_STATUS_CONTEST_USER)
 
             prolist_order = {pro_id: idx for idx, pro_id in enumerate(self.contest.pro_list.keys())}
             prolist = sorted(filter(lambda pro: self.contest.is_pro(pro['pro_id']), prolist),

--- a/src/handlers/manage/pro.py
+++ b/src/handlers/manage/pro.py
@@ -143,10 +143,17 @@ class ManageProHandler(RequestHandler):
             if mode == "upload":
                 pack_token = self.get_argument('pack_token')
 
-            err, pro_id = await ProService.inst.add_pro(name, status, pack_token)
+            err, pro_id = await ProService.inst.add_pro(name, status)
             await LogService.inst.add_log(
-                f"{self.acct.name} has sent a request to add the problem #{pro_id}", 'manage.pro.add.pro'
+                f"{self.acct.name} has sent a request to add the problem #{pro_id}", 'manage.pro.add.pro',
+                {
+                    'acct_id': self.acct.acct_id
+                }
             )
+            if err:
+                return self.error(err)
+
+            err, _ = await ProService.inst.unpack_pro(pro_id, pack_token)
             if err:
                 return self.error(err)
 
@@ -656,7 +663,7 @@ class ManageProHandler(RequestHandler):
                         return self.error(('Econf', 'Challenge metadata json syntax error'))
 
                 err, _ = await ProService.inst.update_pro(
-                    pro_id, name, status, None, None, tags, allow_submit
+                    pro_id, name, status, tags, allow_submit
                 )
                 err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
                 if err:
@@ -713,10 +720,7 @@ class ManageProHandler(RequestHandler):
                 if err:
                     return self.error(err)
 
-                err, _ = await ProService.inst.update_pro(
-                    pro_id, pro['name'], pro['status'], ProConst.PACKTYPE_FULL, pack_token, pro['tags'], pro['allow_submit']
-                )
-
+                err, _ = await ProService.inst.unpack_pro(pro_id, pack_token)
                 if err:
                     PackService.inst.clear(pack_token)
                     await LogService.inst.add_log(

--- a/src/handlers/manage/pro.py
+++ b/src/handlers/manage/pro.py
@@ -153,9 +153,10 @@ class ManageProHandler(RequestHandler):
             if err:
                 return self.error(err)
 
-            err, _ = await ProService.inst.unpack_pro(pro_id, pack_token)
-            if err:
-                return self.error(err)
+            if mode == "upload":
+                err, _ = await ProService.inst.unpack_pro(pro_id, pack_token)
+                if err:
+                    return self.error(err)
 
             self.error(('S', pro_id))
 

--- a/src/handlers/manage/pro.py
+++ b/src/handlers/manage/pro.py
@@ -17,6 +17,7 @@ from services.user import UserConst
 from services.pack import PackService
 
 PERMISSION_DENIED_ERROR = ('Eacces', 'Permission denied')
+ALLOW_STATUSES = [ProConst.STATUS_ONLINE, ProConst.STATUS_CONTEST, ProConst.STATUS_HIDDEN]
 
 class ManageProHandler(RequestHandler):
     @reqenv
@@ -25,7 +26,7 @@ class ManageProHandler(RequestHandler):
         if page is None:
             pageoff = int(self.get_argument('pageoff', default=0))
 
-            err, prolist = await ProService.inst.list_pro(self.acct)
+            err, prolist = await ProService.inst.list_pro(ALLOW_STATUSES)
             pro_total_cnt = len(prolist)
             prolist = prolist[pageoff: pageoff + 40]
 
@@ -35,7 +36,7 @@ class ManageProHandler(RequestHandler):
         elif page == "update":
             pro_id = int(self.get_argument('proid'))
 
-            err, pro = await ProService.inst.get_pro(pro_id, self.acct)
+            err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
             if err:
                 return self.error(err)
 
@@ -48,7 +49,7 @@ class ManageProHandler(RequestHandler):
 
         elif page == "filemanager":
             pro_id = int(self.get_argument('proid'))
-            err, pro = await ProService.inst.get_pro(pro_id, self.acct)
+            err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
             if err:
                 return self.error(err)
 
@@ -113,7 +114,7 @@ class ManageProHandler(RequestHandler):
                 return
 
 
-            err, pro = await ProService.inst.get_pro(pro_id, self.acct)
+            err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
             if err:
                 return self.error(err)
 
@@ -152,14 +153,14 @@ class ManageProHandler(RequestHandler):
             self.error(('S', pro_id))
 
         elif page == "updatetests":
+            pro_id = int(self.get_argument('pro_id'))
+            err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
+            if err:
+                return self.error(err)
+
             if reqtype == "preview":
-                pro_id = int(self.get_argument('pro_id'))
                 filename = self.get_argument('filename')
                 test_type = self.get_argument('type')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
 
                 if test_type not in ['out', 'in']:
                     return self.error(('Eparam', 'Invalid testcase file type'))
@@ -192,13 +193,8 @@ class ManageProHandler(RequestHandler):
                     self.error(('S', ''.join(content)))
 
             elif reqtype == "updateweight":
-                pro_id = int(self.get_argument('pro_id'))
                 group = int(self.get_argument('group'))
                 weight = int(self.get_argument('weight'))
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
 
                 test_group = pro['testm_conf']['test_group']
 
@@ -217,12 +213,7 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == "addtaskgroup":
-                pro_id = int(self.get_argument('pro_id'))
                 weight = int(self.get_argument('weight'))
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
 
                 test_group = pro['testm_conf']['test_group']
 
@@ -243,12 +234,7 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == 'deletetaskgroup':
-                pro_id = int(self.get_argument('pro_id'))
                 group = int(self.get_argument('group'))
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
 
                 test_group = pro['testm_conf']['test_group']
                 if group not in test_group:
@@ -269,13 +255,8 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == 'addsingletestcase':
-                pro_id = int(self.get_argument('pro_id'))
                 group = int(self.get_argument('group'))
                 testcase = self.get_argument('testcase')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
 
                 basepath = f'problem/{pro_id}/res/testdata'
                 if not os.path.exists(f'{basepath}/{testcase}.in') or not os.path.exists(f'{basepath}/{testcase}.out'):
@@ -302,13 +283,8 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == 'deletesingletestcase':
-                pro_id = int(self.get_argument('pro_id'))
                 group = int(self.get_argument('group'))
                 testcase = self.get_argument('testcase')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
 
                 test_group = pro['testm_conf']['test_group']
                 if group not in test_group:
@@ -327,13 +303,8 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == 'renamesinglefile':
-                pro_id = int(self.get_argument('pro_id'))
                 old_filename = self.get_argument('old_filename')
                 new_filename = self.get_argument('new_filename')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
 
                 # check filename
                 basepath = f'problem/{pro_id}/res/testdata'
@@ -383,14 +354,9 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == 'updatesinglefile':
-                pro_id = int(self.get_argument('pro_id'))
                 filename = self.get_argument('filename')
                 test_type = self.get_argument('type')
                 pack_token = self.get_argument('pack_token')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
 
                 if test_type not in ['output', 'input']:
                     PackService.inst.clear(pack_token)
@@ -426,14 +392,9 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == "addsinglefile":
-                pro_id = int(self.get_argument('pro_id'))
                 filename = self.get_argument('filename')
                 input_pack_token = self.get_argument('input_pack_token')
                 output_pack_token = self.get_argument('output_pack_token')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
 
                 basepath = f'problem/{pro_id}/res/testdata'
                 inputfile_path = f'{basepath}/{filename}.in'
@@ -470,12 +431,7 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == 'deletesinglefile':
-                pro_id = int(self.get_argument('pro_id'))
                 filename = self.get_argument('filename')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
 
                 basepath = f'problem/{pro_id}/res/testdata'
                 if not self._is_file_access_safe(basepath, f'{filename}.in'):
@@ -512,17 +468,17 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
         elif page == "filemanager":
+            ALLOW_PATH = ['http', 'res/check', 'res/make']
+            pro_id = int(self.get_argument('pro_id'))
+            basepath = self.get_argument('path')
+            err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
+            if err:
+                return self.error(err)
+            if basepath not in ALLOW_PATH:
+                return self.error(('Eparam', 'Invalid basepath'))
+
             if reqtype == "preview":
-                pro_id = int(self.get_argument('pro_id'))
                 filename = self.get_argument('filename')
-                basepath = self.get_argument('path')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
-
-                if basepath not in ['http', 'res/check', 'res/make']:
-                    return self.error(('Eparam', 'Invalid basepath'))
 
                 basepath = f'problem/{pro_id}/{basepath}'
                 if not self._is_file_access_safe(basepath, filename):
@@ -552,18 +508,8 @@ class ManageProHandler(RequestHandler):
                     self.error(('S', ''.join(content)))
 
             elif reqtype == 'renamesinglefile':
-                pro_id = int(self.get_argument('pro_id'))
                 old_filename = self.get_argument('old_filename')
                 new_filename = self.get_argument('new_filename')
-                basepath = self.get_argument('path')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    self.error(err)
-                    return
-
-                if basepath not in ['http', 'res/check', 'res/make']:
-                    return self.error(('Eparam', 'Invalid basepath'))
 
                 basepath = f'problem/{pro_id}/{basepath}'
                 old_filepath = f'{basepath}/{old_filename}'
@@ -597,17 +543,8 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == 'updatesinglefile':
-                pro_id = int(self.get_argument('pro_id'))
                 filename = self.get_argument('filename')
                 pack_token = self.get_argument('pack_token')
-                basepath = self.get_argument('path')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
-
-                if basepath not in ['http', 'res/check', 'res/make']:
-                    return self.error(('Eparam', 'Invalid basepath'))
 
                 basepath = f'problem/{pro_id}/{basepath}'
                 filepath = f'{basepath}/{filename}'
@@ -637,17 +574,8 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == 'addsinglefile':
-                pro_id = int(self.get_argument('pro_id'))
                 filename = self.get_argument('filename')
                 pack_token = self.get_argument('pack_token')
-                basepath = self.get_argument('path')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
-
-                if basepath not in ['http', 'res/check', 'res/make']:
-                    return self.error(('Eparam', 'Invalid basepath'))
 
                 basepath = f'problem/{pro_id}/{basepath}'
                 filepath = f'{basepath}/{filename}'
@@ -677,16 +605,7 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == 'deletesinglefile':
-                pro_id = int(self.get_argument('pro_id'))
                 filename = self.get_argument('filename')
-                basepath = self.get_argument('path')
-
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
-                if err:
-                    return self.error(err)
-
-                if basepath not in ['http', 'res/check', 'res/make']:
-                    return self.error(('Eparam', 'Invalid basepath'))
 
                 basepath = f'problem/{pro_id}/{basepath}'
                 filepath = f'{basepath}/{filename}'
@@ -739,7 +658,7 @@ class ManageProHandler(RequestHandler):
                 err, _ = await ProService.inst.update_pro(
                     pro_id, name, status, None, None, tags, allow_submit
                 )
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
+                err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
                 if err:
                     return self.error(err)
 
@@ -790,7 +709,7 @@ class ManageProHandler(RequestHandler):
                 pro_id = int(self.get_argument('pro_id'))
                 pack_token = self.get_argument('pack_token')
 
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
+                err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
                 if err:
                     return self.error(err)
 
@@ -831,7 +750,7 @@ class ManageProHandler(RequestHandler):
                 pro_id = int(self.get_argument('pro_id'))
                 limits = json.loads(self.get_argument('limits'))
 
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct)
+                err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
                 if err:
                     return self.error(err)
 
@@ -883,7 +802,7 @@ class ManageProHandler(RequestHandler):
             if not can_submit:
                 return self.error(('Ejudge', 'No available judge'))
 
-            err, pro = await ProService.inst.get_pro(pro_id, self.acct)
+            err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
             if err:
                 return self.error(err)
 

--- a/src/handlers/pro.py
+++ b/src/handlers/pro.py
@@ -361,7 +361,7 @@ class ProTagsHandler(RequestHandler):
         )
 
         err, _ = await ProService.inst.update_pro(
-            pro_id, pro['name'], pro['status'], '', None, tags, pro['allow_submit']
+            pro_id, pro['name'], pro['status'], tags, pro['allow_submit']
         )
 
         if err:

--- a/src/handlers/pro.py
+++ b/src/handlers/pro.py
@@ -54,7 +54,10 @@ class ProsetHandler(RequestHandler):
         if proclass_id == 0:
             proclass_id = None
 
-        err, prolist = await ProService.inst.list_pro(self.acct)
+        allow_statuses = [ProConst.STATUS_ONLINE]
+        if self.acct.is_kernel():
+            allow_statuses.append(ProConst.STATUS_HIDDEN)
+        err, prolist = await ProService.inst.list_pro(allow_statuses)
 
         proclass = None
         if proclass_id:
@@ -228,21 +231,25 @@ class ProsetHandler(RequestHandler):
 
 class ProStaticHandler(RequestHandler):
     @reqenv
-    async def get(self, pro_id, path):
+    async def get(self, pro_id: int, path: str):
         pro_id = int(pro_id)
+        allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
         if self.contest:
             if not self.contest.is_pro(pro_id):
                 return self.error(('Enoext', 'Problem not in contest'))
 
-        err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
+            allow_statuses = ProConst.PRO_STATUS_CONTEST_USER
+        else:
+            if self.acct.is_kernel():
+                allow_statuses = ProConst.PRO_STATUS_KERNEL_USER
+
+
+        err, pro = await ProService.inst.get_pro(pro_id, allow_statuses)
         if err:
             return self.error(err)
 
         if pro['status'] == ProConst.STATUS_CONTEST:
-            if not self.contest:
-                return self.error(PERMISSION_DENIED_ERROR)
-
-            elif not (self.contest.is_running() or self.contest.is_admin(self.acct)):
+            if not (self.contest.is_running() or self.contest.is_admin(self.acct)):
                 return self.error(PERMISSION_DENIED_ERROR)
 
         if path.endswith('pdf'):
@@ -264,6 +271,7 @@ class ProHandler(RequestHandler):
     @reqenv
     async def get(self, pro_id):
         pro_id = int(pro_id)
+        allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
 
         if self.contest:
             if not self.contest.is_pro(pro_id):
@@ -275,12 +283,15 @@ class ProHandler(RequestHandler):
             elif not self.contest.is_running() and not self.contest.is_member(self.acct):
                 return self.error(PERMISSION_DENIED_ERROR)
 
-        err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
+            allow_statuses = ProConst.PRO_STATUS_CONTEST_USER
+
+        else:
+            if self.acct.is_kernel():
+                allow_statuses = ProConst.PRO_STATUS_KERNEL_USER
+
+        err, pro = await ProService.inst.get_pro(pro_id, allow_statuses)
         if err:
             return self.error(err)
-
-        if pro['status'] == ProConst.STATUS_CONTEST and not self.contest:
-            return self.error(PERMISSION_DENIED_ERROR)
 
         # NOTE: Guest cannot see tags
         # NOTE: Admin can see tags
@@ -333,7 +344,14 @@ class ProTagsHandler(RequestHandler):
         tags = self.get_argument('tags')
         pro_id = int(self.get_argument('pro_id'))
 
-        err, pro = await ProService.inst.get_pro(pro_id, self.acct)
+        allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
+        if self.contest:
+            allow_statuses = ProConst.PRO_STATUS_CONTEST_USER
+        else:
+            if self.acct.is_kernel():
+                allow_statuses = ProConst.PRO_STATUS_KERNEL_USER
+
+        err, pro = await ProService.inst.get_pro(pro_id, allow_statuses)
         if err:
             return self.error(err)
 

--- a/src/handlers/rank.py
+++ b/src/handlers/rank.py
@@ -15,12 +15,13 @@ class ProRankHandler(RequestHandler):
 
         tz = datetime.timezone(datetime.timedelta(hours=+8))
         pro_id = int(pro_id)
-        err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
+        allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
+        if self.acct.is_kernel():
+            allow_statuses = ProConst.PRO_STATUS_KERNEL_USER
+
+        err, _ = await ProService.inst.get_pro(pro_id, allow_statuses)
         if err:
             return self.error(err)
-
-        if pro['status'] == ProConst.STATUS_CONTEST:
-            return self.error(PERMISSION_DENIED_ERROR)
 
         async with self.db.acquire() as con:
             result = await con.fetch(

--- a/src/handlers/submit.py
+++ b/src/handlers/submit.py
@@ -22,6 +22,7 @@ class SubmitHandler(RequestHandler):
 
         pro_id = int(pro_id)
 
+        allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
         allow_compilers = ChalConst.ALLOW_COMPILERS
         if self.contest:
             if not self.contest.is_running() and not self.contest.is_admin(self.acct):
@@ -31,6 +32,10 @@ class SubmitHandler(RequestHandler):
                 return self.error(('Enoext', 'Problem not in contest'))
 
             allow_compilers = self.contest.allow_compilers
+            allow_statuses = ProConst.PRO_STATUS_CONTEST_USER
+        else:
+            if self.acct.is_kernel():
+                allow_statuses = ProConst.PRO_STATUS_KERNEL_USER
 
         can_submit = JudgeServerClusterService.inst.is_server_online()
 
@@ -39,7 +44,7 @@ class SubmitHandler(RequestHandler):
             return
 
         pro_id = int(pro_id)
-        err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
+        err, pro = await ProService.inst.get_pro(pro_id, allow_statuses)
         if err:
             return self.error(err)
 
@@ -61,9 +66,12 @@ class SubmitHandler(RequestHandler):
         if not can_submit:
             return self.error(('Ejudge', 'No available judge'))
 
+        allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
+
         contest_id = 0
         if self.contest:
             contest_id = self.contest.contest_id
+            allow_statuses = ProConst.PRO_STATUS_CONTEST_USER
 
         reqtype = self.get_argument('reqtype')
         if reqtype == 'submit':
@@ -78,18 +86,18 @@ class SubmitHandler(RequestHandler):
 
                 if not self.contest.is_pro(pro_id):
                     return self.error(('Enoext', 'Problem not in contest'))
+
             else:
                 pri = ChalConst.NORMAL_PRI
+                if self.acct.is_kernel():
+                    allow_statuses = ProConst.PRO_STATUS_KERNEL_USER
 
             if err := await self.is_allow_submit(code, comp_type, pro_id):
                 return self.error(err)
 
-            err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
+            err, pro = await ProService.inst.get_pro(pro_id, allow_statuses)
             if err:
                 return self.error(err)
-
-            if pro['status'] == ProConst.STATUS_CONTEST and not self.contest:
-                return self.error(PERMISSION_DENIED_ERROR)
 
             if not pro['allow_submit']:
                 return self.error(('Eacces', 'Problem did not allow submit'))
@@ -105,21 +113,21 @@ class SubmitHandler(RequestHandler):
                     return self.error(err)
 
         elif reqtype == 'rechal':
+            chal_id = int(self.get_argument('chal_id'))
             if ((self.contest is None and self.acct.is_kernel())  # not in contest
                     or (self.contest and self.contest.is_admin(self.acct))):  # in contest
                 if self.contest:
                     pri = ChalConst.CONTEST_REJUDGE_PRI
                 else:
                     pri = ChalConst.NORMAL_REJUDGE_PRI
-
-                chal_id = int(self.get_argument('chal_id'))
+                    allow_statuses = ProConst.PRO_STATUS_KERNEL_USER
 
                 err, _ = await ChalService.inst.reset_chal(chal_id)
                 err, chal = await ChalService.inst.get_chal(chal_id)
 
                 pro_id = chal['pro_id']
                 comp_type = chal['comp_type']
-                err, pro = await ProService.inst.get_pro(pro_id, self.acct, is_contest=self.contest is not None)
+                err, pro = await ProService.inst.get_pro(pro_id, allow_statuses)
                 if err:
                     return self.error(err)
 

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -165,7 +165,7 @@ class ProService:
                     f"""
                         SELECT "problem"."pro_id", "problem"."name", "problem"."status", "problem"."tags"
                         FROM "problem"
-                        WHERE "problem"."status" IN ({"".join(map(str, allow_pro_statuses))})
+                        WHERE "problem"."status" IN ({",".join(map(str, allow_pro_statuses))})
                         ORDER BY "pro_id" ASC;
                     """
                 )

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -34,6 +34,8 @@ class ProConst:
         CHECKER_CMS: "cms",
     }
 
+    STR_2_CHECKER_TYPE = {s: t for s, t in CHECKER_TYPE.items()}
+
     PACKTYPE_FULL = 1
     PACKTYPE_CONTHTML = 2
     PACKTYPE_CONTPDF = 3
@@ -162,7 +164,7 @@ class ProService:
 
         return None, prolist
 
-    async def add_pro(self, name, status, pack_token):
+    async def add_pro(self, name: str, status: int):
         name_len = len(name)
         if name_len < ProConst.NAME_MIN:
             return ("Enamemin", "Problem name too short"), None
@@ -186,36 +188,28 @@ class ProService:
 
             pro_id = int(result[0]["pro_id"])
 
-            if pack_token:
-                err, _ = await self.unpack_pro(pro_id, ProConst.PACKTYPE_FULL, pack_token)
-                if err:
-                    return err, None
-
-                await con.execute("REFRESH MATERIALIZED VIEW test_valid_rate;")
-
-            else:
-                os.mkdir(f"problem/{pro_id}")
-                os.chmod(os.path.abspath(f"problem/{pro_id}"), 0o755)
-                os.mkdir(f"problem/{pro_id}/res")
-                os.mkdir(f"problem/{pro_id}/http")
-                os.mkdir(f"problem/{pro_id}/res/testdata")
-                os.symlink(
-                    os.path.abspath(f"problem/{pro_id}/http"),
-                    f"{config.WEB_PROBLEM_STATIC_FILE_DIRECTORY}/{pro_id}",
-                )
+            os.mkdir(f"problem/{pro_id}")
+            os.chmod(os.path.abspath(f"problem/{pro_id}"), 0o755)
+            os.mkdir(f"problem/{pro_id}/res")
+            os.mkdir(f"problem/{pro_id}/http")
+            os.mkdir(f"problem/{pro_id}/res/testdata")
+            os.symlink(
+                os.path.abspath(f"problem/{pro_id}/http"),
+                f"{config.WEB_PROBLEM_STATIC_FILE_DIRECTORY}/{pro_id}",
+            )
 
         await self.rs.delete("prolist")
 
         return None, pro_id
 
     # TODO: Too many args
-    async def update_pro(self, pro_id, name, status, pack_type, pack_token=None, tags="", allow_submit=True):
+    async def update_pro(self, pro_id: int, name: str, status: int, tags="", allow_submit=True):
+        assert ProConst.STATUS_ONLINE <= status <= ProConst.STATUS_HIDDEN
         name_len = len(name)
         if name_len < ProConst.NAME_MIN:
             return ("Enamemin", "Problem name too short"), None
         if name_len > ProConst.NAME_MAX:
             return ("Enamemax", "Problem name too long"), None
-        del name_len
         if status < ProConst.STATUS_ONLINE or status > ProConst.STATUS_HIDDEN:
             return ("Eparam", "Invalid problem status"), None
         if tags and not re.match(r"^[a-zA-Z0-9-_, ]+$", tags):
@@ -237,12 +231,6 @@ class ProService:
             if len(result) != 1:
                 return ("Enoext", "Problem not found"), None
 
-            if pack_token is not None:
-                err, _ = await self.unpack_pro(pro_id, pack_type, pack_token)
-                if err:
-                    return err, None
-
-                await con.execute("REFRESH MATERIALIZED VIEW test_valid_rate;")
 
         await self.rs.delete("prolist")
 
@@ -280,112 +268,101 @@ class ProService:
 
         return None, None
 
-    async def unpack_pro(self, pro_id, pack_type, pack_token):
+    async def unpack_pro(self, pro_id: int, pack_token: str):
         from services.chal import ChalConst
-        if pack_type == ProConst.PACKTYPE_FULL:
-            err, _ = await PackService.inst.unpack(pack_token, f"problem/{pro_id}", True)
-            if err:
-                return err, None
+        err, _ = await PackService.inst.unpack(pack_token, f"problem/{pro_id}", True)
+        if err:
+            return err, None
 
-            try:
-                os.chmod(os.path.abspath(f"problem/{pro_id}"), 0o755)
-                os.symlink(
-                    os.path.abspath(f"problem/{pro_id}/http"),
-                    f"{config.WEB_PROBLEM_STATIC_FILE_DIRECTORY}/{pro_id}",
-                )
+        try:
+            os.chmod(os.path.abspath(f"problem/{pro_id}"), 0o755)
+            os.symlink(
+                os.path.abspath(f"problem/{pro_id}/http"),
+                f"{config.WEB_PROBLEM_STATIC_FILE_DIRECTORY}/{pro_id}",
+            )
 
-            except FileExistsError:
-                pass
+        except FileExistsError:
+            pass
 
-            try:
-                with open(f"problem/{pro_id}/conf.json") as conf_f:
-                    conf = json.load(conf_f)
-            except json.decoder.JSONDecodeError:
-                return ("Econf", "Problem config json syntax error"), None
+        try:
+            with open(f"problem/{pro_id}/conf.json") as conf_f:
+                conf = json.load(conf_f)
+        except json.decoder.JSONDecodeError:
+            return ("Econf", "Problem config json syntax error"), None
 
-            is_makefile = False
-            if 'compile' in conf:
-                is_makefile = conf["compile"] == 'makefile'
-            elif 'is_makefile' in conf:
-                is_makefile = conf["is_makefile"]
+        is_makefile = False
+        if 'compile' in conf:
+            is_makefile = conf["compile"] == 'makefile'
+        elif 'is_makefile' in conf:
+            is_makefile = conf["is_makefile"]
 
-            check_type = self._get_check_type(conf["check"])
+        check_type = ProConst.STR_2_CHECKER_TYPE[conf["check"]]
 
-            ALLOW_COMPILERS = set(list(ChalConst.ALLOW_COMPILERS) + ['default'])
-            if is_makefile:
-                ALLOW_COMPILERS = {'default', 'gcc', 'g++', 'clang', 'clang++'}
+        ALLOW_COMPILERS = set(list(ChalConst.ALLOW_COMPILERS) + ['default'])
+        if is_makefile:
+            ALLOW_COMPILERS = {'default', 'gcc', 'g++', 'clang', 'clang++'}
 
-            if "limit" in conf:
-                limits = {}
-                for comp_type, limit in conf["limit"].items():
-                    if comp_type not in ALLOW_COMPILERS:
-                        continue
+        if "limit" in conf:
+            limits = {}
+            for comp_type, limit in conf["limit"].items():
+                if comp_type not in ALLOW_COMPILERS:
+                    continue
 
-                    try:
-                        limit['timelimit'] = max(int(limit['timelimit']), 0)
-                        limit['memlimit'] = max(int(limit['memlimit']) * 1024, 0)
-                    except (ValueError, KeyError):
-                        continue
-
-                    limits[comp_type] = limit
-
-                if 'default' not in limits:
-                    return ("Econf", "Problem limit config require default value"), None
-
-            elif 'timelimit' in conf and 'memlimit' in conf:
                 try:
-                    limits = {
-                        'default': {
-                            'timelimit': int(conf["timelimit"]),
-                            'memlimit': int(conf["memlimit"]) * 1024
-                        }
-                    }
+                    limit['timelimit'] = max(int(limit['timelimit']), 0)
+                    limit['memlimit'] = max(int(limit['memlimit']) * 1024, 0)
+                except KeyError as e:
+                    limit[e.args[0]] = 0
                 except ValueError:
-                    return ("Econf", "Problem limit config have invalid value"), None
-            else:
-                 return ("Econf", "Problem config require limit or timelimit/memlimit"), None
+                    continue
 
-            chalmeta = {}
-            if 'metadata' in conf:
-                chalmeta = conf["metadata"]  # INFO: ioredir data
+                limits[comp_type] = limit
 
-            async with self.db.acquire() as con:
-                await con.execute('DELETE FROM "test_config" WHERE "pro_id" = $1;', int(pro_id))
-                await con.execute(
-                    'UPDATE "problem" SET is_makefile = $1, check_type = $2, chalmeta = $3, "limit" = $4 WHERE pro_id = $5',
-                    is_makefile, check_type, json.dumps(chalmeta), json.dumps(limits), pro_id
-                )
+            if 'default' not in limits:
+                return ("Econf", "Problem limit config require default value"), None
 
-                insert_values = []
+        elif 'timelimit' in conf and 'memlimit' in conf:
+            try:
+                limits = {
+                    'default': {
+                        'timelimit': int(conf["timelimit"]),
+                        'memlimit': int(conf["memlimit"]) * 1024
+                    }
+                }
+            except ValueError:
+                return ("Econf", "Problem limit config have invalid value"), None
+        else:
+                return ("Econf", "Problem config require limit or timelimit/memlimit"), None
 
-                for test_idx, test_conf in enumerate(conf["test"]):
-                    for i in range(len(test_conf["data"])):
-                        test_conf["data"][i] = str(test_conf["data"][i])
+        chalmeta = {}
+        if 'metadata' in conf:
+            chalmeta = conf["metadata"]  # INFO: ioredir data
 
-                    metadata = {"data": test_conf["data"]}
-                    insert_values.append((pro_id, test_idx, test_conf['weight'], json.dumps(metadata)))
+        async with self.db.acquire() as con:
+            await con.execute('DELETE FROM "test_config" WHERE "pro_id" = $1;', int(pro_id))
+            await con.execute(
+                'UPDATE "problem" SET is_makefile = $1, check_type = $2, chalmeta = $3, "limit" = $4 WHERE pro_id = $5',
+                is_makefile, check_type, json.dumps(chalmeta), json.dumps(limits), pro_id
+            )
 
-                await con.executemany(
-                    '''INSERT INTO "test_config"
-                        ("pro_id", "test_idx", "weight", "metadata")
-                        VALUES ($1, $2, $3, $4);''',
-                    insert_values
-                )
+            insert_values = []
 
+            for test_idx, test_conf in enumerate(conf["test"]):
+                for i in range(len(test_conf["data"])):
+                    test_conf["data"][i] = str(test_conf["data"][i])
 
+                metadata = {"data": test_conf["data"]}
+                insert_values.append((pro_id, test_idx, test_conf['weight'], json.dumps(metadata)))
+
+            await con.executemany(
+                '''INSERT INTO "test_config"
+                    ("pro_id", "test_idx", "weight", "metadata")
+                    VALUES ($1, $2, $3, $4);''',
+                insert_values
+            )
+
+        await con.execute("REFRESH MATERIALIZED VIEW test_valid_rate;")
         return None, None
-
-    def _get_check_type(self, s: str):
-        if s == "diff":
-            return ProConst.CHECKER_DIFF
-        elif s == "diff-strict":
-            return ProConst.CHECKER_DIFF_STRICT
-        elif s == "diff-float":
-            return ProConst.CHECKER_DIFF_FLOAT
-        elif s == "ioredir":
-            return ProConst.CHECKER_IOREDIR
-        elif s == "cms":
-            return ProConst.CHECKER_CMS
 
 class ProClassConst:
     OFFICIAL_PUBLIC = 0

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -6,7 +6,6 @@ from msgpack import packb, unpackb
 
 import config
 from services.pack import PackService
-from services.user import Account
 
 
 class ProConst:
@@ -39,6 +38,11 @@ class ProConst:
     PACKTYPE_CONTHTML = 2
     PACKTYPE_CONTPDF = 3
 
+    # NOTE: collection for problem status
+    PRO_STATUS_NORMAL_USER = [STATUS_ONLINE]
+    PRO_STATUS_KERNEL_USER = [STATUS_ONLINE, STATUS_HIDDEN]
+    PRO_STATUS_CONTEST_USER = [STATUS_ONLINE, STATUS_CONTEST]
+
 
 class ProService:
     def __init__(self, db, rs):
@@ -46,27 +50,25 @@ class ProService:
         self.rs = rs
         ProService.inst = self
 
-    async def get_pro(self, pro_id, acct: Account | None = None, is_contest: bool = False):
+    async def get_pro(self, pro_id: int, allow_statuses: list[int]):
         """
-        Parameter `is_contest` should be set to true if you want to get contest problems and your account type is not kernel.
-
         :param pro_id:
         :param acct:
         :param is_contest:
         :return:
         """
+        for status in allow_statuses:
+            assert ProConst.STATUS_ONLINE <= status <= ProConst.STATUS_HIDDEN
         pro_id = int(pro_id)
-        max_status = self.get_acct_limit(acct, is_contest)
 
         async with self.db.acquire() as con:
             result = await con.fetch(
                 """
                     SELECT "name", "status", "tags", "allow_submit",
                     "check_type", "is_makefile", "chalmeta", "limit", "rate_precision"
-                    FROM "problem" WHERE "pro_id" = $1 AND "status" <= $2;
+                    FROM "problem" WHERE "pro_id" = $1;
                 """,
                 pro_id,
-                max_status,
             )
             if len(result) != 1:
                 return ("Enoext", "Problem not found"), None
@@ -83,6 +85,9 @@ class ProService:
                 json.loads(result["limit"]),
                 json.loads(result["chalmeta"]),
             )
+
+            if status not in allow_statuses:
+                return ("Eacces", "Permission denied"), None
 
             result = await con.fetch(
                 """
@@ -120,27 +125,23 @@ class ProService:
             },
         )
 
-    async def list_pro(self, acct: Account | None = None, is_contest=False):
-        if acct is None:
-            max_status = ProConst.STATUS_ONLINE
+    async def list_pro(self, allow_pro_statuses: list[int]):
+        for status in allow_pro_statuses:
+            assert ProConst.STATUS_ONLINE <= status <= ProConst.STATUS_HIDDEN
 
-        else:
-            max_status = self.get_acct_limit(acct, contest=is_contest)
-
-        field = f"{max_status}|{[1, 2]}"  # TODO: Remove class column on db
+        field = f"{allow_pro_statuses}"
         if (prolist := (await self.rs.hget("prolist", field))) is not None:
             prolist = unpackb(prolist)
 
         else:
             async with self.db.acquire() as con:
                 result = await con.fetch(
-                    """
+                    f"""
                         SELECT "problem"."pro_id", "problem"."name", "problem"."status", "problem"."tags"
                         FROM "problem"
-                        WHERE "problem"."status" <= $1
+                        WHERE "problem"."status" IN ({"".join(map(str, allow_pro_statuses))})
                         ORDER BY "pro_id" ASC;
-                    """,
-                    max_status,
+                    """
                 )
 
             prolist = []
@@ -278,20 +279,6 @@ class ProService:
         await self.rs.hdel('pro_rate', pro_id)
 
         return None, None
-
-    # TODO: 把這破函數命名改一下
-    def get_acct_limit(self, acct: Account | None = None, contest=False):
-        if contest:
-            return ProConst.STATUS_CONTEST
-
-        elif acct is None:
-            return ProConst.STATUS_ONLINE
-
-        elif acct.is_kernel():
-            return ProConst.STATUS_HIDDEN
-
-        else:
-            return ProConst.STATUS_ONLINE
 
     async def unpack_pro(self, pro_id, pack_type, pack_token):
         from services.chal import ChalConst

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -39,7 +39,7 @@ class ProConst:
         CHECKER_CMS: "cms",
     }
 
-    STR_2_CHECKER_TYPE = {s: t for s, t in CHECKER_TYPE.items()}
+    STR_2_CHECKER_TYPE = {t: s for s, t in CHECKER_TYPE.items()}
 
     PACKTYPE_FULL = 1
     PACKTYPE_CONTHTML = 2

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -306,8 +306,8 @@ class ProService:
                     - Keys are compiler types (e.g., "gcc", "clang", "default").
                         Allowed compilers can be found in `ChalConst.ALLOW_COMPILERS`.
                     - Each value must contain:
-                        - "timelimit" (int): Time limit in seconds (≥ 0)
-                        - "memlimit" (int): Memory limit in kilobytes (≥ 0)
+                        - "timelimit" (int): Time limit in seconds (>= 0)
+                        - "memlimit" (int): Memory limit in kilobytes (>= 0)
                     - Must include a "default" configuration.
 
                 - rate_precision (int): Precision of the score (e.g., 0 for integers, 2 for 2 decimal places).

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -463,8 +463,8 @@ class ProService:
                     VALUES ($1, $2, $3, $4);''',
                 insert_values
             )
+            await con.execute("REFRESH MATERIALIZED VIEW test_valid_rate;")
 
-        await con.execute("REFRESH MATERIALIZED VIEW test_valid_rate;")
         return None, None
 
 class ProClassConst:

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -465,6 +465,8 @@ class ProService:
             )
             await con.execute("REFRESH MATERIALIZED VIEW test_valid_rate;")
 
+        await self.rs.delete("prolist")
+
         return None, None
 
 class ProClassConst:

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -9,6 +9,11 @@ from services.pack import PackService
 
 
 class ProConst:
+    """
+    Constants used in problem management for status codes, checker types,
+    name/code length constraints, and allowed user problem status sets.
+    """
+
     NAME_MIN = 1
     NAME_MAX = 64
     CODE_MAX = 16384
@@ -54,11 +59,18 @@ class ProService:
 
     async def get_pro(self, pro_id: int, allow_statuses: list[int]):
         """
-        :param pro_id:
-        :param acct:
-        :param is_contest:
-        :return:
+        Fetch problem configuration and metadata by ID, ensuring it's in the allowed status.
+
+        Args:
+            pro_id (int): The ID of the problem to fetch.
+            allow_statuses (list[int]): Allowed problem statuses for access.
+
+        Returns:
+            Tuple[Optional[Tuple[str, str]], Optional[dict]]:
+                - Error code and message if any error occurs.
+                - A dictionary containing problem metadata if successful.
         """
+
         for status in allow_statuses:
             assert ProConst.STATUS_ONLINE <= status <= ProConst.STATUS_HIDDEN
         pro_id = int(pro_id)
@@ -128,6 +140,18 @@ class ProService:
         )
 
     async def list_pro(self, allow_pro_statuses: list[int]):
+        """
+        List problems with statuses in `allow_pro_statuses`, with Redis caching.
+
+        Args:
+            allow_pro_statuses (list[int]): List of allowed statuses.
+
+        Returns:
+            Tuple[None, list[dict]]:
+                - None for error placeholder (always succeeds).
+                - List of problems matching the given statuses.
+        """
+
         for status in allow_pro_statuses:
             assert ProConst.STATUS_ONLINE <= status <= ProConst.STATUS_HIDDEN
 
@@ -165,6 +189,19 @@ class ProService:
         return None, prolist
 
     async def add_pro(self, name: str, status: int):
+        """
+        Add a new problem to the system with initial folders and symbolic links.
+
+        Args:
+            name (str): The name of the problem.
+            status (int): Initial status (online/contest/hidden).
+
+        Returns:
+            Tuple[Optional[Tuple[str, str]], Optional[int]]:
+                - Error code and message if invalid.
+                - The newly created problem ID if successful.
+        """
+
         name_len = len(name)
         if name_len < ProConst.NAME_MIN:
             return ("Enamemin", "Problem name too short"), None
@@ -202,8 +239,23 @@ class ProService:
 
         return None, pro_id
 
-    # TODO: Too many args
     async def update_pro(self, pro_id: int, name: str, status: int, tags="", allow_submit=True):
+        """
+        Update problem metadata such as name, status, tags, and submission permission.
+
+        Args:
+            pro_id (int): The ID of the problem to update.
+            name (str): New name.
+            status (int): New status (online/contest/hidden).
+            tags (str, optional): Tag string. Defaults to "".
+            allow_submit (bool, optional): Submission permission. Defaults to True.
+
+        Returns:
+            Tuple[Optional[Tuple[str, str]], None]:
+                - Error code and message if any error occurs.
+                - None if successful.
+        """
+
         assert ProConst.STATUS_ONLINE <= status <= ProConst.STATUS_HIDDEN
         name_len = len(name)
         if name_len < ProConst.NAME_MIN:
@@ -236,7 +288,45 @@ class ProService:
 
         return None, None
 
-    async def update_test_config(self, pro_id, testm_conf: dict):
+    async def update_test_config(self, pro_id: int, testm_conf: dict):
+        """
+        Update the test configuration (testm_conf) for a given problem.
+
+        Args:
+            pro_id (int): The ID of the problem to update.
+            testm_conf (dict): The test configuration, with the following structure:
+
+                - is_makefile (bool): Whether the problem uses a Makefile-based compilation.
+                See: https://wiki.tfcis.org/TOJ#Makefile%E9%A1%8C%E7%9B%AE_(%E7%B7%A8%E8%AD%AF%E4%BA%92%E5%8B%95%E9%A1%8C)
+
+                - check_type (int): One of the values defined in ProConst.CHECKER_TYPE, indicating
+                the type of checker (e.g., diff, float-diff, ioredir).
+
+                - limit (dict[str, dict[str, int]]): Per-language time and memory limits.
+                    - Keys are compiler types (e.g., "gcc", "clang", "default").
+                        Allowed compilers can be found in `ChalConst.ALLOW_COMPILERS`.
+                    - Each value must contain:
+                        - "timelimit" (int): Time limit in seconds (≥ 0)
+                        - "memlimit" (int): Memory limit in kilobytes (≥ 0)
+                    - Must include a "default" configuration.
+
+                - rate_precision (int): Precision of the score (e.g., 0 for integers, 2 for 2 decimal places).
+
+                - test_group (dict[int, dict]): Configuration for each test group (subtask). Each key is
+                a test group index, and each value is a dict:
+                    - "weight" (int): The score weight of this test group.
+                    - "metadata" (dict): Metadata describing the test cases, e.g., input/output file names.
+
+        Returns:
+            Tuple[None, None]: Always returns (None, None) on success.
+
+        Side Effects:
+            - All existing `Challenge` records associated with this problem will be reset to
+            the `NotStart` state, due to test configuration changes.
+            - `test_valid_rate` materialized view will be refreshed.
+            - Related Redis cache (`rate`, `pro_rate`) will be invalidated.
+        """
+
         insert_values = []
         is_makefile = testm_conf['is_makefile']
         check_type = testm_conf['check_type']
@@ -269,6 +359,19 @@ class ProService:
         return None, None
 
     async def unpack_pro(self, pro_id: int, pack_token: str):
+        """
+        Unpack and apply a packed problem archive.
+
+        Args:
+            pro_id (int): The ID of the problem to unpack into.
+            pack_token (str): Token for identifying the uploaded archive.
+
+        Returns:
+            Tuple[Optional[Tuple[str, str]], None]:
+                - Error code and message if unpacking or config fails.
+                - None if successful.
+        """
+
         from services.chal import ChalConst
         err, _ = await PackService.inst.unpack(pack_token, f"problem/{pro_id}", True)
         if err:
@@ -417,7 +520,7 @@ class ProClassService:
     async def remove_proclass(self, proclass_id: int):
         async with self.db.acquire() as con:
             result: str = await con.execute('DELETE FROM "proclass" WHERE "proclass_id" = $1', int(proclass_id))
-            affected_row_cnt = int(result.split(" ")[1]) # DELETE \d+
+            affected_row_cnt = int(result.split(" ")[1]) # NOTE: DELETE \d+
             if affected_row_cnt == 0:
                 return ('Enoext', 'Bulletin not found'), None
 

--- a/src/tests/e2e/contest.py
+++ b/src/tests/e2e/contest.py
@@ -791,7 +791,7 @@ class ContestTest(AsyncTest):
             res = user_session.get('pro/7')
             self.assertNotIn('Eacces', res.text)
             res = user_session.get('pro/8')
-            self.assertAPIReturnValue(res.text, ('Enoext', 'Problem not found'))
+            self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
 
         # freeze_scoreboard_period: int = 0
 

--- a/src/tests/e2e/manage/pro/update.py
+++ b/src/tests/e2e/manage/pro/update.py
@@ -35,7 +35,7 @@ class ManageProUpdateTest(AsyncTest):
 
             with AccountContext('test1@test', 'test') as user_session:
                 res = user_session.get('pro/1')
-                self.assertAPIReturnValue(res.text, ('Enoext', 'Problem not found'))
+                self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
 
                 html = self.get_html('proset', user_session)
                 trs = html.select('#prolist > tbody > tr')
@@ -46,7 +46,7 @@ class ManageProUpdateTest(AsyncTest):
                 self.assertEqual(trs[1].select('td')[2].text.strip().replace('\n', ''), 'Move')
 
                 res = user_session.get('submit/1')
-                self.assertIn('Enoext', res.text)
+                self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
 
             # html = self.get_html('proset', admin_session)
             # trs = html.select('tr')[1:]

--- a/src/tests/e2e/rank.py
+++ b/src/tests/e2e/rank.py
@@ -36,7 +36,7 @@ class ProRankTest(AsyncTest):
 
             with AccountContext('test1@test', 'test') as user_session:
                 res = user_session.get('rank/1')
-                self.assertAPIReturnValue(res.text, ('Enoext', 'Problem not found'))
+                self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
 
             admin_session.post('manage/pro/update', data={
                 'reqtype': 'updatepro',


### PR DESCRIPTION
## Refactors
- refactor(pro): Remove dependency on ProService.get_acct_limit() to simplify logic.
- refactor(pro): Remove dependency on ProService.unpack_pro() to simplify logic.

## Documentation
- docs(pro): Add complete docstrings for all public methods in ProService.