### PR TITLE
refactor: move testdata to separate table and use testdata_id in subtasks

### DIFF
--- a/migration/20250723103800_add_testdata_table.py
+++ b/migration/20250723103800_add_testdata_table.py
@@ -1,0 +1,53 @@
+import re
+import json
+import collections
+
+def natsort_key(s):
+    return [int(text) if text.isdigit() else text.lower()
+            for text in re.split(r'(\d+)', s)]
+
+async def dochange(db, rs):
+    await db.execute(
+    '''
+        CREATE TABLE testdata (
+            pro_id integer NOT NULL,
+            id integer NOT NULL,
+            inputfile character varying NOT NULL,
+            outputfile character varying NOT NULL
+        );
+    ''')
+    await db.execute(
+    '''
+        ALTER TABLE ONLY testdata
+            ADD CONSTRAINT testdata_forkey_pro_id FOREIGN KEY (pro_id) REFERENCES problem(pro_id) ON DELETE CASCADE;
+    ''')
+
+    await db.execute('ALTER TABLE test_config ADD COLUMN testdatas INTEGER[] NOT NULL DEFAULT \'{}\'::integer[];')
+
+    test_configs = await db.fetch('SELECT pro_id, test_idx, metadata FROM test_config;')
+
+    m = collections.defaultdict(set)
+    m3: dict[int, dict[str, int]] = {}
+    for pro_id, test_group_idx, metadata in test_configs:
+        testdatas = set()
+        metadata = json.loads(metadata)
+        for testdata in metadata["data"]:
+            m[pro_id].add(testdata)
+
+    for pro_id, testdatas in m.items():
+        m2 = {}
+        for id, testdata in enumerate(sorted(testdatas, key=natsort_key)):
+            m2[testdata] = id
+            await db.execute('INSERT INTO testdata ("pro_id", "id", "inputfile", "outputfile") VALUES ($1, $2, $3, $4);',
+                             pro_id, id, f"{testdata}.in", f"{testdata}.out")
+
+        m3[pro_id] = m2
+
+    for pro_id, test_group_idx, metadata in test_configs:
+        testdatas = []
+        metadata = json.loads(metadata)
+        for testdata in metadata["data"]:
+            testdatas.append(m3[pro_id][testdata])
+        await db.execute("UPDATE test_config SET testdatas=$1 WHERE pro_id=$2 AND test_idx=$3", testdatas, pro_id, test_group_idx)
+
+    await db.execute('ALTER TABLE test_config DROP COLUMN metadata;')

--- a/src/handlers/manage/pro.py
+++ b/src/handlers/manage/pro.py
@@ -15,6 +15,7 @@ from services.log import LogService
 from services.pro import ProService, ProConst
 from services.user import UserConst
 from services.pack import PackService
+from utils.numeric import parse_str_to_list
 
 PERMISSION_DENIED_ERROR = ('Eacces', 'Permission denied')
 ALLOW_STATUSES = [ProConst.STATUS_ONLINE, ProConst.STATUS_CONTEST, ProConst.STATUS_HIDDEN]
@@ -49,6 +50,49 @@ class ManageProHandler(RequestHandler):
 
         elif page == "filemanager":
             pro_id = int(self.get_argument('proid'))
+            download = self.get_argument('download', default=None)
+            if download:
+                basepath = self.get_argument('path')
+                filename = self.get_argument('filename')
+                if basepath not in ['http', 'res/check', 'res/make']:
+                    return self.error(('Eparam', 'Invalid basepath'))
+
+
+                basepath = f'problem/{pro_id}/{basepath}'
+                if not self._is_file_access_safe(basepath, filename):
+                    await LogService.inst.add_log(
+                        f'{self.acct.name} tried to download {filename} for problem #{pro_id}, but it was suspicious',
+                        'manage.pro.update.filemanager.download.failed'
+                    )
+                    return self.error(PERMISSION_DENIED_ERROR)
+
+                filepath = os.path.join(basepath, filename)
+
+                if not os.path.exists(filepath):
+                    await LogService.inst.add_log(
+                        f'{self.acct.name} tried to download {filename} for problem #{pro_id} but not found',
+                        'manage.pro.update.filemanager.download.failed'
+                    )
+                    return self.error(('Enoext', 'File not found'))
+
+                await LogService.inst.add_log(f'{self.acct.name} download {filename} for problem #{pro_id}',
+                                              'manage.pro.update.filemanager.download')
+
+                self.set_header('Content-Type', 'application/octet-stream')
+                self.set_header('Content-Disposition', f'attachment; filename="{filename}"')
+                with open(filepath, 'rb') as f:
+                    try:
+                        while True:
+                            buffer = f.read(65536)
+                            if buffer:
+                                self.write(buffer)
+                            else:
+                                self.finish()
+                                return
+                    except:
+                        self.error(('Eunk', 'Unknown error'))
+                return
+
             err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
             if err:
                 return self.error(err)
@@ -79,26 +123,50 @@ class ManageProHandler(RequestHandler):
 
         elif page == "updatetests":
             pro_id = int(self.get_argument('proid'))
+            err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
+            if err:
+                return self.error(err)
+
+            await self.render(
+                'manage/pro/updatetests',
+                page='pro',
+                pro_id=pro_id,
+                tests=pro['testm_conf'],
+            )
+
+        elif page == "updatetestdata":
+            pro_id = int(self.get_argument('proid'))
+            err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
+            if err:
+                return self.error(err)
 
             download = self.get_argument('download', default=None)
 
             if download:
-                return NotImplemented
+                testdata_type = self.get_argument('type')
+                if testdata_type not in ['input', 'output']:
+                    return self.error(('Eparam', 'Invalid testdata file type'))
+
+                testdata_id = int(self.get_argument('testdata_id'))
+                if testdata_id not in pro['testm_conf']['testdatas']:
+                    self.error(('Enoext', 'Testdata not found'))
+                    return
+
+                if testdata_type == "input":
+                    file = pro['testm_conf']['testdatas'][testdata_id]['inputfile']
+                else:
+                    file = pro['testm_conf']['testdatas'][testdata_id]['outputfile']
+
                 basepath = f'problem/{pro_id}/res/testdata'
-                filepath = f'{basepath}/{download}'
-                if not self._is_file_access_safe(basepath, download):
-                    # TODO: log illegal action
-                    self.error('Eacces')
-                    return
-
+                filepath = f'{basepath}/{file}'
                 if not os.path.exists(filepath):
-                    self.error('Enoext')
-                    return
+                    return self.error(('Enoext', 'Testdata file not found'))
 
-                # TODO: log
+                await LogService.inst.add_log(f'{self.acct.name} download testdata {testdata_id} with {testdata_type} type for problem #{pro_id}',
+                                            'manage.pro.update.testdata.download')
 
                 self.set_header('Content-Type', 'application/octet-stream')
-                self.set_header('Content-Disposition', f'attachment; filename="{download}"')
+                self.set_header('Content-Disposition', f'attachment; filename="{file}"')
                 with open(filepath, 'rb') as f:
                     try:
                         while True:
@@ -109,24 +177,14 @@ class ManageProHandler(RequestHandler):
                                 self.finish()
                                 return
                     except:
-                        self.error('Eunk')
-
+                        self.error(('Eunk', 'Unknown error'))
                 return
 
-
-            err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
-            if err:
-                return self.error(err)
-
-            files = natsorted(set(map(lambda file: file.replace('.in', '').replace('.out', ''),
-                        filter(lambda file: file.endswith('.in') or file.endswith('.out'), os.listdir(f'problem/{pro_id}/res/testdata')))))
-
             await self.render(
-                'manage/pro/updatetests',
+                'manage/pro/updatetestdata',
                 page='pro',
                 pro_id=pro_id,
                 tests=pro['testm_conf'],
-                files=files
             )
 
     @reqenv
@@ -160,47 +218,207 @@ class ManageProHandler(RequestHandler):
 
             self.error(('S', pro_id))
 
-        elif page == "updatetests":
+        elif page == "updatetestdata":
             pro_id = int(self.get_argument('pro_id'))
             err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
             if err:
                 return self.error(err)
 
             if reqtype == "preview":
-                filename = self.get_argument('filename')
-                test_type = self.get_argument('type')
+                testdata_id = int(self.get_argument('testdata_id'))
+                testdata_type = self.get_argument('type')
 
-                if test_type not in ['out', 'in']:
-                    return self.error(('Eparam', 'Invalid testcase file type'))
+                if testdata_id not in pro['testm_conf']['testdatas']:
+                    return self.error(('Enoext', 'Testdata not found'))
 
-                filename += f".{test_type}"
+                if testdata_type not in ['output', 'input']:
+                    return self.error(('Eparam', 'Invalid testdata file type'))
+
+                if testdata_type == 'input':
+                    filename = pro['testm_conf']['testdatas'][testdata_id]['inputfile']
+                else:
+                    filename = pro['testm_conf']['testdatas'][testdata_id]['outputfile']
+
                 basepath = f'problem/{pro_id}/res/testdata'
-                if not self._is_file_access_safe(basepath, filename):
-                    await LogService.inst.add_log(
-                        f'{self.acct.name} tried to preview file:{filename} for problem #{pro_id}, but it was suspicious',
-                        'manage.pro.update.tests.preview.failed'
-                    )
-                    return self.error(PERMISSION_DENIED_ERROR)
-
                 filepath = os.path.join(basepath, filename)
 
                 if not os.path.exists(filepath):
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to preview file:{filename} for problem #{pro_id} but not found',
-                        'manage.pro.update.tests.preview.failed'
+                        'manage.pro.update.testdata.preview.failed'
                     )
                     return self.error(('Enoext', 'File not found'))
 
-                await LogService.inst.add_log(f'{self.acct.name} preview file:{filename} for problem #{pro_id}',
-                                            'manage.pro.update.tests.preview')
-                with open(filepath, 'r') as testcase_f:
-                    content = testcase_f.readlines()
+                await LogService.inst.add_log(f'{self.acct.name} preview testdata {testdata_id} with {testdata_type} type for problem #{pro_id}',
+                                            'manage.pro.update.testdata.preview')
+                with open(filepath, 'r') as testdata_f:
+                    content = testdata_f.readlines()
                     if len(content) > 25:
                         return self.error(('Efile', 'File too large'))
 
-                    self.error(('S', ''.join(content)))
+                    self.error(('S', tornado.escape.xhtml_escape(''.join(content))))
 
-            elif reqtype == "updateweight":
+            elif reqtype == 'updatesinglefile':
+                testdata_id = int(self.get_argument('testdata_id'))
+                testdata_type = self.get_argument('type')
+                pack_token = self.get_argument('pack_token')
+
+                failed = True
+                try:
+                    testdatas: dict[int, dict] = pro['testm_conf']['testdatas']
+                    if testdata_id not in testdatas:
+                        return self.error(('Enoext', 'Testdata not found'))
+
+                    if testdata_type not in ['output', 'input']:
+                        return self.error(('Eparam', 'Invalid testdata file type'))
+
+                    if testdata_type == 'input':
+                        filename = testdatas[testdata_id]['inputfile']
+                    else:
+                        filename = testdatas[testdata_id]['outputfile']
+
+                    basepath = f'problem/{pro_id}/res/testdata'
+                    filepath = f'{basepath}/{filename}'
+
+                    if not self._is_file_access_safe(basepath, filename):
+                        await LogService.inst.add_log(
+                            f'{self.acct.name} tried to update testdata {testdata_id} with {testdata_type} type for problem #{pro_id}, but it was suspicious',
+                            'manage.pro.update.testdata.updatesinglefile.failed',
+                            {
+                                'testdata': testdatas[testdata_id]
+                            }
+                        )
+                        return self.error(PERMISSION_DENIED_ERROR)
+
+                    if not os.path.exists(filepath):
+                        await LogService.inst.add_log(
+                            f'{self.acct.name} tried to update testdata {testdata_id} with {testdata_type} type for problem #{pro_id} but not found',
+                            'manage.pro.update.testdata.updatesinglefile.failed',
+                            {
+                                'testdata': testdatas[testdata_id]
+                            }
+                        )
+                        return self.error(('Enoext', 'Testdata file not found'))
+                    failed = False
+
+                finally:
+                    # NOTE: Like golang defer
+                    if failed:
+                        await PackService.inst.clear(pack_token)
+
+                _ = await PackService.inst.direct_copy(pack_token, filepath)
+
+                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+                await LogService.inst.add_log(
+                    f'{self.acct.name} has sent a request to update testdata {testdata_id} with {testdata_type} type for problem #{pro_id}',
+                    'manage.pro.update.testdata.updatesinglefile',
+                )
+
+                self.error(('S', ''))
+
+            elif reqtype == "addsinglefile":
+                filename = self.get_argument('filename')
+                input_pack_token = self.get_argument('input_pack_token')
+                output_pack_token = self.get_argument('output_pack_token')
+
+                testm_conf = pro['testm_conf']
+                testdatas: dict[int, dict] = testm_conf['testdatas']
+                try:
+                    new_testdata_id = max(testdatas.keys()) + 1
+                except ValueError:
+                    new_testdata_id = 0
+
+
+                basepath = f'problem/{pro_id}/res/testdata'
+                inputfile_path = f'{basepath}/{filename}.in'
+                outputfile_path = f'{basepath}/{filename}.out'
+
+                if not self._is_file_access_safe(
+                    basepath, f'{filename}.in'
+                ) or not self._is_file_access_safe(basepath, f'{filename}.out'):
+                    await PackService.inst.clear(input_pack_token)
+                    await PackService.inst.clear(output_pack_token)
+                    await LogService.inst.add_log(
+                        f'{self.acct.name} tried to add a single file:{filename} for problem #{pro_id}, but it was suspicious',
+                        'manage.pro.update.testdata.addsinglefile.failed'
+                    )
+                    return self.error(PERMISSION_DENIED_ERROR)
+
+                if os.path.exists(inputfile_path) or os.path.exists(outputfile_path):
+                    await PackService.inst.clear(input_pack_token)
+                    await PackService.inst.clear(output_pack_token)
+                    await LogService.inst.add_log(
+                        f'{self.acct.name} tried to add single file:{filename} for problem #{pro_id} but {filename} already exists',
+                        'manage.pro.update.testdata.addsinglefile.failed'
+                    )
+                    return self.error(('Eexist', 'File already exists'))
+
+                _ = await PackService.inst.direct_copy(input_pack_token, inputfile_path)
+                _ = await PackService.inst.direct_copy(output_pack_token, outputfile_path)
+                testdatas[new_testdata_id] = {
+                    'id': new_testdata_id,
+                    'inputfile': f'{filename}.in',
+                    'outputfile': f'{filename}.out',
+                }
+                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+
+                await LogService.inst.add_log(
+                    f'{self.acct.name} has sent a request to add testdata {new_testdata_id} named {filename} for problem #{pro_id}',
+                    'manage.pro.update.testdata.addsinglefile',
+                )
+
+                self.error(('S', ''))
+
+            elif reqtype == 'deletesinglefile':
+                testdata_id = int(self.get_argument('testdata_id'))
+                testm_conf = pro['testm_conf']
+                testdatas: dict[int, dict] = testm_conf['testdatas']
+
+                if testdata_id not in testdatas:
+                    return self.error(('Enoext', 'Testdata not found'))
+
+                inputfile = testdatas[testdata_id]['inputfile']
+                outputfile = testdatas[testdata_id]['outputfile']
+
+                basepath = f'problem/{pro_id}/res/testdata'
+                if not os.path.exists(f'{basepath}/{inputfile}') or not os.path.exists(f'{basepath}/{outputfile}'):
+                    await LogService.inst.add_log(
+                        f'{self.acct.name} tried to delete testdata {testdata_id} for problem #{pro_id} but not found',
+                        'manage.pro.update.testdata.deletesinglefile.failed',
+                        {
+                            'testdata': testdatas[testdata_id]
+                        }
+                    )
+                    return self.error(('Enoext', 'Testdata file not found'))
+
+                os.remove(f'{basepath}/{inputfile}')
+                os.remove(f'{basepath}/{outputfile}')
+
+                for test_group in pro['testm_conf']['test_group'].values():
+                    try:
+                        test_group['testdatas'].remove(testdata_id)
+                    except ValueError:
+                        pass
+                deleted_testdata = pro['testm_conf']['testdatas'].pop(testdata_id)
+
+                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+                await LogService.inst.add_log(
+                    f'{self.acct.name} has sent a request to delete testdata {testdata_id} for problem #{pro_id}',
+                    'manage.pro.update.tests.deletesinglefile',
+                    {
+                        'testdata': deleted_testdata
+                    }
+                )
+
+                self.error(('S', ''))
+
+        elif page == "updatetests":
+            pro_id = int(self.get_argument('pro_id'))
+            err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
+            if err:
+                return self.error(err)
+
+            if reqtype == "updateweight":
                 group = int(self.get_argument('group'))
                 weight = int(self.get_argument('weight'))
 
@@ -227,7 +445,7 @@ class ManageProHandler(RequestHandler):
 
                 test_group[len(test_group)] = {
                     'weight': weight,
-                    'metadata': {'data': []}
+                    'testdatas': []
                 }
 
                 await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
@@ -262,217 +480,28 @@ class ManageProHandler(RequestHandler):
                 )
                 self.error(('S', ''))
 
-            elif reqtype == 'addsingletestcase':
+            elif reqtype == 'settestdata':
                 group = int(self.get_argument('group'))
-                testcase = self.get_argument('testcase')
-
-                basepath = f'problem/{pro_id}/res/testdata'
-                if not os.path.exists(f'{basepath}/{testcase}.in') or not os.path.exists(f'{basepath}/{testcase}.out'):
-                    return self.error(('Enoext', 'Testcase file not found'))
+                testdatas = parse_str_to_list(self.get_argument('testdatas'))
 
                 test_group = pro['testm_conf']['test_group']
                 if group not in test_group:
                     return self.error(('Enoext', 'Group not found'))
 
-                for t in test_group[group]['metadata']['data']:
-                    if testcase == str(t):
-                        await LogService.inst.add_log(
-                            f'{self.acct.name} tried to add testcase:{testcase} for problem #{pro_id} but already exists',
-                            'manage.pro.update.tests.addsingletestcase',
-                        )
-                        return self.error(('Eexist', 'Testcase already exists'))
-
-                test_group[group]['metadata']['data'].append(testcase)
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
-                await LogService.inst.add_log(
-                    f'{self.acct.name} has sent a request to add a testcase:{testcase} to group#{group} for problem #{pro_id}',
-                    'manage.pro.update.tests.addsingletestcase',
-                )
-                self.error(('S', ''))
-
-            elif reqtype == 'deletesingletestcase':
-                group = int(self.get_argument('group'))
-                testcase = self.get_argument('testcase')
-
-                test_group = pro['testm_conf']['test_group']
-                if group not in test_group:
-                    return self.error(('Enoext', 'Group not found'))
-
-                try:
-                    test_group[group]['metadata']['data'].remove(testcase)
-                except ValueError:
-                    return self.error(('Enoext', 'Testcase not found'))
+                test_group[group]['testdatas'] = []
+                for testdata_id in testdatas:
+                    if testdata_id not in pro['testm_conf']['testdatas']:
+                        continue
+                    test_group[group]['testdatas'].append(testdata_id)
 
                 await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
                 await LogService.inst.add_log(
-                    f'{self.acct.name} has sent a request to delete a testcase:{testcase} to group#{group} for problem #{pro_id}',
-                    'manage.pro.update.tests.deletesingletestcase',
+                    f'{self.acct.name} has sent a request to set testdatas to group#{group} for problem #{pro_id}',
+                    'manage.pro.update.tests.settestdata',
+                    {
+                        'testdatas': testdatas
+                    }
                 )
-                self.error(('S', ''))
-
-            elif reqtype == 'renamesinglefile':
-                old_filename = self.get_argument('old_filename')
-                new_filename = self.get_argument('new_filename')
-
-                # check filename
-                basepath = f'problem/{pro_id}/res/testdata'
-                old_inputfile_path = f'{basepath}/{old_filename}.in'
-                old_outputfile_path = f'{basepath}/{old_filename}.out'
-                new_inputfile_path = f'{basepath}/{new_filename}.in'
-                new_outputfile_path = f'{basepath}/{new_filename}.out'
-                if not self._is_file_access_safe(basepath, f'{old_filename}.in') or not self._is_file_access_safe(basepath, f'{new_filename}.in'):
-                    await LogService.inst.add_log(
-                        f'{self.acct.name} tried to rename {old_filename} to {new_filename} for problem #{pro_id}, but it was suspicious',
-                        'manage.pro.update.tests.renamesinglefile.failed'
-                    )
-                    return self.error(PERMISSION_DENIED_ERROR)
-
-                if not os.path.exists(old_inputfile_path) or not os.path.exists(old_outputfile_path):
-                    await LogService.inst.add_log(
-                        f'{self.acct.name} tried to rename {old_filename} to {new_filename} for problem #{pro_id} but {old_filename} not found',
-                        'manage.pro.update.tests.renamesinglefile.failed'
-                    )
-                    return self.error(('Enoext', 'Old filename not found'))
-
-                if os.path.exists(new_inputfile_path) or os.path.exists(new_outputfile_path):
-                    await LogService.inst.add_log(
-                        f'{self.acct.name} tried to rename {old_filename} to {new_filename} for problem #{pro_id} but {new_filename} already exists',
-                        'manage.pro.update.tests.renamesinglefile.failed'
-                    )
-                    return self.error(('Eexist', 'New filename already exists'))
-
-                os.rename(old_inputfile_path, new_inputfile_path)
-                os.rename(old_outputfile_path, new_outputfile_path)
-
-                is_modified = False
-                for test_group in pro['testm_conf']['test_group'].values():
-                    test = test_group['metadata']['data']
-
-                    for i in range(len(test)):
-                        if test[i] == old_filename:
-                            is_modified = True
-                            test[i] = new_filename
-
-                if is_modified:
-                    await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
-                await LogService.inst.add_log(
-                    f'{self.acct.name} has sent a request to rename {old_filename} to {new_filename} for problem #{pro_id}',
-                    'manage.pro.update.tests.renamesinglefile',
-                )
-                self.error(('S', ''))
-
-            elif reqtype == 'updatesinglefile':
-                filename = self.get_argument('filename')
-                test_type = self.get_argument('type')
-                pack_token = self.get_argument('pack_token')
-
-                if test_type not in ['output', 'input']:
-                    PackService.inst.clear(pack_token)
-                    return self.error(('Eparam', 'Invalid testcase file type'))
-
-                basepath = f'problem/{pro_id}/res/testdata'
-                filepath = f'{basepath}/{filename}.{test_type[0:-3]}'
-
-                if not self._is_file_access_safe(basepath, f"{filename}.{test_type[0:-3]}"):
-                    PackService.inst.clear(pack_token)
-                    await LogService.inst.add_log(
-                        f'{self.acct.name} tried to update {filename} for problem #{pro_id}, but it was suspicious',
-                        'manage.pro.update.tests.updatesinglefile.failed'
-                    )
-                    return self.error(PERMISSION_DENIED_ERROR)
-
-                if not os.path.exists(filepath):
-                    PackService.inst.clear(pack_token)
-                    await LogService.inst.add_log(
-                        f'{self.acct.name} tried to update {filename}.{test_type[0:-3]} for problem #{pro_id} but not found',
-                        'manage.pro.update.tests.updatesinglefile.failed'
-                    )
-                    return self.error(('Enoext', 'Testcase file not found'))
-
-                _ = await PackService.inst.direct_copy(pack_token, filepath)
-
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
-                await LogService.inst.add_log(
-                    f'{self.acct.name} has sent a request to update a single file:{filename} for problem #{pro_id}',
-                    'manage.pro.update.tests.updatesinglefile',
-                )
-
-                self.error(('S', ''))
-
-            elif reqtype == "addsinglefile":
-                filename = self.get_argument('filename')
-                input_pack_token = self.get_argument('input_pack_token')
-                output_pack_token = self.get_argument('output_pack_token')
-
-                basepath = f'problem/{pro_id}/res/testdata'
-                inputfile_path = f'{basepath}/{filename}.in'
-                outputfile_path = f'{basepath}/{filename}.out'
-
-                if not self._is_file_access_safe(
-                    basepath, f'{filename}.in'
-                ) or not self._is_file_access_safe(basepath, f'{filename}.out'):
-                    PackService.inst.clear(input_pack_token)
-                    PackService.inst.clear(output_pack_token)
-                    await LogService.inst.add_log(
-                        f'{self.acct.name} tried to add a single file:{filename} for problem #{pro_id}, but it was suspicious',
-                        'manage.pro.update.tests.addsinglefile.failed'
-                    )
-                    return self.error(PERMISSION_DENIED_ERROR)
-
-                if os.path.exists(inputfile_path) or os.path.exists(outputfile_path):
-                    PackService.inst.clear(input_pack_token)
-                    PackService.inst.clear(output_pack_token)
-                    await LogService.inst.add_log(
-                        f'{self.acct.name} tried to add single file:{filename} for problem #{pro_id} but {filename} already exists',
-                        'manage.pro.update.tests.addsinglefile.failed'
-                    )
-                    return self.error(('Eexist', 'File already exists'))
-
-                _ = await PackService.inst.direct_copy(input_pack_token, inputfile_path)
-                _ = await PackService.inst.direct_copy(output_pack_token, outputfile_path)
-
-                await LogService.inst.add_log(
-                    f'{self.acct.name} has sent a request to add a single file:{filename} for problem #{pro_id}',
-                    'manage.pro.update.tests.addsinglefile',
-                )
-
-                self.error(('S', ''))
-
-            elif reqtype == 'deletesinglefile':
-                filename = self.get_argument('filename')
-
-                basepath = f'problem/{pro_id}/res/testdata'
-                if not self._is_file_access_safe(basepath, f'{filename}.in'):
-                    await LogService.inst.add_log(
-                        f'{self.acct.name} tried to delete a single file:{filename} for problem #{pro_id}, but it was suspicious',
-                        'manage.pro.update.tests.deletesinglefile.failed'
-                    )
-                    return self.error(PERMISSION_DENIED_ERROR)
-
-                if not os.path.exists(f'{basepath}/{filename}.in') or not os.path.exists(f'{basepath}/{filename}.out'):
-                    await LogService.inst.add_log(
-                        f'{self.acct.name} tried to delete a single file:{filename} for problem #{pro_id} but not found',
-                        'manage.pro.update.tests.deletesinglefile.failed'
-                    )
-                    return self.error(('Enoext', 'Testcase file not found'))
-
-                os.remove(f'{basepath}/{filename}.in')
-                os.remove(f'{basepath}/{filename}.out')
-
-                for test_group in pro['testm_conf']['test_group'].values():
-                    test = test_group['metadata']['data']
-
-                    try:
-                        test.remove(filename)
-                    except ValueError:
-                        pass
-
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
-                await LogService.inst.add_log(
-                    f'{self.acct.name} has sent a request to delete a single file:{filename} for problem #{pro_id}',
-                    'manage.pro.update.tests.deletesinglefile',
-                )
-
                 self.error(('S', ''))
 
         elif page == "filemanager":
@@ -522,7 +551,7 @@ class ManageProHandler(RequestHandler):
                 basepath = f'problem/{pro_id}/{basepath}'
                 old_filepath = f'{basepath}/{old_filename}'
                 new_filepath = f'{basepath}/{new_filename}'
-                if not self._is_file_access_safe(basepath, new_filename):
+                if not self._is_file_access_safe(basepath, new_filename) or not self._is_file_access_safe(basepath, old_filename):
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to rename {old_filename} to {new_filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.filemanager.renamesinglefile.failed'
@@ -558,7 +587,7 @@ class ManageProHandler(RequestHandler):
                 filepath = f'{basepath}/{filename}'
 
                 if not self._is_file_access_safe(basepath, filename):
-                    PackService.inst.clear(pack_token)
+                    await PackService.inst.clear(pack_token)
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to update {filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.filemanager.updatesinglefile.failed'
@@ -566,7 +595,7 @@ class ManageProHandler(RequestHandler):
                     return self.error(PERMISSION_DENIED_ERROR)
 
                 if not os.path.exists(filepath):
-                    PackService.inst.clear(pack_token)
+                    await PackService.inst.clear(pack_token)
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to update {filename} for problem #{pro_id} but not found',
                         'manage.pro.update.filemanager.updatesinglefile.failed'
@@ -589,7 +618,7 @@ class ManageProHandler(RequestHandler):
                 filepath = f'{basepath}/{filename}'
 
                 if not self._is_file_access_safe(basepath, filename):
-                    PackService.inst.clear(pack_token)
+                    await PackService.inst.clear(pack_token)
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to add {filename} for problem #{pro_id}, but it was suspicious',
                         'manage.pro.update.filemanager.addsinglefile.failed'
@@ -597,7 +626,7 @@ class ManageProHandler(RequestHandler):
                     return self.error(PERMISSION_DENIED_ERROR)
 
                 if os.path.exists(filepath):
-                    PackService.inst.clear(pack_token)
+                    await PackService.inst.clear(pack_token)
                     await LogService.inst.add_log(
                         f'{self.acct.name} tried to add {filename} for problem #{pro_id} but {filename} already exists',
                         'manage.pro.update.filemanager.addsinglefile.failed'
@@ -723,7 +752,7 @@ class ManageProHandler(RequestHandler):
 
                 err, _ = await ProService.inst.unpack_pro(pro_id, pack_token)
                 if err:
-                    PackService.inst.clear(pack_token)
+                    await PackService.inst.clear(pack_token)
                     await LogService.inst.add_log(
                         f"{self.acct.name} tried to update the problem #{pro_id} by uploading problem package but failed",
                         'manage.pro.update.pro.package.failed',

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -494,7 +494,7 @@ class ChalService:
                         'test_idx': test_group_idx,
                         'timelimit': timelimit,
                         'memlimit': memlimit,
-                        'metadata': test['metadata'],
+                        'metadata': {'data': [testm_conf['testdatas'][testdata_id]['inputfile'].removesuffix('.in') for testdata_id in test['testdatas']]},
                     }
                 )
                 insert_values.append((chal_id, acct_id, pro_id, test_group_idx, ChalConst.STATE_JUDGE, timestamp))

--- a/src/services/pack.py
+++ b/src/services/pack.py
@@ -73,4 +73,25 @@ class PackService:
         os.remove(f'tmp/{pack_token}')
         await self._run_and_wait_process('/bin/bash', 'newline.sh', f'{dst}/res/testdata')
 
-        return None, None
+        def check_file_illegal(path):
+            if os.path.islink(path):
+                return ('Eparam', f'{path} should not be a link. So suspicious. You maybe a hacker.')
+
+            if not os.path.isfile(path):
+                return ('Eparam', f'What the heck about {path}. What file are you uploading? So suspicious.')
+
+            return None
+
+        err = None
+        def dfs(path):
+            nonlocal err
+            if err:
+                return
+            for name in os.listdir(path):
+                if os.path.isdir(os.path.join(path, name)):
+                    dfs(os.path.join(path, name))
+                else:
+                    err = check_file_illegal(os.path.join(path, name))
+
+
+        return err, None

--- a/src/services/pack.py
+++ b/src/services/pack.py
@@ -38,9 +38,10 @@ class PackService:
 
         os.remove(f'tmp/{pack_token}')
 
-    def clear(self, pack_token):
+    async def clear(self, pack_token):
         if os.path.exists(f'tmp/{pack_token}'):
             os.remove(f'tmp/{pack_token}')
+            await self.rs.delete(f'PACK_TOKEN@{pack_token}')
 
     async def _run_and_wait_process(self, program, *args):
         process = await asyncio.create_subprocess_exec(program, *args)

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -1,6 +1,7 @@
-import json
 import os
 import re
+import json
+import shutil
 
 from msgpack import packb, unpackb
 
@@ -105,18 +106,33 @@ class ProService:
 
             result = await con.fetch(
                 """
-                    SELECT "test_idx", "weight", "metadata"
+                    SELECT "test_idx", "weight", "testdatas"
                     FROM "test_config" WHERE "pro_id" = $1 ORDER BY "test_idx" ASC;
                 """,
                 pro_id,
             )
 
-        test_groups = {}
-        for test_group_idx, weight, metadata in result:
-            test_groups[test_group_idx] = {
-                "weight": weight,
-                "metadata": json.loads(metadata),
-            }
+            test_groups = {}
+            for test_group_idx, weight, testdatas in result:
+                test_groups[test_group_idx] = {
+                    "weight": weight,
+                    "testdatas": testdatas,
+                }
+
+            result = await con.fetch(
+                """
+                    SELECT "id", "inputfile", "outputfile"
+                    FROM "testdata" WHERE "pro_id" = $1;
+                """,
+                pro_id
+            )
+            testdatas = {}
+            for id, inputfile, outputfile in result:
+                testdatas[id] = {
+                    "id": id,
+                    "inputfile": inputfile,
+                    "outputfile": outputfile,
+                }
 
         testm_conf = {
             "chalmeta": chalmeta,
@@ -125,6 +141,7 @@ class ProService:
             "is_makefile": is_makefile,
             "test_group": test_groups,
             "rate_precision": rate_precision,
+            "testdatas": testdatas
         }
 
         return (
@@ -327,7 +344,8 @@ class ProService:
             - Related Redis cache (`rate`, `pro_rate`) will be invalidated.
         """
 
-        insert_values = []
+        insert_test_config_values = []
+        insert_testdatas_values = []
         is_makefile = testm_conf['is_makefile']
         check_type = testm_conf['check_type']
         chalmeta = testm_conf['chalmeta']
@@ -335,22 +353,36 @@ class ProService:
         rate_precision = testm_conf['rate_precision']
         for test_group_idx, test_group_conf in testm_conf['test_group'].items():
             weight = test_group_conf['weight']
-            insert_values.append((pro_id, test_group_idx, weight, json.dumps(test_group_conf['metadata'])))
+            insert_test_config_values.append((pro_id, test_group_idx, weight, test_group_conf['testdatas']))
+
+        for testdata in testm_conf['testdatas'].values():
+            insert_testdatas_values.append((pro_id, testdata['id'], testdata['inputfile'], testdata['outputfile']))
 
         async with self.db.acquire() as con:
             await con.execute('DELETE FROM "test_config" WHERE "pro_id" = $1;', int(pro_id))
+            await con.execute('DELETE FROM "testdata" WHERE "pro_id" = $1;', int(pro_id))
             await con.execute(
                 'UPDATE "problem" SET is_makefile = $1, check_type = $2, chalmeta = $3, "limit" = $4, "rate_precision" = $5 WHERE pro_id = $6',
                 is_makefile, check_type, json.dumps(chalmeta), json.dumps(limit), rate_precision, pro_id
             )
 
-            if insert_values:
+            if insert_test_config_values:
                 await con.executemany(
                     '''INSERT INTO "test_config"
-                        ("pro_id", "test_idx", "weight", "metadata")
+                        ("pro_id", "test_idx", "weight", "testdatas")
                         VALUES ($1, $2, $3, $4);''',
-                    insert_values
+                    insert_test_config_values
                 )
+
+            if insert_testdatas_values:
+                await con.executemany(
+                    '''
+                        INSERT INTO "testdata" ("pro_id", "id", "inputfile", "outputfile")
+                        VALUES ($1, $2, $3, $4);
+                    ''',
+                    insert_testdatas_values
+                )
+
 
         await self.db.execute("REFRESH MATERIALIZED VIEW test_valid_rate;")
         await self.rs.delete('rate')
@@ -373,98 +405,116 @@ class ProService:
         """
 
         from services.chal import ChalConst
-        err, _ = await PackService.inst.unpack(pack_token, f"problem/{pro_id}", True)
-        if err:
-            return err, None
-
+        failed = True
         try:
-            os.chmod(os.path.abspath(f"problem/{pro_id}"), 0o755)
-            os.symlink(
-                os.path.abspath(f"problem/{pro_id}/http"),
-                f"{config.WEB_PROBLEM_STATIC_FILE_DIRECTORY}/{pro_id}",
-            )
+            err, _ = await PackService.inst.unpack(pack_token, f"problem/{pro_id}", True)
+            if err:
+                return err, None
 
-        except FileExistsError:
-            pass
-
-        try:
-            with open(f"problem/{pro_id}/conf.json") as conf_f:
-                conf = json.load(conf_f)
-        except json.decoder.JSONDecodeError:
-            return ("Econf", "Problem config json syntax error"), None
-
-        is_makefile = False
-        if 'compile' in conf:
-            is_makefile = conf["compile"] == 'makefile'
-        elif 'is_makefile' in conf:
-            is_makefile = conf["is_makefile"]
-
-        check_type = ProConst.STR_2_CHECKER_TYPE[conf["check"]]
-
-        ALLOW_COMPILERS = set(list(ChalConst.ALLOW_COMPILERS) + ['default'])
-        if is_makefile:
-            ALLOW_COMPILERS = {'default', 'gcc', 'g++', 'clang', 'clang++'}
-
-        if "limit" in conf:
-            limits = {}
-            for comp_type, limit in conf["limit"].items():
-                if comp_type not in ALLOW_COMPILERS:
-                    continue
-
-                try:
-                    limit['timelimit'] = max(int(limit['timelimit']), 0)
-                    limit['memlimit'] = max(int(limit['memlimit']) * 1024, 0)
-                except KeyError as e:
-                    limit[e.args[0]] = 0
-                except ValueError:
-                    continue
-
-                limits[comp_type] = limit
-
-            if 'default' not in limits:
-                return ("Econf", "Problem limit config require default value"), None
-
-        elif 'timelimit' in conf and 'memlimit' in conf:
             try:
-                limits = {
-                    'default': {
-                        'timelimit': int(conf["timelimit"]),
-                        'memlimit': int(conf["memlimit"]) * 1024
+                os.chmod(os.path.abspath(f"problem/{pro_id}"), 0o755)
+                os.symlink(
+                    os.path.abspath(f"problem/{pro_id}/http"),
+                    f"{config.WEB_PROBLEM_STATIC_FILE_DIRECTORY}/{pro_id}",
+                )
+
+            except FileExistsError:
+                pass
+
+            try:
+                with open(f"problem/{pro_id}/conf.json") as conf_f:
+                    conf = json.load(conf_f)
+            except json.decoder.JSONDecodeError:
+                return ("Econf", "Problem config json syntax error"), None
+
+            testm_conf = {
+                'rate_precision': 0,
+            }
+
+            testm_conf['is_makefile'] = False
+            if 'compile' in conf:
+                testm_conf['is_makefile'] = conf["compile"] == 'makefile'
+            elif 'is_makefile' in conf:
+                testm_conf['is_makefile'] = conf["is_makefile"]
+
+            testm_conf['check_type'] = ProConst.STR_2_CHECKER_TYPE[conf["check"]]
+
+            ALLOW_COMPILERS = set(list(ChalConst.ALLOW_COMPILERS) + ['default'])
+            if testm_conf['is_makefile']:
+                ALLOW_COMPILERS = {'default', 'gcc', 'g++', 'clang', 'clang++'}
+
+            if "limit" in conf:
+                limits = {}
+                for comp_type, limit in conf["limit"].items():
+                    if comp_type not in ALLOW_COMPILERS:
+                        continue
+
+                    try:
+                        limit['timelimit'] = max(int(limit['timelimit']), 0)
+                        limit['memlimit'] = max(int(limit['memlimit']) * 1024, 0)
+                    except KeyError as e:
+                        limit[e.args[0]] = 0
+                    except ValueError:
+                        continue
+
+                    limits[comp_type] = limit
+
+                if 'default' not in limits:
+                    return ("Econf", "Problem limit config require default value"), None
+
+            elif 'timelimit' in conf and 'memlimit' in conf:
+                try:
+                    limits = {
+                        'default': {
+                            'timelimit': int(conf["timelimit"]),
+                            'memlimit': int(conf["memlimit"]) * 1024
+                        }
                     }
-                }
-            except ValueError:
-                return ("Econf", "Problem limit config have invalid value"), None
-        else:
-                return ("Econf", "Problem config require limit or timelimit/memlimit"), None
+                except ValueError:
+                    return ("Econf", "Problem limit config have invalid value"), None
+            else:
+                    return ("Econf", "Problem config require limit or timelimit/memlimit"), None
+            testm_conf['limit'] = limits
 
-        chalmeta = {}
-        if 'metadata' in conf:
-            chalmeta = conf["metadata"]  # INFO: ioredir data
+            if 'metadata' in conf:
+                testm_conf['chalmeta'] = conf["metadata"]  # INFO: ioredir data
 
-        async with self.db.acquire() as con:
-            await con.execute('DELETE FROM "test_config" WHERE "pro_id" = $1;', int(pro_id))
-            await con.execute(
-                'UPDATE "problem" SET is_makefile = $1, check_type = $2, chalmeta = $3, "limit" = $4 WHERE pro_id = $5',
-                is_makefile, check_type, json.dumps(chalmeta), json.dumps(limits), pro_id
-            )
-
-            insert_values = []
-
+            test_group = {}
+            testdatas: dict[str, int] = {}
+            testdata_id_counter = 0
             for test_idx, test_conf in enumerate(conf["test"]):
                 for i in range(len(test_conf["data"])):
                     test_conf["data"][i] = str(test_conf["data"][i])
+                    if test_conf["data"][i] not in testdatas:
+                        testdatas[test_conf["data"][i]] = testdata_id_counter
+                        testdata_id_counter += 1
 
-                metadata = {"data": test_conf["data"]}
-                insert_values.append((pro_id, test_idx, test_conf['weight'], json.dumps(metadata)))
+                test_group[test_idx] = {
+                    'weight': int(test_conf['weight']),
+                    'testdatas': []
+                }
 
-            await con.executemany(
-                '''INSERT INTO "test_config"
-                    ("pro_id", "test_idx", "weight", "metadata")
-                    VALUES ($1, $2, $3, $4);''',
-                insert_values
-            )
-            await con.execute("REFRESH MATERIALIZED VIEW test_valid_rate;")
+            for test_idx, test_conf in enumerate(conf["test"]):
+                for i in range(len(test_conf["data"])):
+                    test_group[test_idx]['testdatas'].append(testdatas[test_conf["data"][i]])
 
+            testm_conf['testdatas'] = {}
+
+            for testdata, testdata_id in testdatas.items():
+                testm_conf['testdatas'][testdata_id] = {
+                    'id': testdata_id,
+                    'inputfile': f"{testdata}.in",
+                    'outputfile': f"{testdata}.out",
+                }
+
+            testm_conf['test_group'] = test_group
+            failed = False
+
+        finally:
+            if failed and os.path.exists(f"problem/{pro_id}"):
+                shutil.rmtree(f"problem/{pro_id}")
+
+        await self.update_test_config(pro_id, testm_conf)
         await self.rs.delete("prolist")
 
         return None, None

--- a/src/static/templ/acct/proclass-update.html
+++ b/src/static/templ/acct/proclass-update.html
@@ -1,4 +1,5 @@
 {% from services.pro import ProClassConst %}
+{% from utils.numeric import merge_list_to_str %}
 
 <script type="text/javascript">
     function init() {
@@ -104,8 +105,7 @@
 
         <div class="mb-1">
             <label>Problem List</label>
-            {% set list = str(proclass['list']) %}
-            <input class="form-control" id="list" type="text" value="{{ list[1:-1] }}">
+            <input class="form-control" id="list" type="text" value="{{ merge_list_to_str(proclass['list']) }}">
         </div>
 
         <div class="mb-1">

--- a/src/static/templ/manage/board/update.html
+++ b/src/static/templ/manage/board/update.html
@@ -113,6 +113,8 @@
 {% end %}
 {% block content %}
 {% from services.board import BoardConst %}
+{% from utils.numeric import merge_list_to_str %}
+
 <div class="col-lg-10 ms-lg-2 mt-lg-2">
 	<form id="form">
 		<div class="mb-1">
@@ -147,12 +149,12 @@
 
         <div class="mb-1">
             <label>Account List</label>
-            <input class="form-control" id="acct_list" value="{{ str(board['acct_list'])[1:-1].replace(' ', '') }}" type="text">
+            <input class="form-control" id="acct_list" value="{{ merge_list_to_str(board['acct_list']) }}" type="text">
         </div>
 
         <div class="mb-1">
             <label>Problem List</label>
-            <input class="form-control" id="pro_list" value="{{ str(board['pro_list'])[1:-1].replace(' ', '') }}" type="text">
+            <input class="form-control" id="pro_list" value="{{ merge_list_to_str(board['pro_list']) }}" type="text">
         </div>
 
 		<div class="mt-2">

--- a/src/static/templ/manage/pro/filemanager.html
+++ b/src/static/templ/manage/pro/filemanager.html
@@ -28,11 +28,20 @@
 
 					$("#code").find("code").html(file_content);
                     $("#preview-title").text(filename);
+                    $("#preview-title").attr("filename", filename);
+                    $("#preview-title").attr("path", path);
                     Prism.highlightAll();
 					preview_modal.show();
 				});
 			});
 		});
+
+        $("#previewModal").find("button.download").on('click', function(e) {
+            let filename = $("#preview-title").attr("filename");
+            let path = $("#preview-title").attr("path");
+
+            window.open(`/oj/be/manage/pro/filemanager?proid=${pro_id}&download=1&filename=${filename}&path=${path}`);
+        });
 
 		document.querySelectorAll('button.rename-single-file').forEach(el => {
 			el.addEventListener('click', function (e) {
@@ -238,7 +247,7 @@
 			</div>
 
 			<div class="modal-footer">
-                <a href="" id="downloadLink">Download(WIP)</a>
+				<button class="btn btn-primary download">Download</button>
 			</div>
 		</div>
 	</div>
@@ -309,7 +318,6 @@
                                             <button class="btn btn-primary me-2 update-single-file">Update</button>
                                             <button class="btn btn-danger me-2 delete-single-file">Delete</button>
                                             <button class="btn btn-secondary me-2 rename-single-file">Rename</button>
-                                            <button class="btn btn-secondary me-2 download-single-file">Download(WIP)</button>
                                         </div>
                                     </td>
 								</tr>

--- a/src/static/templ/manage/pro/update.html
+++ b/src/static/templ/manage/pro/update.html
@@ -256,7 +256,8 @@
 		<button type="button" class="btn btn-primary submit">Update</button>
     </form>
 
-	<a class="btn btn-primary" href="/oj/manage/pro/updatetests/?proid={{ pro['pro_id'] }}">Edit Testcases</a>
+	<a class="btn btn-primary" href="/oj/manage/pro/updatetests/?proid={{ pro['pro_id'] }}">Edit Subtask</a>
+	<a class="btn btn-primary" href="/oj/manage/pro/updatetestdata/?proid={{ pro['pro_id'] }}">Edit Testdata</a>
     <a class="btn btn-primary" href="/oj/manage/pro/filemanager/?proid={{ pro['pro_id'] }}">File Manager</a>
 </div>
 {% end %}

--- a/src/static/templ/manage/pro/updatetestdata.html
+++ b/src/static/templ/manage/pro/updatetestdata.html
@@ -1,0 +1,332 @@
+{% extends '../manage.html' %}
+{% block head %}
+<script src="/oj/third/prism.js"></script>
+<link rel="stylesheet" type="text/css" href="/oj/manage-pro.css">
+<link rel="stylesheet" href="/oj/third/prism.css">
+
+<script type="text/javascript" id="contjs">
+	function init() {
+		let pro_id = "{{ pro_id }}";
+		let preview_modal = new bootstrap.Modal(document.getElementById('previewModal'));
+        let add_single_file_modal = new bootstrap.Modal(document.getElementById('addSingleFileModal'));
+
+		document.querySelectorAll('a.preview-file').forEach(el => {
+			el.addEventListener('click', function (e) {
+				let tr = $(this).parents('tr');
+                let testdata_id = tr.attr('testdata_id');
+                let name = $(this).text();
+                let type = '';
+				if ($(this).hasClass('input')) {
+					type = 'input';
+				} else {
+					type = 'output';
+				}
+
+				let file_content = '';
+				$.post('/oj/be/manage/pro/updatetestdata', {
+					'reqtype': 'preview',
+					'pro_id': pro_id,
+                    'testdata_id': testdata_id,
+					'type': type,
+				}, function (res) {
+                    res = JSON.parse(res);
+                    file_content = res.data;
+
+					$("#code").find("code").html(file_content);
+                    $("#preview-title").text(`${name}`);
+                    $("#preview-title").attr("testdata_id", testdata_id);
+                    $("#preview-title").attr("testdata_type", type);
+                    Prism.highlightAll();
+					preview_modal.show();
+				});
+			});
+		});
+
+        $("#previewModal").find("button.download").on('click', function(e) {
+            let testdata_id = $("#preview-title").attr("testdata_id");
+            let type = $("#preview-title").attr("testdata_type");
+
+            window.open(`/oj/be/manage/pro/updatetestdata?proid=${pro_id}&download=1&testdata_id=${testdata_id}&type=${type}`);
+        });
+
+		document.querySelectorAll('button.delete-single-file').forEach(el => {
+			el.addEventListener('click', function (e) {
+				let testdata_id = $(this).parents('tr').attr('testdata_id');
+
+				$.post('/oj/be/manage/pro/updatetestdata', {
+					'reqtype': 'deletesinglefile',
+					'pro_id': pro_id,
+                    'testdata_id': testdata_id,
+				}, function (res) {
+					let msg = '';
+					let dialog_type = null;
+
+                    res = JSON.parse(res);
+                    if (res.status == 'S') {
+						dialog_type = index.DIALOG_TYPE.success;
+                        msg = `Delete Testdata ${testdata_id} successfully.`;
+                    } else {
+                        dialog_type = index.DIALOG_TYPE.error;
+                        msg = res.data;
+                    }
+
+					index.show_notify_dialog(msg, dialog_type);
+                    index.reload();
+				});
+			});
+		});
+
+        let j_add_single_file = $("#addSingleFileModal");
+        $("button.add-single-file").on('click', function(e) {
+            j_add_single_file.find("input.filename").val("");
+            j_add_single_file.find("input.inputfile").val("");
+            j_add_single_file.find("input.outputfile").val("");
+            add_single_file_modal.show();
+        });
+
+        j_add_single_file.find("button.cancel").on('click', function(e) {
+            add_single_file_modal.hide();
+        });
+
+        j_add_single_file.find("button.upload").on('click', function(e) {
+			function _update(input_pack_token, output_pack_token, filename) {
+				$.post('/oj/be/manage/pro/updatetestdata', {
+					'reqtype': 'addsinglefile',
+					'input_pack_token': input_pack_token,
+					'output_pack_token': output_pack_token,
+					'pro_id': pro_id,
+                    'filename': filename,
+				}, function (res) {
+                    let msg = '';
+					let dialog_type = null;
+
+                    res = JSON.parse(res);
+                    if (res.status == 'S') {
+						dialog_type = index.DIALOG_TYPE.success;
+                        msg = `Upload single file successfully`;
+                    } else {
+                        dialog_type = index.DIALOG_TYPE.error;
+                        msg = res.data;
+                    }
+
+					index.show_notify_dialog(msg, dialog_type);
+                    index.reload();
+				});
+			}
+            add_single_file_modal.hide();
+
+            let filename = j_add_single_file.find("input.filename").val();
+            if (filename.length == 0) {
+                index.show_notify_dialog('Filename should not empty', index.DIALOG_TYPE.error);
+                return;
+            }
+
+            let inputfiles = j_add_single_file.find("input.inputfile")[0].files;
+            let outputfiles = j_add_single_file.find("input.outputfile")[0].files;
+
+            if (inputfiles.length == 0 || outputfiles.length == 0) {
+                index.show_notify_dialog('File should not empty', index.DIALOG_TYPE.error);
+                return;
+            }
+
+            let inputfile = inputfiles[0];
+            let outputfile = outputfiles[0];
+
+            pack.get_token().done(function(input_token) {
+                index.create_progress_bar('Input File Uploading...');
+
+                pack.send(input_token, inputfile).done(function () {
+                    index.update_progress_bar_progress(100);
+                    pack.get_token().done(function(output_token) {
+                        index.update_progress_bar_progress(0);
+                        index.update_progress_bar_title("Output File Uploading...");
+
+                        pack.send(output_token, outputfile).done(function() {
+                            index.update_progress_bar_progress(100);
+                            index.remove_progress_bar();
+                            _update(input_token, output_token, filename);
+
+                            j_add_single_file.find("input.inputfile").val("");
+                            j_add_single_file.find("input.outputfile").val("");
+                        }).progress(function(prog) {
+                            index.update_progress_bar_progress(prog * 100);
+                        });
+                    });
+
+                }).progress(function(prog) {
+                    index.update_progress_bar_progress(prog * 100);
+                });
+            });
+        });
+
+		document.querySelectorAll('button.update-single-file').forEach(el => {
+			let type = null;
+			let j_input = $(el).siblings('input');
+
+            function _update(pack_token, testdata_id, group_idx) {
+				$.post('/oj/be/manage/pro/updatetestdata', {
+                    'reqtype': 'updatesinglefile',
+					'pack_token': pack_token,
+					'pro_id': pro_id,
+                    'testdata_id': testdata_id,
+					'type': type,
+				}, function (res) {
+                    let msg = '';
+					let dialog_type = null;
+
+                    res = JSON.parse(res);
+                    if (res.status == 'S') {
+						dialog_type = index.DIALOG_TYPE.success;
+                        msg = `Update Testdata ${testdata_id} with ${type} successfully.`;
+                    } else {
+                        dialog_type = index.DIALOG_TYPE.error;
+                        msg = res.data;
+                    }
+
+					index.show_notify_dialog(msg, dialog_type);
+                    index.reload();
+				});
+			}
+
+			el.addEventListener('click', function (e) {
+				j_input.click();
+				if ($(this).hasClass('input')) {
+					type = 'input';
+				} else {
+					type = 'output';
+				}
+				e.preventDefault();
+				e.stopPropagation();
+			});
+
+			j_input.on('change', function (e) {
+				if (e.target.files.length == 0) {
+					return;
+				}
+
+                let testdata_id = $(this).parents('tr').attr('testdata_id');
+				let group = $(this).parents('.accordion-collapse').attr('group');
+				let file = e.target.files[0];
+				pack.get_token().done(function(token) {
+					index.create_progress_bar('Uploading...');
+
+					pack.send(token, file).done(function () {
+						index.update_progress_bar_progress(100);
+						index.remove_progress_bar();
+						_update(token, testdata_id, group);
+						j_input.val(''); // for the same file upload
+
+					}).progress(function(prog) {
+						index.update_progress_bar_progress(prog * 100);
+					});
+				});
+			});
+        });
+	}
+</script>
+{% end %}
+
+{% block content %}
+<div class="modal fade" id="previewModal" aria-hidden="true">
+	<div class="modal-dialog modal-dialog-scrollable">
+		<div class="modal-content">
+			<div class="modal-header">
+                <h5 class="modal-title" id="preview-title">Preview Testdata File</h5>
+			</div>
+
+			<div class="modal-body">
+				<pre id="code"
+					data-language="markup"
+					data-prismjs-copy="複製" data-prismjs-copy-error="Copy Failed!!!" data-prismjs-copy-success="Copy Success!!!"
+				>
+					<code class="language-markup"></code>
+				</pre>
+			</div>
+
+			<div class="modal-footer">
+				<button class="btn btn-primary download">Download</button>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="modal fade" id="addSingleFileModal" aria-hidden="true">
+	<div class="modal-dialog modal-dialog-scrollable">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title" id="preview-title">Add Single File</h5>
+			</div>
+
+			<div class="modal-body">
+                <form>
+                    <label for="" class="form-label">Filename</label>
+                    <input class="form-control filename" type="text">
+                    <label for="" class="form-label">Input File</label>
+                    <input type="file" class="form-control inputfile">
+                    <label for="" class="form-label">Output File</label>
+                    <input type="file" class="form-control outputfile">
+                </form>
+			</div>
+
+			<div class="modal-footer">
+				<button class="btn btn-primary upload">Upload</button>
+				<button class="btn btn-secondary cancel">Cancel</button>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<div class="col-lg-10 ms-lg-2 mt-lg-2">
+    <button class="btn btn-primary add-single-file">
+        Add Single File
+    </button>
+    <!-- <button class="btn btn-primary">Add Multiple Files (WIP)</button>
+    <button class="btn btn-danger">Delete All Files (WIP)</button>
+    <button class="btn btn-primary">Download All Files (WIP)</button> -->
+    <table class="table table-hover table-sm table-responsive-sm my-3">
+        <thead>
+            <tr>
+                <th scope="col">ID</th>
+                <th scope="col">Input Filename</th>
+                <th scope="col">Output Filename</th>
+                <th scope="col">Operation</th>
+            </tr>
+        </thead>
+
+        <tbody>
+            {% for testdata_id, testdata in tests['testdatas'].items() %}
+                <tr testdata_id="{{ testdata_id }}">
+                    <th scope="row">{{ testdata_id }}</th>
+                    <td><a class="preview-file input">{{ testdata['inputfile'] }}</a></td>
+                    <td><a class="preview-file output">{{ testdata['outputfile'] }}</a></td>
+                    <td>
+                        <div class="btn-toolbar">
+                            <div class="dropdown me-2">
+                                <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                    Update
+                                </button>
+                                <ul class="dropdown-menu">
+                                    <li>
+                                        <input type="file" style="display: none;">
+                                        <button class="btn btn-primary dropdown-item update-single-file input">Input</button>
+                                    </li>
+
+                                    <li>
+                                        <input type="file" style="display: none;">
+                                        <button class="btn btn-primary dropdown-item update-single-file output">Output</button>
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <button class="btn btn-danger me-2 delete-single-file">Delete</button>
+                        </div>
+                    </td>
+                </tr>
+            {% end %}
+        </tbody>
+</table>
+</div>
+
+{% end %}

--- a/src/static/templ/manage/pro/updatetests.html
+++ b/src/static/templ/manage/pro/updatetests.html
@@ -7,45 +7,15 @@
 <script type="text/javascript" id="contjs">
 	function init() {
 		let pro_id = "{{ pro_id }}";
-		let preview_modal = new bootstrap.Modal(document.getElementById('previewModal'));
-        let add_single_file_modal = new bootstrap.Modal(document.getElementById('addSingleFileModal'));
-
-		document.querySelectorAll('a.preview-file').forEach(el => {
-			el.addEventListener('click', function (e) {
-				let tr = $(this).parents('tr');
-                let filename = tr.attr('filename');
-                let type = '';
-				if ($(this).hasClass('input')) {
-					type = 'in';
-				} else {
-					type = 'out';
-				}
-
-				let file_content = '';
-				$.post('/oj/be/manage/pro/updatetests', {
-					'reqtype': 'preview',
-					'pro_id': pro_id,
-                    'filename': filename,
-					'type': type,
-				}, function (res) {
-                    res = JSON.parse(res);
-                    file_content = res.data;
-
-					$("#code").find("code").html(file_content);
-                    $("#preview-title").text(`${filename}.${type}`);
-                    Prism.highlightAll();
-					preview_modal.show();
-				});
-			});
-		});
+        let re = /^(\d+(-\d+)?)(\s*,\s*\d+(-\d+)?)*$/;
 
         document.querySelectorAll('.edit-weight').forEach(el => {
 			el.addEventListener('click', function (e) {
 				let group = $(this).parents('.accordion-collapse').attr('group');
+                let weight = $(this).siblings('#weight').val();
 
-				let weight = parseInt(prompt('new weight', $(this).attr('weight')));
 				if (isNaN(weight)) {
-					alert('請輸入數字');
+					alert('Weight must be a number');
 					return;
 				}
 
@@ -72,210 +42,8 @@
 			});
 		});
 
-        document.querySelectorAll('button.rename-single-file').forEach(el => {
-			el.addEventListener('click', function (e) {
-                let old_filename = $(this).parents('tr').attr('filename');
-                let new_filename = prompt('New testcase filename', old_filename);
-
-				$.post('/oj/be/manage/pro/updatetests', {
-                    'reqtype': 'renamesinglefile',
-					'pro_id': pro_id,
-                    'old_filename': old_filename,
-                    'new_filename': new_filename,
-				}, function (res) {
-                    					let msg = '';
-					let dialog_type = null;
-
-                    res = JSON.parse(res);
-                    if (res.status == 'S') {
-						dialog_type = index.DIALOG_TYPE.success;
-                        msg = `Rename ${old_filename} to ${new_filename} successfully.`;
-                    } else {
-                        msg = res.data;
-                    }
-
-					index.show_notify_dialog(msg, dialog_type);
-                    index.reload();
-				});
-			});
-        });
-
-		document.querySelectorAll('button.delete-single-file').forEach(el => {
-			el.addEventListener('click', function (e) {
-				let filename = $(this).parents('tr').attr('filename');
-
-				$.post('/oj/be/manage/pro/updatetests', {
-					'reqtype': 'deletesinglefile',
-					'pro_id': pro_id,
-                    'filename': filename,
-				}, function (res) {
-					let msg = '';
-					let dialog_type = null;
-					if (res[0] == 'E') {
-						dialog_type = index.DIALOG_TYPE.error;
-						if (res == 'Enoext') {
-							msg = 'File not found';
-						} else {
-							msg = res;
-						}
-					} else {
-						dialog_type = index.DIALOG_TYPE.success;
-                        msg = `Delete Input & Output File ${filename} successfully.`;
-					}
-
-					index.show_notify_dialog(msg, dialog_type);
-                    index.reload();
-				});
-			});
-		});
-
-        let j_add_single_file = $("#addSingleFileModal");
-        $("button.add-single-file").on('click', function(e) {
-            j_add_single_file.find("input.filename").val("");
-            j_add_single_file.find("input.inputfile").val("");
-            j_add_single_file.find("input.outputfile").val("");
-            add_single_file_modal.show();
-        });
-
-        j_add_single_file.find("button.cancel").on('click', function(e) {
-            add_single_file_modal.hide();
-        });
-
-        j_add_single_file.find("button.upload").on('click', function(e) {
-			function _update(input_pack_token, output_pack_token, filename) {
-				$.post('/oj/be/manage/pro/updatetests', {
-					'reqtype': 'addsinglefile',
-					'input_pack_token': input_pack_token,
-					'output_pack_token': output_pack_token,
-					'pro_id': pro_id,
-                    'filename': filename,
-				}, function (res) {
-                    let msg = '';
-					let dialog_type = null;
-
-                    res = JSON.parse(res);
-                    if (res.status == 'S') {
-						dialog_type = index.DIALOG_TYPE.success;
-                        msg = `Upload single file successfully`;
-                    } else {
-                        msg = res.data;
-                    }
-
-					index.show_notify_dialog(msg, dialog_type);
-                    index.reload();
-				});
-			}
-            add_single_file_modal.hide();
-
-            let filename = j_add_single_file.find("input.filename").val();
-            if (filename.length == 0) {
-                index.show_notify_dialog('Filename should not empty', index.DIALOG_TYPE.error);
-                return;
-            }
-
-            let inputfiles = j_add_single_file.find("input.inputfile")[0].files;
-            let outputfiles = j_add_single_file.find("input.outputfile")[0].files;
-
-            if (inputfiles.length == 0 || outputfiles.length == 0) {
-                index.show_notify_dialog('File should not empty', index.DIALOG_TYPE.error);
-                return;
-            }
-
-            let inputfile = inputfiles[0];
-            let outputfile = outputfiles[0];
-
-            pack.get_token().done(function(input_token) {
-                index.create_progress_bar('Input File Uploading...');
-
-                pack.send(input_token, inputfile).done(function () {
-                    index.update_progress_bar_progress(100);
-                    pack.get_token().done(function(output_token) {
-                        index.update_progress_bar_progress(0);
-                        index.update_progress_bar_title("Output File Uploading...");
-
-                        pack.send(output_token, outputfile).done(function() {
-                            index.update_progress_bar_progress(100);
-                            index.remove_progress_bar();
-                            _update(input_token, output_token, filename);
-
-                            j_add_single_file.find("input.inputfile").val("");
-                            j_add_single_file.find("input.outputfile").val("");
-                        }).progress(function(prog) {
-                            index.update_progress_bar_progress(prog * 100);
-                        });
-                    });
-
-                }).progress(function(prog) {
-                    index.update_progress_bar_progress(prog * 100);
-                });
-            });
-        });
-
-		document.querySelectorAll('button.update-single-file').forEach(el => {
-			let type = null;
-			let j_input = $(el).siblings('input');
-
-            function _update(pack_token, filename, group_idx) {
-				$.post('/oj/be/manage/pro/updatetests', {
-                    'reqtype': 'updatesinglefile',
-					'pack_token': pack_token,
-					'pro_id': pro_id,
-                    'filename': filename,
-					'type': type,
-				}, function (res) {
-                    					let msg = '';
-					let dialog_type = null;
-
-                    res = JSON.parse(res);
-                    if (res.status == 'S') {
-						dialog_type = index.DIALOG_TYPE.success;
-                        msg = `Update ${type} File ${filename} successfully.`;
-                    } else {
-                        msg = res.data;
-                    }
-
-					index.show_notify_dialog(msg, dialog_type);
-                    index.reload();
-				});
-			}
-
-			el.addEventListener('click', function (e) {
-				j_input.click();
-				if ($(this).hasClass('input')) {
-					type = 'input';
-				} else {
-					type = 'output';
-				}
-				e.preventDefault();
-				e.stopPropagation();
-			});
-
-			j_input.on('change', function (e) {
-				if (e.target.files.length == 0) {
-					return;
-				}
-
-                let filename = $(this).parents('tr').attr('filename');
-				let group = $(this).parents('.accordion-collapse').attr('group');
-				let file = e.target.files[0];
-				pack.get_token().done(function(token) {
-					index.create_progress_bar('Uploading...');
-
-					pack.send(token, file).done(function () {
-						index.update_progress_bar_progress(100);
-						index.remove_progress_bar();
-						_update(token, filename, group);
-						j_input.val(''); // for the same file upload
-
-					}).progress(function(prog) {
-						index.update_progress_bar_progress(prog * 100);
-					});
-				});
-			});
-        });
-
         $("button.add-group").on('click', function(e) {
-            let weight = parseInt(prompt('new test group weight: '));
+            let weight = parseInt(prompt('New test group weight: '));
             $.post('/oj/be/manage/pro/updatetests', {
                 'reqtype': 'addtaskgroup',
                 'pro_id': pro_id,
@@ -322,16 +90,20 @@
             });
         });
 
-        document.querySelectorAll('button.add-single-testcase').forEach(el => {
+        document.querySelectorAll('button.set-testdatas').forEach(el => {
             el.addEventListener('click', function(e) {
                 let group = $(this).parents('.accordion-collapse').attr('group');
-                let testcase = prompt("");
-                if (testcase.length == 0) return;
+                let testdatas = $(this).siblings('#testdatas').val();
+                if (!re.test(testdatas)) {
+                    index.show_notify_dialog("Testdatas wrong. Please follow the instruction", index.DIALOG_TYPE.warning);
+                    return;
+                }
+
 				$.post('/oj/be/manage/pro/updatetests', {
-					'reqtype': 'addsingletestcase',
+					'reqtype': 'settestdata',
 					'pro_id': pro_id,
                     'group': group,
-                    'testcase': testcase,
+                    'testdatas': testdatas,
 				}, function (res) {
                     let msg = '';
 					let dialog_type = null;
@@ -339,34 +111,7 @@
                     res = JSON.parse(res);
                     if (res.status == 'S') {
 						dialog_type = index.DIALOG_TYPE.success;
-                        msg = `Add single testcase ${testcase} to task group #${group} successfully.`;
-                    } else {
-                        msg = res.data;
-                    }
-
-					index.show_notify_dialog(msg, dialog_type);
-                    index.reload();
-				});
-            });
-        });
-
-        document.querySelectorAll('button.delete-single-testcase').forEach(el => {
-            el.addEventListener('click', function(e) {
-                let group = $(this).parents('.accordion-collapse').attr('group');
-                let testcase = $(this).parents('tr').attr('testcase');
-				$.post('/oj/be/manage/pro/updatetests', {
-					'reqtype': 'deletesingletestcase',
-					'pro_id': pro_id,
-                    'group': group,
-                    'testcase': testcase,
-				}, function (res) {
-                    let msg = '';
-					let dialog_type = null;
-
-                    res = JSON.parse(res);
-                    if (res.status == 'S') {
-						dialog_type = index.DIALOG_TYPE.success;
-                        msg = `Delete single testcase ${testcase} from task group #${group} successfully.`;
+                        msg = `Task group #${group} set testdatas successfully.`;
                     } else {
                         msg = res.data;
                     }
@@ -381,65 +126,15 @@
 {% end %}
 
 {% block content %}
-<div class="modal fade" id="previewModal" aria-hidden="true">
-	<div class="modal-dialog modal-dialog-scrollable">
-		<div class="modal-content">
-			<div class="modal-header">
-                <h5 class="modal-title" id="preview-title">Preview Testcase File</h5>
-			</div>
-
-			<div class="modal-body">
-				<pre id="code"
-					data-language="markup"
-					data-prismjs-copy="複製" data-prismjs-copy-error="Copy Failed!!!" data-prismjs-copy-success="Copy Success!!!"
-				>
-					<code class="language-markup"></code>
-				</pre>
-			</div>
-
-			<div class="modal-footer">
-				<button class="btn btn-primary">Download(WIP)</button>
-			</div>
-		</div>
-
-	</div>
-</div>
-
-<div class="modal fade" id="addSingleFileModal" aria-hidden="true">
-	<div class="modal-dialog modal-dialog-scrollable">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h5 class="modal-title" id="preview-title">Add Single File</h5>
-			</div>
-
-			<div class="modal-body">
-                <form>
-                    <label for="" class="form-label">Filename</label>
-                    <input class="form-control filename" type="text">
-                    <label for="" class="form-label">Input File</label>
-                    <input type="file" class="form-control inputfile">
-                    <label for="" class="form-label">Output File</label>
-                    <input type="file" class="form-control outputfile">
-                </form>
-			</div>
-
-			<div class="modal-footer">
-				<button class="btn btn-primary upload">Upload</button>
-				<button class="btn btn-secondary cancel">Cancel</button>
-			</div>
-		</div>
-
-	</div>
-</div>
-
-<div class="col-lg-5 ms-lg-2 mt-lg-2">
+{% from utils.numeric import merge_list_to_str %}
+<div class="col-lg-10 ms-lg-2 mt-lg-2">
 	<button class="btn btn-primary add-group">Add Task Group</button>
 
 	<div class="accordion" id="tests">
     {% for test_group_idx, test_conf in tests['test_group'].items() %}
 		<div class="accordion-item">
 			<h2 class="accordion-header">
-					<button
+				    <button
 						class="accordion-button"
 						type="button"
 						data-bs-toggle="collapse"
@@ -452,93 +147,22 @@
 			</h2>
 			<div id="collapse{{ test_group_idx }}" class="accordion-collapse collapse" data-bs-parent="#tests" group="{{ test_group_idx }}">
 				<div class="accordion-body">
-                    <button class="btn btn-primary add-single-testcase">Add Single Testcase</button>
+                    <button class="btn btn-danger delete-group">Delete Current Task Group</button>
 
-                    <button class="btn btn-primary edit-weight" weight="{{ test_conf['weight'] }}">Edit Task Group Weight</button>
-                    <button class="btn btn-primary delete-group">Delete Current Task Group</button>
+                    <div class="input-group mb-3">
+                        <input id="weight" class="form-control mb-1" type="number" value="{{ test_conf['weight'] }}" placeholder="Weight">
+                        <button class="btn btn-primary edit-weight">Update weight</button>
+                    </div>
 
-					<table class="table table-hover table-sm table-responsive-sm my-3">
-						<thead>
-							<tr>
-								<th scope="col">#</th>
-                                <th scope="col">Filename</th>
-								<th scope="col">Operation</th>
-							</tr>
-						</thead>
-
-						<tbody>
-                            {% for idx, testcase in enumerate(test_conf['metadata']['data']) %}
-                                <tr idx="{{ idx }}" testcase="{{ testcase }}">
-									<th scope="row">{{ idx + 1 }}</th>
-                                    <td>{{ testcase }}</td>
-									<td>
-										<div class="btn-toolbar">
-											<button class="btn btn-danger me-2 delete-single-testcase">Delete</button>
-										</div>
-									</td>
-								</tr>
-							{% end %}
-						</tbody>
-					</table>
+                    <label for="testdatas" class="form-label">Testdata id. Starts from 0, for examples: <code>0</code>, <code>1-4</code>, <code>2,4,9-11,13-18</code></label>
+                    <div class="input-group mb-3">
+                        <input id="testdatas" class="form-control mb-1" type="text" value="{{ merge_list_to_str(test_conf['testdatas']) }}" placeholder="Testdata">
+                        <button class="btn btn-primary set-testdatas">Update Testdatas</button>
+                    </div>
 				</div>
 			</div>
 		</div>
 	{% end %}
 	</div>
 </div>
-
-<div class="col-lg-5 ms-lg-2 mt-lg-2">
-    <button class="btn btn-primary add-single-file">
-        Add Single File
-    </button>
-    <!-- <button class="btn btn-primary">Add Multiple Files (WIP)</button>
-    <button class="btn btn-danger">Delete All Files (WIP)</button>
-    <button class="btn btn-primary">Download All Files (WIP)</button> -->
-    <table class="table table-hover table-sm table-responsive-sm my-3">
-        <thead>
-            <tr>
-                <th scope="col">#</th>
-                <th scope="col">Filename</th>
-                <th scope="col">Input</th>
-                <th scope="col">Output</th>
-                <th scope="col">Operation</th>
-            </tr>
-        </thead>
-
-        <tbody>
-            {% for idx, filename in enumerate(files) %}
-                <tr idx="{{ idx }}" filename="{{ filename }}">
-                    <th scope="row">{{ idx + 1 }}</th>
-                    <td>{{ filename }}</td>
-                    <td><a class="preview-file input">Show Input</a></td>
-                    <td><a class="preview-file output">Show Output</a></td>
-                    <td>
-                        <div class="btn-toolbar">
-                            <div class="dropdown me-2">
-                                <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                    Update
-                                </button>
-                                <ul class="dropdown-menu">
-                                    <li>
-                                        <input type="file" style="display: none;">
-                                        <button class="btn btn-primary dropdown-item update-single-file input">Input</button>
-                                    </li>
-
-                                    <li>
-                                        <input type="file" style="display: none;">
-                                        <button class="btn btn-primary dropdown-item update-single-file output">Output</button>
-                                    </li>
-                                </ul>
-                            </div>
-
-                            <button class="btn btn-danger me-2 delete-single-file">Delete</button>
-                            <button class="btn btn-secondary me-2 rename-single-file">Rename</button>
-                        </div>
-                    </td>
-                </tr>
-            {% end %}
-        </tbody>
-</table>
-</div>
-
 {% end %}

--- a/src/static/templ/manage/proclass/add.html
+++ b/src/static/templ/manage/proclass/add.html
@@ -4,7 +4,7 @@
 <script type="text/javascript">
     function init() {
         let j_form = $("#form");
-        let re = /[^0-9,\ ]/;
+        let re = /^(\d+(-\d+)?)(\s*,\s*\d+(-\d+)?)*$/;
 
         let desc_textarea = document.getElementById('desc');
         let desc_preview = document.getElementById('descPreviewDialog');
@@ -28,8 +28,8 @@
             let list = j_form.find("#list").val();
             let proclass_type = j_form.find("#type").val();
 
-            if (list.length === 0 || re.test(list)) {
-                index.show_notify_dialog("Problem List錯誤，請輸入數字、逗號與空白設定，範例：1, 2, 3", index.DIALOG_TYPE.warning);
+            if (list.length === 0 || !re.test(list)) {
+                index.show_notify_dialog("Problem List錯誤，請輸入數字、逗號、減號與空白做設定，範例：1, 2, 3, 5-7", index.DIALOG_TYPE.warning);
                 return;
             }
 

--- a/src/static/templ/manage/proclass/update.html
+++ b/src/static/templ/manage/proclass/update.html
@@ -4,7 +4,7 @@
 <script type="text/javascript">
     function init() {
         let j_form = $("#form");
-        let re = /[^0-9,\ ]/;
+        let re = /^(\d+(-\d+)?)(\s*,\s*\d+(-\d+)?)*$/;
 
         j_form.find("#desc").val(index.unescape_html(`{{ markdown_escape(proclass['desc']) }}`));
 
@@ -30,8 +30,8 @@
             let list = j_form.find("#list").val();
             let proclass_type = j_form.find("#type").val();
 
-            if (list.length === 0 || re.test(list)) {
-                index.show_notify_dialog("Problem List錯誤，請輸入數字、逗號與空白設定，範例：1, 2, 3", index.DIALOG_TYPE.warning);
+            if (list.length === 0 || !re.test(list)) {
+                index.show_notify_dialog("Problem List錯誤，請輸入數字、逗號、減號與空白做設定，範例：1, 2, 3, 5-7", index.DIALOG_TYPE.warning);
                 return;
             }
 
@@ -76,6 +76,7 @@
 {% end %}
 {% block content %}
 {% from services.pro import ProClassConst %}
+{% from utils.numeric import merge_list_to_str %}
 
 <div class="modal fade" id="descPreviewDialog" tabindex="-1" aria-hidden="true">
 <div class="modal-dialog modal-dialog-scrollable modal-xl">
@@ -109,8 +110,7 @@
 
         <div class="mb-1">
             <label>Problem List</label>
-            {% set list = str(proclass['list']) %}
-            <input class="form-control" id="list" type="text" value="{{ list[1:-1] }}">
+            <input class="form-control" id="list" type="text" value="{{ merge_list_to_str(proclass['list']) }}">
         </div>
 
         <div class="mb-1">

--- a/src/tests/e2e/board.py
+++ b/src/tests/e2e/board.py
@@ -32,7 +32,7 @@ class BoardTest(AsyncTest):
                              (now - datetime.timedelta(days=7)).strftime('%Y/%m/%d %H:%M'))
             self.assertEqual(html.select_one('input#datepickerEndInput').attrs.get('value'),
                              (now + datetime.timedelta(days=7)).strftime('%Y/%m/%d %H:%M'))
-            self.assertEqual(html.select_one('input#pro_list').attrs.get('value').strip(), '1,2')
+            self.assertEqual(html.select_one('input#pro_list').attrs.get('value').strip(), '1-2')
             self.assertEqual(html.select_one('input#acct_list').attrs.get('value').strip(), '1')
 
             html = self.get_html('board/1', admin_session)

--- a/src/tests/e2e/manage/pro/filemanager.py
+++ b/src/tests/e2e/manage/pro/filemanager.py
@@ -1,3 +1,4 @@
+import re
 import os
 import copy
 import json
@@ -60,6 +61,18 @@ class ManageProFileManagerTest(AsyncTest):
                 ],
                 admin_session
             )
+
+            # NOTE: download
+            res = admin_session.get('manage/pro/filemanager?proid=1&download=1&filename=cont.html&path=http')
+            self.assertIsNotNone(res.headers.get("content-disposition"))
+            self.assertEqual(re.findall(r'filename="?([^";]+)"?', res.headers.get("content-disposition"))[0], "cont.html")
+            self.assertEqual(res.content.decode('utf-8'), open('tests/static_file/toj3/http/cont.html').read())
+
+            res = admin_session.get('manage/pro/filemanager?proid=1&download=1&filename=test.html&path=http')
+            self.assertAPIReturnValue(res.text, ('Enoext', 'File not found'))
+
+            res = admin_session.get('manage/pro/filemanager?proid=1&download=1&filename=passwd&path=/etc')
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Invalid basepath'))
 
             # NOTE: addsinglefile
             pack_token = await self._upload_file('tests/static_file/toj3/3.in', admin_session)

--- a/src/tests/e2e/manage/pro/specialscore.py
+++ b/src/tests/e2e/manage/pro/specialscore.py
@@ -50,10 +50,10 @@ class ManageProSpecialScoreTest(AsyncTest):
             })
             self.assertAPIReturnSuccess(res.text)
 
-            # NOTE: In this case, the testcase is not important, but we need at least one testcase because without any test cases, the judge cannot function.
+            # NOTE: In this case, the testdata is not important, but we need at least one testdata because without any test cases, the judge cannot function.
             inputfile_token = await self._upload_file('tests/static_file/toj3/3.in', admin_session)
             outputfile_token = await self._upload_file('tests/static_file/toj3/3.out', admin_session)
-            res = admin_session.post('manage/pro/updatetests', data={
+            res = admin_session.post('manage/pro/updatetestdata', data={
                 'reqtype': 'addsinglefile',
                 'pro_id': expected_pro_id,
                 'filename': '1',
@@ -94,9 +94,9 @@ class ManageProSpecialScoreTest(AsyncTest):
             self.assertAPIReturnSuccess(res.text)
 
             res = admin_session.post('manage/pro/updatetests?proid=1', data={
-                'reqtype': 'addsingletestcase',
+                'reqtype': 'settestdata',
                 'pro_id': 5,
-                'testcase': '1',
+                'testdatas': '0',
                 'group': 0,
             })
             self.assertAPIReturnSuccess(res.text)
@@ -144,9 +144,9 @@ class ManageProSpecialScoreTest(AsyncTest):
                 self.assertAPIReturnSuccess(res.text)
 
                 res = admin_session.post('manage/pro/updatetests?proid=1', data={
-                    'reqtype': 'addsingletestcase',
+                    'reqtype': 'settestdata',
                     'pro_id': 6,
-                    'testcase': '1',
+                    'testdatas': '0',
                     'group': group_idx,
                 })
                 self.assertAPIReturnSuccess(res.text)

--- a/src/tests/e2e/manage/pro/updatetests.py
+++ b/src/tests/e2e/manage/pro/updatetests.py
@@ -1,3 +1,4 @@
+import re
 import os
 import copy
 import json
@@ -14,7 +15,7 @@ class ManageProUpdateTestsTest(AsyncTest):
 
         return pack_token
 
-    def assertTable(self, default_data: dict, assert_tables: list[dict], session):
+    def assertTable(self, url: str, default_data: dict, assert_tables: list[dict], session):
         for table in assert_tables:
             equal_value = table.pop("equal_value")
 
@@ -22,35 +23,47 @@ class ManageProUpdateTestsTest(AsyncTest):
             for key, val in table.items():
                 d[key] = val
 
-            res = session.post('manage/pro/updatetests', data=d)
+            res = session.post(url, data=d)
             self.assertAPIReturnValue(res.text, equal_value)
 
     async def main(self):
         with AccountContext("admin@test", "testtest") as admin_session:
             # NOTE: preview
-            res = admin_session.post('manage/pro/updatetests?proid=1', data={
+            res = admin_session.post('manage/pro/updatetestdata?proid=1', data={
                 'reqtype': 'preview',
                 'pro_id': 1,
-                'filename': '1',
-                'type': 'out',
+                'testdata_id': 0,
+                'type': 'output',
             })
             self.assertEqual(json.loads(res.text)['data'], open('tests/static_file/toj3/res/testdata/1.out').read())
 
             self.assertTable(
+                'manage/pro/updatetestdata',
                 {
                     'reqtype': 'preview',
                     'pro_id': 1,
-                    'filename': '1',
-                    'type': 'out',
+                    'testdata_id': 0,
+                    'type': 'output',
                 },
                 [
                     {'pro_id': '100', 'equal_value': ('Enoext', 'Problem not found')}, # problem not found
-                    {'filename': '2', 'equal_value': ('Efile', 'File too large')}, # file has more than 25 lines or cannot be decoded as UTF-8.
-                    {'filename': '../conf.json', 'equal_value': ('Eacces', 'Permission denied')}, # illegal filepath access
-                    {'filename': '5', 'equal_value': ('Enoext', 'File not found')} # file not found
+                    {'testdata_id': 1, 'equal_value': ('Efile', 'File too large')}, # file has more than 25 lines or cannot be decoded as UTF-8.
+                    {'testdata_id': 100, 'equal_value': ('Enoext', 'Testdata not found')},
                 ],
                 admin_session
             )
+
+            # NOTE: download file
+            res = admin_session.get('manage/pro/updatetestdata?proid=1&download=1&testdata_id=0&type=output')
+            self.assertIsNotNone(res.headers.get("content-disposition"))
+            self.assertEqual(re.findall(r'filename="?([^";]+)"?', res.headers.get("content-disposition"))[0], "1.out")
+            self.assertEqual(res.content.decode('utf-8'), open('tests/static_file/toj3/res/testdata/1.out').read())
+
+            res = admin_session.get('manage/pro/updatetestdata?proid=1&download=1&testdata_id=123&type=output')
+            self.assertAPIReturnValue(res.text, ('Enoext', 'Testdata not found'))
+
+            res = admin_session.get('manage/pro/updatetestdata?proid=1&download=1&testdata_id=0&type=what')
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Invalid testdata file type'))
 
             # NOTE: updateweight
             res = admin_session.post('manage/pro/updatetests?proid=1', data={
@@ -88,7 +101,7 @@ class ManageProUpdateTestsTest(AsyncTest):
             # NOTE: addsinglefile
             inputfile_token = await self._upload_file('tests/static_file/toj3/3.in', admin_session)
             outputfile_token = await self._upload_file('tests/static_file/toj3/3.out', admin_session)
-            res = admin_session.post('manage/pro/updatetests?proid=1', data={
+            res = admin_session.post('manage/pro/updatetestdata?proid=1', data={
                 'reqtype': 'addsinglefile',
                 'pro_id': 1,
                 'filename': '3',
@@ -100,8 +113,15 @@ class ManageProUpdateTestsTest(AsyncTest):
             self.assertTrue(os.path.exists('problem/1/res/testdata/3.out'))
             self.assertEqual(open('tests/static_file/toj3/3.in').read(), open('problem/1/res/testdata/3.in').read())
             self.assertEqual(open('tests/static_file/toj3/3.out').read(), open('problem/1/res/testdata/3.out').read())
+            html = self.get_html('manage/pro/updatetestdata?proid=1', admin_session)
+            trs = html.select('tbody > tr')
+            self.assertEqual(len(trs), 3)
+            self.assertEqual(trs[2].attrs['testdata_id'], '2')
+            self.assertEqual(trs[2].select_one('a.input').text.strip(), '3.in')
+            self.assertEqual(trs[2].select_one('a.output').text.strip(), '3.out')
 
             self.assertTable(
+                'manage/pro/updatetestdata',
                 {
                     'reqtype': 'addsinglefile',
                     'pro_id': 1,
@@ -117,35 +137,17 @@ class ManageProUpdateTestsTest(AsyncTest):
                 admin_session
             )
 
-            # NOTE: addsingletestcase
+            # NOTE: settestdata (add testdata to range)
             res = admin_session.post('manage/pro/updatetests?proid=1', data={
-                'reqtype': 'addsingletestcase',
+                'reqtype': 'settestdata',
                 'pro_id': 1,
-                'testcase': '3',
+                'testdatas': '0-2',
                 'group': 2,
             })
             self.assertAPIReturnSuccess(res.text)
             html = self.get_html('manage/pro/updatetests?proid=1', admin_session)
             groups = html.select_one('div#tests').select('div.accordion-item')
-            testcase_trs = groups[2].select('tbody > tr')
-            self.assertEqual(testcase_trs[0].select('td')[0].text.strip(), '3')
-            self.assertEqual(testcase_trs[0].attrs.get('testcase'), '3')
-
-            self.assertTable(
-                {
-                    'reqtype': 'addsingletestcase',
-                    'pro_id': 1,
-                    'testcase': '3',
-                    'group': 2,
-                },
-                [
-                    {'pro_id': '100', 'equal_value': ('Enoext', 'Problem not found')}, # problem not found,
-                    {'testcase': '300', 'equal_value': ('Enoext', 'Testcase file not found')}, # testcase not found
-                    {'group': '300', 'equal_value': ('Enoext', 'Group not found')}, # group not found
-                    {'testcase': '3', 'equal_value': ('Eexist', 'Testcase already exists')}, # testcase already exists
-                ],
-                admin_session
-            )
+            self.assertEqual(groups[2].select_one('#testdatas').attrs['value'].strip(), "0-2")
 
             def callback():
                 res = admin_session.post('submit', data={
@@ -157,64 +159,30 @@ class ManageProUpdateTestsTest(AsyncTest):
             chal_states_result = self.get_chal_state(chal_id=1, session=admin_session)
             self.assertEqual(chal_states_result, [ChalConst.STATE_AC] * len(chal_states_result))
 
-            # NOTE: renamesinglefile
-            res = admin_session.post('manage/pro/updatetests?proid=1', data={
-                'reqtype': 'renamesinglefile',
-                'pro_id': 1,
-                'old_filename': '3',
-                'new_filename': '4',
-            })
-            self.assertAPIReturnSuccess(res.text)
-            self.assertTrue(os.path.exists('problem/1/res/testdata/4.in'))
-            self.assertTrue(os.path.exists('problem/1/res/testdata/4.out'))
-            self.assertEqual(open('tests/static_file/toj3/3.in').read(), open('problem/1/res/testdata/4.in').read())
-            self.assertEqual(open('tests/static_file/toj3/3.out').read(), open('problem/1/res/testdata/4.out').read())
-            html = self.get_html('manage/pro/updatetests?proid=1', admin_session)
-            groups = html.select_one('div#tests').select('div.accordion-item')
-            testcase_trs = groups[2].select('tbody > tr')
-            self.assertEqual(testcase_trs[0].select('td')[0].text.strip(), '4')
-            self.assertEqual(testcase_trs[0].attrs.get('testcase'), '4')
-
-            self.assertTable(
-                {
-                    'reqtype': 'renamesinglefile',
-                    'pro_id': 1,
-                    'old_filename': '3',
-                    'new_filename': '4',
-                },
-                [
-                    {'pro_id': '100', 'equal_value': ('Enoext', 'Problem not found')}, # problem not found,
-                    {'old_filename': '../conf.json', 'new_filename': '../tw87.json', 'equal_value': ('Eacces', 'Permission denied')}, # illegal filepath access
-                    {'old_filename': '4', 'new_filename': '4', 'equal_value': ('Eexist', 'New filename already exists')}, # new file already exists
-                    {'old_filename': '5', 'equal_value': ('Enoext', 'Old filename not found')}, # old file not found
-                ],
-                admin_session
-            )
-
             # NOTE: updatesinglefile
             pack_token = await self._upload_file('tests/static_file/toj3/3.out.incorrect', admin_session)
-            res = admin_session.post('manage/pro/updatetests?proid=1', data={
+            res = admin_session.post('manage/pro/updatetestdata?proid=1', data={
                 'reqtype': 'updatesinglefile',
                 'pro_id': 1,
-                'filename': '4',
+                'testdata_id': 2,
                 'type': 'output',
                 'pack_token': pack_token,
             })
             self.assertAPIReturnSuccess(res.text)
 
             self.assertTable(
+                'manage/pro/updatetestdata',
                 {
                     'reqtype': 'updatesinglefile',
                     'pro_id': 1,
-                    'filename': '4',
+                    'testdata_id': 2,
                     'type': 'output',
                     'pack_token': pack_token,
                 },
                 [
                     {'pro_id': '100', 'equal_value': ('Enoext', 'Problem not found')}, # problem not found,
-                    {'type': '../../', 'equal_value': ('Eparam', 'Invalid testcase file type')}, # type in ['output', 'input']
-                    {'filename': '../conf.json', 'equal_value': ('Eacces', 'Permission denied')}, # illegal filepath access
-                    {'filename': '5', 'equal_value': ('Enoext', 'Testcase file not found')}, # file not found
+                    {'type': '../../', 'equal_value': ('Eparam', 'Invalid testdata file type')}, # type in ['output', 'input']
+                    {'testdata_id': 100, 'equal_value': ('Enoext', 'Testdata not found')},
                 ],
                 admin_session
             )
@@ -229,31 +197,31 @@ class ManageProUpdateTestsTest(AsyncTest):
             chal_states_result = self.get_chal_state(chal_id=1, session=admin_session)
             self.assertEqual(chal_states_result, [ChalConst.STATE_AC, ChalConst.STATE_AC, ChalConst.STATE_WA])
 
-            # NOTE: deletesingletestcase
+            # NOTE: settestdata (remove testdata from range)
             inputfile_token = await self._upload_file('tests/static_file/toj3/3.in', admin_session)
             outputfile_token = await self._upload_file('tests/static_file/toj3/3.out', admin_session)
-            res = admin_session.post('manage/pro/updatetests?proid=1', data={
+            res = admin_session.post('manage/pro/updatetestdata?proid=1', data={
                 'reqtype': 'addsinglefile',
                 'pro_id': 1,
-                'filename': '3',
+                'filename': '4',
                 'input_pack_token': inputfile_token,
                 'output_pack_token': outputfile_token,
             })
             self.assertAPIReturnSuccess(res.text)
+            html = self.get_html('manage/pro/updatetestdata?proid=1', admin_session)
+            trs = html.select('tbody > tr')
+            self.assertEqual(len(trs), 4)
+
             res = admin_session.post('manage/pro/updatetests?proid=1', data={
-                'reqtype': 'addsingletestcase',
+                'reqtype': 'settestdata',
                 'pro_id': 1,
-                'testcase': '3',
+                'testdatas': '0-1, 3',
                 'group': 2,
             })
             self.assertAPIReturnSuccess(res.text)
-            res = admin_session.post('manage/pro/updatetests?proid=1', data={
-                'reqtype': 'deletesingletestcase',
-                'pro_id': 1,
-                'testcase': '4',
-                'group': 2,
-            })
-            self.assertAPIReturnSuccess(res.text)
+            html = self.get_html('manage/pro/updatetests?proid=1', admin_session)
+            groups = html.select_one('div#tests').select('div.accordion-item')
+            self.assertEqual(groups[2].select_one('#testdatas').attrs['value'].strip(), "0-1,3")
             def callback():
                 res = admin_session.post('submit', data={
                     'reqtype': 'rechal',
@@ -265,25 +233,28 @@ class ManageProUpdateTestsTest(AsyncTest):
             self.assertEqual(chal_states_result, [ChalConst.STATE_AC, ChalConst.STATE_AC, ChalConst.STATE_AC])
 
             # NOTE: deletesinglefile
-            res = admin_session.post('manage/pro/updatetests?proid=1', data={
+            res = admin_session.post('manage/pro/updatetestdata?proid=1', data={
                 'reqtype': 'deletesinglefile',
                 'pro_id': 1,
-                'filename': '4',
+                'testdata_id': 3,
             })
             self.assertAPIReturnSuccess(res.text)
             self.assertFalse(os.path.exists('problem/1/res/testdata/4.in'))
             self.assertFalse(os.path.exists('problem/1/res/testdata/4.out'))
+            html = self.get_html('manage/pro/updatetestdata?proid=1', admin_session)
+            trs = html.select('tbody > tr')
+            self.assertEqual(len(trs), 3)
 
             self.assertTable(
+                'manage/pro/updatetestdata',
                 {
                     'reqtype': 'deletesinglefile',
                     'pro_id': 1,
-                    'filename': '4',
+                    'testdata_id': 3,
                 },
                 [
                     {'pro_id': '100', 'equal_value': ('Enoext', 'Problem not found')}, # problem not found,
-                    {'filename': '../conf.json', 'equal_value': ('Eacces', 'Permission denied')}, # illegal filepath access
-                    {'filename': '5', 'equal_value': ('Enoext', 'Testcase file not found')}, # file not found
+                    {'testdata_id': 100, 'equal_value': ('Enoext', 'Testdata not found')}, # illegal filepath access
                 ],
                 admin_session
             )

--- a/src/tests/e2e/proclass.py
+++ b/src/tests/e2e/proclass.py
@@ -99,7 +99,7 @@ class ProClassTest(AsyncTest):
 
             html = self.get_html('manage/proclass/update?proclassid=1', admin_session)
             self.assertEqual(html.select_one('input#name').attrs.get('value'), 'test')
-            self.assertEqual(html.select_one('input#list').attrs.get('value'), '1, 2')
+            self.assertEqual(html.select_one('input#list').attrs.get('value'), '1-2')
             self.assertIsNotNone(html.select('select#type > option')[0].attrs.get('selected'))
             res = admin_session.get('manage/proclass/update?proclassid=1')
             self.assertEqual(re.findall(r'j_form\.find\("#desc"\)\.val\(index\.unescape_html\(`(.*)`\)\);', res.text, re.I)[0], 'desc desc')


### PR DESCRIPTION
Move testdata to separate table and reference by testdata_id in subtasks to simplify admin operations and reduce DB size.
For future large refactor and judg rewrite.
Remove rename testdata function.
Also implemented file download functionality.