### PR TITLE
refactor: rename DB columns and convert some dicts to dataclasses

### DIFF
--- a/migration/20250724120400_rename.py
+++ b/migration/20250724120400_rename.py
@@ -1,0 +1,130 @@
+import json
+async def dochange(db, rs):
+    res = await db.fetch('SELECT pro_id, "limit" FROM problem;')
+    for pro_id, limit in res:
+        limit: dict[str, dict[str, int]] = json.loads(limit)
+
+        for lim in limit.values():
+            lim['time'] = lim.pop('timelimit')
+            lim['memory'] = lim.pop('memlimit')
+
+        await db.execute('UPDATE problem SET "limit" = $1 WHERE pro_id = $2;', json.dumps(limit), pro_id)
+    await db.execute('''ALTER TABLE problem ALTER COLUMN "limit" SET DEFAULT '{"default": {"time": 0, "memory":0}}'::jsonb;''')
+
+    await db.execute("ALTER TABLE test_config RENAME COLUMN weight TO rate;")
+    await db.execute("ALTER TABLE test_config RENAME COLUMN test_idx TO subtask_id;")
+    await db.execute("ALTER TABLE test RENAME COLUMN test_idx TO subtask_id;")
+    await db.execute("ALTER TABLE test RENAME COLUMN runtime TO time;")
+    await db.execute("ALTER TABLE challenge_state RENAME COLUMN runtime TO time;")
+    await db.execute('ALTER TABLE problem RENAME COLUMN "limit" TO limits;')
+    await db.execute("ALTER TABLE problem RENAME COLUMN check_type TO checker_type;")
+
+    await db.execute("ALTER INDEX challenge_state_idx_chal_id RENAME TO total_result_idx_chal_id;")
+    await db.execute("ALTER TABLE challenge_state RENAME CONSTRAINT challenge_state_forkey_chal_id TO total_result_forkey_chal_id;")
+    await db.execute("ALTER TABLE challenge_state RENAME CONSTRAINT challenge_state_unique_chal_id TO total_result_unique_chal_id;")
+
+
+    await db.execute("ALTER INDEX test_config_pkey RENAME TO subtask_config_pkey;")
+    await db.execute("ALTER INDEX test_pkey RENAME TO subtask_result_pkey;")
+    await db.execute("ALTER INDEX test_idx_acct_id RENAME TO subtask_result_idx_acct_id;")
+    await db.execute("ALTER TABLE test RENAME CONSTRAINT test_forkey_acct_id TO subtask_result_forkey_acct_id;")
+    await db.execute("ALTER TABLE test RENAME CONSTRAINT test_forkey_chal_id TO subtask_result_forkey_chal_id;")
+    await db.execute("ALTER TABLE test RENAME CONSTRAINT test_forkey_pro_id_test_idx TO subtask_forkey_pro_id_subtask_id;")
+
+    await db.execute("DROP TRIGGER trigger_delete_challenge_state ON test;")
+    await db.execute("ALTER TABLE challenge_state RENAME TO total_result;")
+    await db.execute("ALTER TABLE test_config RENAME TO subtask_config;")
+    await db.execute("ALTER TABLE test RENAME TO subtask_result;")
+
+    await db.execute(
+    '''
+        CREATE OR REPLACE FUNCTION delete_total_result()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            DELETE FROM total_result WHERE chal_id = OLD.chal_id;
+            RETURN OLD;
+        END;
+        $$ LANGUAGE plpgsql;
+    ''')
+
+    await db.execute(
+    '''
+        CREATE TRIGGER trigger_delete_total_result
+        AFTER DELETE ON subtask_result
+        FOR EACH ROW
+        EXECUTE FUNCTION delete_total_result();
+    ''')
+
+    await db.execute(
+    '''
+    CREATE OR REPLACE FUNCTION update_total_result(p_chal_id INTEGER)
+    RETURNS VOID AS $$
+    BEGIN
+        WITH challenge_summary AS (
+            SELECT
+                t.chal_id,
+                MAX(t.state) AS max_state,
+                SUM(t.time) AS total_time,
+                SUM(t.memory) AS total_memory,
+                SUM(
+                    CASE
+                        WHEN (t.state = 1 OR t.state = 2) AND t.rate IS NOT NULL THEN t.rate -- special score
+                        WHEN t.state = 1 AND t.rate IS NULL THEN tvr.rate -- default score
+                        ELSE 0
+                    END
+                ) AS total_rate
+            FROM subtask_result t
+            LEFT JOIN test_valid_rate tvr ON t.pro_id = tvr.pro_id AND t.subtask_id = tvr.test_idx
+            WHERE t.chal_id = p_chal_id
+            GROUP BY t.chal_id
+        )
+        INSERT INTO total_result (chal_id, state, time, memory, rate)
+        SELECT
+            chal_id,
+            max_state,
+            total_time,
+            total_memory,
+            total_rate
+        FROM challenge_summary
+        ON CONFLICT (chal_id) DO UPDATE
+        SET
+            state = EXCLUDED.state,
+            time = EXCLUDED.time,
+            memory = EXCLUDED.memory,
+            rate = EXCLUDED.rate
+        WHERE
+            total_result.state != EXCLUDED.state OR
+            total_result.time != EXCLUDED.time OR
+            total_result.memory != EXCLUDED.memory OR
+            total_result.rate != EXCLUDED.rate;
+
+        RETURN;
+    END;
+    $$ LANGUAGE plpgsql;
+    '''
+    )
+
+    log_type = [
+        ('manage.contest.remove', 'manage.board.remove'),
+        ('manage.contest.set', 'manage.board.update'),
+        ('manage.pro.update.tests.updateweight', 'manage.pro.update.tests.updaterate'),
+        ('manage.pro.update.conf', 'manage.pro.update.pro'),
+        ('manage.pro.update.tests.preview', 'manage.pro.update.testdata.preview'),
+        ('manage.pro.update.tests.preview.failed', 'manage.pro.update.testdata.preview.failed'),
+        ('manage.pro.update.tests.addsinglefile', 'manage.pro.update.testdata.addsinglefile'),
+        ('manage.pro.update.tests.addsinglefile.failed', 'manage.pro.update.testdata.addsinglefile.failed'),
+        ('manage.pro.update.tests.updatesinglefile', 'manage.pro.update.testdata.updatesinglefile'),
+        ('manage.pro.update.tests.updatesinglefile.failed', 'manage.pro.update.testdata.updatesinglefile.failed'),
+        ('manage.pro.update.tests.deletesinglefile', 'manage.pro.update.testdata.deletesinglefile'),
+        ('manage.pro.update.tests.deletesinglefile.failed', 'manage.pro.update.testdata.deletesinglefile.failed'),
+        ('manage.pro.update.tests.addtaskgroup', 'manage.pro.update.tests.addsubtask'),
+        ('manage.pro.update.tests.addtaskgroup.failed', 'manage.pro.update.tests.addsubtask.failed'),
+        ('manage.pro.update.tests.deletetaskgroup', 'manage.pro.update.tests.deletesubtask'),
+        ('manage.pro.update.tests.addetetaskgroup.failed', 'manage.pro.update.tests.deletesubtask.failed'),
+        ('contest.manage.chal.rechal', 'manage.chal.rechal'),
+    ]
+
+    for old_log_type, new_log_type in log_type:
+        await db.execute('UPDATE log SET type=$1 WHERE type=$2;', new_log_type, old_log_type)
+
+    await rs.delete("prolist")

--- a/src/handlers/board.py
+++ b/src/handlers/board.py
@@ -32,7 +32,7 @@ class BoardHandler(RequestHandler):
         err, ratemap = await RateService.inst.map_rate(starttime=meta['start'], endtime=meta['end'])
 
         p_list = meta['pro_list']
-        prolist = list(filter(lambda pro: pro['pro_id'] in p_list, prolist))
+        prolist = list(filter(lambda pro: pro.pro_id in p_list, prolist))
 
         acctlist2 = []
         submit_count = {}
@@ -43,7 +43,7 @@ class BoardHandler(RequestHandler):
                 count = 0
 
                 for pro in prolist:
-                    pro_id = pro['pro_id']
+                    pro_id = pro.pro_id
                     if acct_id in ratemap and pro_id in ratemap[acct_id]:
                         rate = ratemap[acct_id][pro_id]
                         acct.rate += rate['rate']
@@ -79,7 +79,7 @@ class BoardHandler(RequestHandler):
         # NOTE: board最下面的score/submit那行
         pro_sc_sub = {}
         for pro in prolist:
-            pro_id = pro['pro_id']
+            pro_id = pro.pro_id
             sc = 0
             sub = 0
             for acct in acctlist2:

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -1,6 +1,7 @@
 import asyncio
 import decimal
 import json
+from dataclasses import is_dataclass, asdict
 
 from handlers.base import RequestHandler, WebSocketSubHandler, reqenv
 from handlers.contests.base import contest_require_permission
@@ -63,12 +64,14 @@ class ChalListHandler(RequestHandler):
 
         flt = flt_builder.pro(query_pros).acct(query_accts).build()
 
-        _, chalstat = await ChalService.inst.get_chals_count(flt)
+        _, chal_cnt = await ChalService.inst.get_chals_count(flt)
         _, challist = await ChalService.inst.list_chal(pageoff, 20, flt)
+        for chal in challist:
+            chal.compiler_type = ChalConst.COMPILER_NAME[chal.compiler_type]
 
         await self.render(
             'challist',
-            chalstat=chalstat,
+            chal_cnt=chal_cnt,
             challist=challist,
             flt=flt,
             pageoff=pageoff,
@@ -85,21 +88,21 @@ class ChalHandler(RequestHandler):
     async def get(self, chal_id):
         chal_id = int(chal_id)
 
-        err, chal = await ChalService.inst.get_chal(chal_id, with_test=True)
+        err, chal = await ChalService.inst.get_chal(chal_id, with_result=True)
         if err:
             return self.error(err)
 
         allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
-        if chal['contest_id'] and not self.contest:
+        if chal.contest_id and not self.contest:
             return self.error(('Enoext', 'Contest not found'))
 
         elif self.contest:
             if not self.contest.is_start():
-                if self.contest.is_admin(acct_id=chal['acct_id']) and not self.contest.is_admin(self.acct):
+                if self.contest.is_admin(acct_id=chal.acct_id) and not self.contest.is_admin(self.acct):
                     return self.error(('Eacces', 'Permission denied'))
 
             elif self.contest.is_running():
-                if self.contest.hide_admin and self.contest.is_admin(acct_id=chal['acct_id']) and not self.contest.is_admin(self.acct):
+                if self.contest.hide_admin and self.contest.is_admin(acct_id=chal.acct_id) and not self.contest.is_admin(self.acct):
                     return self.error(('Eacces', 'Permission denied'))
 
             allow_statuses = ProConst.PRO_STATUS_CONTEST_USER
@@ -107,20 +110,20 @@ class ChalHandler(RequestHandler):
         elif self.acct.is_kernel():
             allow_statuses = ProConst.PRO_STATUS_KERNEL_USER
 
-        err, pro = await ProService.inst.get_pro(chal['pro_id'], allow_statuses)
+        err, pro = await ProService.inst.get_pro(chal.pro_id, allow_statuses)
         if err:
             return self.error(err)
 
-        chal['comp_type'] = ChalConst.COMPILER_NAME[chal['comp_type']]
+        chal.compiler_type = ChalConst.COMPILER_NAME[chal.compiler_type]
 
         rechal = self.acct.is_kernel()
         if self.contest:
             rechal = rechal and self.contest.is_admin(self.acct)
 
         final_response = []
-        for idx, test in enumerate(chal['testl'], start=1):
-            response = test['response']
-            final_response.append(f"Task {idx}: {response}")
+        for subtask_id, subtask_result in chal.subtask_results.items():
+            if subtask_result.response:
+                final_response.append(f"Subtask {subtask_id}: {subtask_result.response}")
 
         await self.render('chal', pro=pro, chal=chal, rechal=rechal, response='\n'.join(final_response))
         return
@@ -129,6 +132,8 @@ class _Encoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, decimal.Decimal):
             return str(o)
+        elif is_dataclass(o):
+            return asdict(o)
         return super().default(o)
 
 class ChalListNewChalHandler(WebSocketSubHandler):
@@ -152,13 +157,13 @@ class ChalListNewStateHandler(WebSocketSubHandler):
                 continue
 
             chal_id = int(msg['data'])
-            if self.first_chal_id <= chal_id <= self.last_chal_id:
-                _, new_state = await ChalService.inst.get_calculated_chal_state(chal_id, self.allow_pro_statuses)
-                await self.write_message(json.dumps(new_state, cls=_Encoder))
+            if chal_id in self.chalids:
+                _, total_result = await ChalService.inst.get_total_result(chal_id, self.allow_pro_statuses)
+                await self.write_message(
+                    json.dumps({'chal_id': chal_id, **asdict(total_result)}, cls=_Encoder))
 
     async def open(self):
-        self.first_chal_id = -1
-        self.last_chal_id = -1
+        self.chalids: set[int] = None
         self.allow_pro_statuses = [ProConst.STATUS_ONLINE]
 
         await self.p.subscribe('challiststatesub')
@@ -169,26 +174,25 @@ class ChalListNewStateHandler(WebSocketSubHandler):
         # TODO: contest challist
         # TODO: user authentication
 
-        if self.first_chal_id == -1:
+        if self.chalids is None:
             j = json.loads(msg)
 
-            self.first_chal_id = int(j["first_chal_id"])
-            self.last_chal_id = int(j["last_chal_id"])
+            self.chalids = set(j["chalids"])
+
             err, acct = await UserService.inst.info_acct(acct_id=int(j["acct_id"]))
             if not err and acct.is_kernel():
                 self.allow_pro_statuses.append(ProConst.STATUS_HIDDEN)
 
 
 class ChalNewStateHandler(WebSocketSubHandler):
-
     async def listen_chalstate(self):
         async for msg in self.p.listen():
             if msg['type'] != 'message':
                 continue
 
             if int(msg['data']) == self.chal_id:
-                _, chal_states = await ChalService.inst.get_chal_state(self.chal_id)
-                await self.write_message(json.dumps(chal_states, cls=_Encoder))
+                _, chal_states = await ChalService.inst.get_subtask_results(self.chal_id)
+                await self.write_message(json.dumps(list(chal_states.values()), cls=_Encoder))
 
     async def open(self):
         self.chal_id = -1

--- a/src/handlers/code.py
+++ b/src/handlers/code.py
@@ -15,23 +15,23 @@ class CodeHandler(RequestHandler):
     async def post(self):
         chal_id = int(self.get_argument('chal_id'))
 
-        err, code, comp_type = await CodeService.inst.get_code(chal_id, self.acct)
+        err, code, compiler_type = await CodeService.inst.get_code(chal_id, self.acct)
         if err:
             return self.error(err)
 
-        if comp_type in ['gcc', 'g++', 'clang', 'clang++']:
-            comp_type = 'cpp'
-        elif comp_type == 'rustc':
-            comp_type = 'rust'
-        elif comp_type in ['python3', 'pypy3']:
-            comp_type = 'python'
-        elif comp_type == 'java':
-            comp_type = 'java'
+        if compiler_type in ['gcc', 'g++', 'clang', 'clang++']:
+            compiler_type = 'cpp'
+        elif compiler_type == 'rustc':
+            compiler_type = 'rust'
+        elif compiler_type in ['python3', 'pypy3']:
+            compiler_type = 'python'
+        elif compiler_type == 'java':
+            compiler_type = 'java'
         else:
-            comp_type = 'cpp'
+            compiler_type = 'cpp'
 
         res = {
-            'comp_type': comp_type,
+            'compiler_type': compiler_type,
             'code': tornado.escape.xhtml_escape(code),
         }
         self.error(('S', res))

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -39,7 +39,7 @@ class ContestManageProHandler(RequestHandler):
                 return self.error(('Eexist', f'Problem(#{pro_id}) is already in contest'))
 
             self.contest.pro_list[pro_id] = {
-                "score_type": ProblemScoreType.IOI2017.value
+                "score_type": ProblemScoreType.IOI2017
             }
 
             await ContestService.inst.update_contest(self.acct, self.contest, prolist_updated=True)
@@ -62,7 +62,7 @@ class ContestManageProHandler(RequestHandler):
             pro_id = parse_str_to_list(pro_id)
             for p_id in pro_id:
                 self.contest.pro_list[p_id] = {
-                    "score_type": ProblemScoreType.IOI2017.value
+                    "score_type": ProblemScoreType.IOI2017
                 }
 
             await ContestService.inst.update_contest(self.acct, self.contest, prolist_updated=True)
@@ -96,8 +96,8 @@ class ContestManageProHandler(RequestHandler):
                 result = await con.fetch(
                     f'''
                         SELECT "challenge"."chal_id", "challenge"."compiler_type" FROM "challenge"
-                        INNER JOIN "challenge_state"
-                        ON "challenge"."chal_id" = "challenge_state"."chal_id" AND "challenge"."contest_id" = {self.contest.contest_id}
+                        INNER JOIN "total_result"
+                        ON "challenge"."chal_id" = "total_result"."chal_id" AND "challenge"."contest_id" = {self.contest.contest_id}
                         WHERE "pro_id" = $1;
                     ''',
                     pro_id
@@ -110,15 +110,9 @@ class ContestManageProHandler(RequestHandler):
 
             # TODO: send notify to user
             async def _rechal(rechals):
-                for chal_id, comp_type in rechals:
+                for chal_id, compiler_type in rechals:
                     _, _ = await ChalService.inst.reset_chal(chal_id)
-                    _, _ = await ChalService.inst.emit_chal(
-                        chal_id,
-                        pro_id,
-                        pro['testm_conf'],
-                        comp_type,
-                        ChalConst.CONTEST_REJUDGE_PRI,
-                    )
+                    _, _ = await ChalService.inst.emit_chal(chal_id, pro_id, pro.config, compiler_type, ChalConst.CONTEST_REJUDGE_PRI)
 
             await asyncio.create_task(_rechal(rechals=result))
             self.error(('S', f'Problem(#{pro_id}) is rechallenging.'))
@@ -135,7 +129,8 @@ class ContestManageProHandler(RequestHandler):
             if err:
                 return self.error(err)
 
-            err, _ = await ProService.inst.update_pro(pro_id, pro['name'], ProConst.STATUS_ONLINE, pro['tags'])
+            pro.status = ProConst.STATUS_ONLINE
+            err, _ = await ProService.inst.update_pro(pro)
             if err:
                 return self.error(err)
 

--- a/src/handlers/contests/proset.py
+++ b/src/handlers/contests/proset.py
@@ -1,5 +1,3 @@
-import tornado
-
 from handlers.base import reqenv, RequestHandler
 from services.pro import ProConst, ProService
 from services.rate import RateService
@@ -22,28 +20,25 @@ class ContestProsetHandler(RequestHandler):
             _, prolist = await ProService.inst.list_pro(ProConst.PRO_STATUS_CONTEST_USER)
 
             prolist_order = {pro_id: idx for idx, pro_id in enumerate(self.contest.pro_list.keys())}
-            prolist = sorted(filter(lambda pro: self.contest.is_pro(pro['pro_id']), prolist),
-                                  key=lambda pro: prolist_order[pro['pro_id']])
+            prolist = sorted(filter(lambda pro: self.contest.is_pro(pro.pro_id), prolist),
+                                  key=lambda pro: prolist_order[pro.pro_id])
 
-            def get_score(pro):
-                pro['score'] = 0
-                pro['state'] = None
-                if pro['pro_id'] in acct_rates:
-                    pro['score'] += acct_rates[pro['pro_id']]['rate']
-                    pro['state'] = acct_rates[pro['pro_id']]['state']
-
-                return pro
-
-            prolist = list(map(get_score, prolist))
+            score_map: dict[int, dict] = {}
+            for pro in prolist:
+                pro_id = pro.pro_id
+                score_map[pro_id] = {'score': 0, 'state': None}
+                if pro_id in acct_rates:
+                    score_map[pro_id]['score'] += acct_rates[pro.pro_id]['rate']
+                    score_map[pro_id]['state'] = acct_rates[pro.pro_id]['state']
 
             if self.contest.is_public_scoreboard or self.contest.is_admin(self.acct):
                 show_ac_ratio = True
                 for pro in prolist:
-                    _, rate = await RateService.inst.get_pro_ac_rate(pro['pro_id'], contest_id=self.contest.contest_id)
-                    pro['rate_data'] = rate
+                    _, rate = await RateService.inst.get_pro_ac_rate(pro.pro_id, contest_id=self.contest.contest_id)
+                    score_map[pro.pro_id]['rate_data'] = rate
 
         pro_total_cnt = len(prolist)
         prolist = prolist[pageoff: pageoff + 40]
 
         await self.render('contests/proset', contest=self.contest, show_ac_ratio=show_ac_ratio,
-                          prolist=prolist, pro_total_cnt=pro_total_cnt, pageoff=pageoff)
+                          prolist=prolist, pro_total_cnt=pro_total_cnt, score_map=score_map, pageoff=pageoff)

--- a/src/handlers/index.py
+++ b/src/handlers/index.py
@@ -61,19 +61,6 @@ class AbouotHandler(RequestHandler):
         await self.render('about')
 
 
-class OnlineCounterHandler(RequestHandler):
-    @reqenv
-    async def get(self):
-        if (cnt := (await self.rs.get('online_counter'))) is None:
-            cnt = 0
-        else:
-            cnt = cnt.decode('utf-8')
-
-        set_cnt = await self.rs.scard('online_counter_set')
-
-        self.finish(f"<h1>{cnt}</h1> <br> <h1>{set_cnt}</h1>")
-
-
 class DevInfoHandler(RequestHandler):
     @reqenv
     async def get(self):

--- a/src/handlers/manage/board.py
+++ b/src/handlers/manage/board.py
@@ -62,7 +62,7 @@ class ManageBoardHandler(RequestHandler):
             acct_list = parse_str_to_list(acct_list_str)
             pro_list = parse_str_to_list(pro_list_str)
             await LogService.inst.add_log(
-                f"{self.acct.name} was added to the contest \"{name}\".", 'manage.board.add',
+                f"{self.acct.name} was added to the board \"{name}\".", 'manage.board.add',
                 {
                     "name": name,
                     "status": status,
@@ -99,7 +99,7 @@ class ManageBoardHandler(RequestHandler):
             pro_list = parse_str_to_list(pro_list_str)
 
             await LogService.inst.add_log(
-                f"{self.acct.name} was updated in the contest \"{name}\".", 'manage.board.update',
+                f"{self.acct.name} was updated in the board \"{name}\".", 'manage.board.update',
                 {
                     "name": name,
                     "status": status,
@@ -117,6 +117,6 @@ class ManageBoardHandler(RequestHandler):
             board_id = int(self.get_argument('board_id'))
             await BoardService.inst.remove_board(board_id)
             await LogService.inst.add_log(
-                f"{self.acct.name} was removed the contest \"{board_id}\".", 'manage.board.remove'
+                f"{self.acct.name} was removed the board \"{board_id}\".", 'manage.board.remove'
             )
             self.error(('S', ''))

--- a/src/handlers/manage/pro.py
+++ b/src/handlers/manage/pro.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+from dataclasses import asdict
 import json
 import os
 
@@ -12,10 +13,12 @@ from handlers.base import RequestHandler, reqenv, require_permission
 from services.chal import ChalConst, ChalService
 from services.judge import JudgeServerClusterService
 from services.log import LogService
-from services.pro import ProService, ProConst
+from services.pro import Limit, ProService, ProConst, SubtaskConfig, Testdata
 from services.user import UserConst
 from services.pack import PackService
 from utils.numeric import parse_str_to_list
+
+# TODO: Remove unnecessary security check
 
 PERMISSION_DENIED_ERROR = ('Eacces', 'Permission denied')
 ALLOW_STATUSES = [ProConst.STATUS_ONLINE, ProConst.STATUS_CONTEST, ProConst.STATUS_HIDDEN]
@@ -97,16 +100,16 @@ class ManageProHandler(RequestHandler):
             if err:
                 return self.error(err)
 
-            testm_conf = pro['testm_conf']
+            config = pro.config
             dirs = []
-            if testm_conf['is_makefile']:
+            if config.is_makefile:
                 files = list(natsorted(filter(lambda name: os.path.isfile(f'problem/{pro_id}/res/make/{name}'), os.listdir(f'problem/{pro_id}/res/make'))))
                 dirs.append({
                     'path': 'res/make',
                     'files': files,
                 })
 
-            if testm_conf['check_type'] in [ProConst.CHECKER_IOREDIR, ProConst.CHECKER_CMS]:
+            if config.checker_type in [ProConst.CHECKER_IOREDIR, ProConst.CHECKER_CMS]:
                 files = list(natsorted(filter(lambda name: os.path.isfile(f'problem/{pro_id}/res/check/{name}'), os.listdir(f'problem/{pro_id}/res/check'))))
                 dirs.append({
                     'path': 'res/check',
@@ -131,7 +134,7 @@ class ManageProHandler(RequestHandler):
                 'manage/pro/updatetests',
                 page='pro',
                 pro_id=pro_id,
-                tests=pro['testm_conf'],
+                config=pro.config,
             )
 
         elif page == "updatetestdata":
@@ -148,14 +151,14 @@ class ManageProHandler(RequestHandler):
                     return self.error(('Eparam', 'Invalid testdata file type'))
 
                 testdata_id = int(self.get_argument('testdata_id'))
-                if testdata_id not in pro['testm_conf']['testdatas']:
+                if testdata_id not in pro.config.testdatas:
                     self.error(('Enoext', 'Testdata not found'))
                     return
 
                 if testdata_type == "input":
-                    file = pro['testm_conf']['testdatas'][testdata_id]['inputfile']
+                    file = pro.config.testdatas[testdata_id].inputfile
                 else:
-                    file = pro['testm_conf']['testdatas'][testdata_id]['outputfile']
+                    file = pro.config.testdatas[testdata_id].outputfile
 
                 basepath = f'problem/{pro_id}/res/testdata'
                 filepath = f'{basepath}/{file}'
@@ -184,7 +187,7 @@ class ManageProHandler(RequestHandler):
                 'manage/pro/updatetestdata',
                 page='pro',
                 pro_id=pro_id,
-                tests=pro['testm_conf'],
+                config=pro.config,
             )
 
     @reqenv
@@ -228,16 +231,16 @@ class ManageProHandler(RequestHandler):
                 testdata_id = int(self.get_argument('testdata_id'))
                 testdata_type = self.get_argument('type')
 
-                if testdata_id not in pro['testm_conf']['testdatas']:
+                if testdata_id not in pro.config.testdatas:
                     return self.error(('Enoext', 'Testdata not found'))
 
                 if testdata_type not in ['output', 'input']:
                     return self.error(('Eparam', 'Invalid testdata file type'))
 
-                if testdata_type == 'input':
-                    filename = pro['testm_conf']['testdatas'][testdata_id]['inputfile']
+                if testdata_type == "input":
+                    filename = pro.config.testdatas[testdata_id].inputfile
                 else:
-                    filename = pro['testm_conf']['testdatas'][testdata_id]['outputfile']
+                    filename = pro.config.testdatas[testdata_id].outputfile
 
                 basepath = f'problem/{pro_id}/res/testdata'
                 filepath = os.path.join(basepath, filename)
@@ -265,7 +268,7 @@ class ManageProHandler(RequestHandler):
 
                 failed = True
                 try:
-                    testdatas: dict[int, dict] = pro['testm_conf']['testdatas']
+                    testdatas = pro.config.testdatas
                     if testdata_id not in testdatas:
                         return self.error(('Enoext', 'Testdata not found'))
 
@@ -273,9 +276,9 @@ class ManageProHandler(RequestHandler):
                         return self.error(('Eparam', 'Invalid testdata file type'))
 
                     if testdata_type == 'input':
-                        filename = testdatas[testdata_id]['inputfile']
+                        filename = testdatas[testdata_id].inputfile
                     else:
-                        filename = testdatas[testdata_id]['outputfile']
+                        filename = testdatas[testdata_id].outputfile
 
                     basepath = f'problem/{pro_id}/res/testdata'
                     filepath = f'{basepath}/{filename}'
@@ -308,7 +311,7 @@ class ManageProHandler(RequestHandler):
 
                 _ = await PackService.inst.direct_copy(pack_token, filepath)
 
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+                await ProService.inst.update_pro_config(pro_id, pro.config)
                 await LogService.inst.add_log(
                     f'{self.acct.name} has sent a request to update testdata {testdata_id} with {testdata_type} type for problem #{pro_id}',
                     'manage.pro.update.testdata.updatesinglefile',
@@ -321,13 +324,11 @@ class ManageProHandler(RequestHandler):
                 input_pack_token = self.get_argument('input_pack_token')
                 output_pack_token = self.get_argument('output_pack_token')
 
-                testm_conf = pro['testm_conf']
-                testdatas: dict[int, dict] = testm_conf['testdatas']
+                testdatas = pro.config.testdatas
                 try:
                     new_testdata_id = max(testdatas.keys()) + 1
                 except ValueError:
                     new_testdata_id = 0
-
 
                 basepath = f'problem/{pro_id}/res/testdata'
                 inputfile_path = f'{basepath}/{filename}.in'
@@ -355,12 +356,8 @@ class ManageProHandler(RequestHandler):
 
                 _ = await PackService.inst.direct_copy(input_pack_token, inputfile_path)
                 _ = await PackService.inst.direct_copy(output_pack_token, outputfile_path)
-                testdatas[new_testdata_id] = {
-                    'id': new_testdata_id,
-                    'inputfile': f'{filename}.in',
-                    'outputfile': f'{filename}.out',
-                }
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+                testdatas[new_testdata_id] = Testdata(new_testdata_id, f'{filename}.in', f'{filename}.out')
+                await ProService.inst.update_pro_config(pro_id, pro.config)
 
                 await LogService.inst.add_log(
                     f'{self.acct.name} has sent a request to add testdata {new_testdata_id} named {filename} for problem #{pro_id}',
@@ -371,14 +368,13 @@ class ManageProHandler(RequestHandler):
 
             elif reqtype == 'deletesinglefile':
                 testdata_id = int(self.get_argument('testdata_id'))
-                testm_conf = pro['testm_conf']
-                testdatas: dict[int, dict] = testm_conf['testdatas']
+                testdatas: dict[int, dict] = pro.config.testdatas
 
                 if testdata_id not in testdatas:
                     return self.error(('Enoext', 'Testdata not found'))
 
-                inputfile = testdatas[testdata_id]['inputfile']
-                outputfile = testdatas[testdata_id]['outputfile']
+                inputfile = testdatas[testdata_id].inputfile
+                outputfile = testdatas[testdata_id].outputfile
 
                 basepath = f'problem/{pro_id}/res/testdata'
                 if not os.path.exists(f'{basepath}/{inputfile}') or not os.path.exists(f'{basepath}/{outputfile}'):
@@ -394,19 +390,20 @@ class ManageProHandler(RequestHandler):
                 os.remove(f'{basepath}/{inputfile}')
                 os.remove(f'{basepath}/{outputfile}')
 
-                for test_group in pro['testm_conf']['test_group'].values():
+                for subtask_config in pro.config.subtask_configs.values():
                     try:
-                        test_group['testdatas'].remove(testdata_id)
+                        subtask_config.testdatas.remove(pro.config.testdatas[testdata_id])
                     except ValueError:
-                        pass
-                deleted_testdata = pro['testm_conf']['testdatas'].pop(testdata_id)
+                        continue
 
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+                deleted_testdata = pro.config.testdatas.pop(testdata_id)
+
+                await ProService.inst.update_pro_config(pro_id, pro.config)
                 await LogService.inst.add_log(
                     f'{self.acct.name} has sent a request to delete testdata {testdata_id} for problem #{pro_id}',
                     'manage.pro.update.tests.deletesinglefile',
                     {
-                        'testdata': deleted_testdata
+                        'testdata': asdict(deleted_testdata)
                     }
                 )
 
@@ -418,88 +415,84 @@ class ManageProHandler(RequestHandler):
             if err:
                 return self.error(err)
 
-            if reqtype == "updateweight":
-                group = int(self.get_argument('group'))
-                weight = int(self.get_argument('weight'))
+            if reqtype == "updaterate":
+                subtask_id = int(self.get_argument('subtask'))
+                rate = int(self.get_argument('rate'))
 
-                test_group = pro['testm_conf']['test_group']
+                subtask_configs = pro.config.subtask_configs
+                if subtask_id not in subtask_configs:
+                    return self.error(('Enoext', 'Subtask not found'))
 
-                if group not in test_group:
-                    return self.error(('Enoext', 'Group not found'))
-
-                test_group[group]['weight'] = weight
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+                subtask_configs[subtask_id].rate = rate
+                await ProService.inst.update_pro_config(pro_id, pro.config)
                 await LogService.inst.add_log(
-                    f'{self.acct.name} has sent a request to update weight of subtask#{group} for problem #{pro_id}',
-                    'manage.pro.update.tests.updateweight',
+                    f'{self.acct.name} has sent a request to update rate of subtask#{subtask_id} for problem #{pro_id}',
+                    'manage.pro.update.tests.updaterate',
                     {
-                        'weight': weight,
+                        'rate': rate,
                     }
                 )
                 self.error(('S', ''))
 
-            elif reqtype == "addtaskgroup":
-                weight = int(self.get_argument('weight'))
+            elif reqtype == "addsubtask":
+                rate = int(self.get_argument('rate'))
 
-                test_group = pro['testm_conf']['test_group']
+                subtask_configs = pro.config.subtask_configs
+                subtask_configs[len(subtask_configs)] = SubtaskConfig(len(subtask_configs), [], rate)
 
-                test_group[len(test_group)] = {
-                    'weight': weight,
-                    'testdatas': []
-                }
-
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+                await ProService.inst.update_pro_config(pro_id, pro.config)
                 await LogService.inst.add_log(
                     f'{self.acct.name} has sent a request to add a new subtask for problem #{pro_id}',
-                    'manage.pro.update.tests.addtaskgroup',
+                    'manage.pro.update.tests.addsubtask',
                     {
-                        'weight': weight,
-                        'test_group_idx': len(test_group) - 1
+                        'rate': rate,
+                        'subtask_id': len(subtask_configs) - 1
                     }
                 )
                 self.error(('S', ''))
 
-            elif reqtype == 'deletetaskgroup':
-                group = int(self.get_argument('group'))
+            elif reqtype == 'deletesubtask':
+                subtask_id = int(self.get_argument('subtask'))
 
-                test_group = pro['testm_conf']['test_group']
-                if group not in test_group:
-                    return self.error(('Enoext', 'Group not found'))
+                subtask_configs = pro.config.subtask_configs
+                if subtask_id not in subtask_configs:
+                    return self.error(('Enoext', 'Subtask not found'))
 
-                test_group.pop(group)
-                remain_groups = list(test_group.values())
-                test_group.clear()
+                subtask_configs.pop(subtask_id)
+                remain_subtasks = list(subtask_configs.values())
+                subtask_configs.clear()
 
-                for group_idx, group in enumerate(remain_groups):
-                    test_group[group_idx] = group
+                for new_subtask_id, subtask in enumerate(remain_subtasks):
+                    subtask_configs[new_subtask_id] = subtask
 
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+                await ProService.inst.update_pro_config(pro_id, pro.config)
                 await LogService.inst.add_log(
                     f'{self.acct.name} has sent a request to delete a subtask for problem #{pro_id}',
-                    'manage.pro.update.tests.deletetaskgroup',
+                    'manage.pro.update.tests.deletesubtask',
                 )
                 self.error(('S', ''))
 
             elif reqtype == 'settestdata':
-                group = int(self.get_argument('group'))
+                subtask_id = int(self.get_argument('subtask'))
                 testdatas = parse_str_to_list(self.get_argument('testdatas'))
 
-                test_group = pro['testm_conf']['test_group']
-                if group not in test_group:
-                    return self.error(('Enoext', 'Group not found'))
+                subtask_configs = pro.config.subtask_configs
+                if subtask_id not in subtask_configs:
+                    return self.error(('Enoext', 'Subtask not found'))
 
-                test_group[group]['testdatas'] = []
+                subtask_configs[subtask_id].testdatas.clear()
                 for testdata_id in testdatas:
-                    if testdata_id not in pro['testm_conf']['testdatas']:
+                    if testdata_id not in pro.config.testdatas:
                         continue
-                    test_group[group]['testdatas'].append(testdata_id)
 
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+                    subtask_configs[subtask_id].testdatas.append(pro.config.testdatas[testdata_id])
+
+                await ProService.inst.update_pro_config(pro_id, pro.config)
                 await LogService.inst.add_log(
-                    f'{self.acct.name} has sent a request to set testdatas to group#{group} for problem #{pro_id}',
+                    f'{self.acct.name} has sent a request to set testdatas to subtask#{subtask_id} for problem #{pro_id}',
                     'manage.pro.update.tests.settestdata',
                     {
-                        'testdatas': testdatas
+                        'testdatas': [testdata.testdata_id for testdata in subtask_configs[subtask_id].testdatas]
                     }
                 )
                 self.error(('S', ''))
@@ -611,7 +604,7 @@ class ManageProHandler(RequestHandler):
                 self.error(('S', ''))
 
             elif reqtype == 'addsinglefile':
-                filename = self.get_argument('filename')
+                filename = self.get_argument('filename') # TODO: os.path.basename()
                 pack_token = self.get_argument('pack_token')
 
                 basepath = f'problem/{pro_id}/{basepath}'
@@ -676,7 +669,7 @@ class ManageProHandler(RequestHandler):
                 status = int(self.get_argument('status'))
                 tags = self.get_argument('tags')
                 allow_submit = self.get_argument('allow_submit') == "true"
-                # NOTE: test config
+                # NOTE: subtask config
                 rate_precision = int(self.get_argument('rate_precision'))
                 if rate_precision > ProConst.RATE_PRECISION_MAX or rate_precision < ProConst.RATE_PRECISION_MIN:
                     return self.error(('Eparam', 'Invalid rate precision'))
@@ -688,41 +681,43 @@ class ManageProHandler(RequestHandler):
                 if check_type == ProConst.CHECKER_IOREDIR:
                     chalmeta = self.get_argument('chalmeta')
                     try:
-                        chalmeta = json.loads(chalmeta)
+                        json.loads(chalmeta)
                     except json.JSONDecodeError:
                         return self.error(('Econf', 'Challenge metadata json syntax error'))
 
-                err, _ = await ProService.inst.update_pro(
-                    pro_id, name, status, tags, allow_submit
-                )
                 err, pro = await ProService.inst.get_pro(pro_id, ALLOW_STATUSES)
                 if err:
                     return self.error(err)
+                pro.name = name
+                pro.status = status
+                pro.tags = tags
+                pro.allow_submit = allow_submit
+                err, _ = await ProService.inst.update_pro(pro)
 
-                conf = pro['testm_conf']
+                config = pro.config
                 if (
-                    conf['is_makefile'] != is_makefile
-                    or conf['check_type'] != check_type
-                    or conf['rate_precision'] != rate_precision
+                    config.is_makefile != is_makefile
+                    or config.checker_type != check_type
+                    or config.rate_precision != rate_precision
                 ):
-                    old_is_makefile = conf['is_makefile']
-                    old_check_type = conf['check_type']
+                    old_is_makefile = config.is_makefile
+                    old_check_type = config.checker_type
                     custom_check_type = [ProConst.CHECKER_IOREDIR, ProConst.CHECKER_CMS]
                     if not old_is_makefile and is_makefile:
                         if not os.path.exists(f'problem/{pro_id}/res/make'):
                             os.mkdir(f'problem/{pro_id}/res/make')
-                    conf['is_makefile'] = is_makefile
+                    config.is_makefile = is_makefile
 
                     if old_check_type not in custom_check_type and check_type in custom_check_type:
                         if not os.path.exists(f'problem/{pro_id}/res/check'):
                             os.mkdir(f'problem/{pro_id}/res/check')
-                    conf['check_type'] = check_type
+                    config.checker_type = check_type
 
                     if check_type == ProConst.CHECKER_IOREDIR:
-                        chalmeta = json.dumps(chalmeta)
+                        config.chalmeta = chalmeta
 
-                    conf['rate_precision'] = rate_precision
-                    await ProService.inst.update_test_config(pro_id, conf)
+                    config.rate_precision = rate_precision
+                    await ProService.inst.update_pro_config(pro_id, config)
                 await LogService.inst.add_log(
                     f"{self.acct.name} has sent a request to update the problem #{pro_id}", 'manage.pro.update.pro',
                     {
@@ -752,7 +747,6 @@ class ManageProHandler(RequestHandler):
 
                 err, _ = await ProService.inst.unpack_pro(pro_id, pack_token)
                 if err:
-                    await PackService.inst.clear(pack_token)
                     await LogService.inst.add_log(
                         f"{self.acct.name} tried to update the problem #{pro_id} by uploading problem package but failed",
                         'manage.pro.update.pro.package.failed',
@@ -789,39 +783,42 @@ class ManageProHandler(RequestHandler):
                     return self.error(err)
 
                 ALLOW_COMPILERS = set(list(ChalConst.ALLOW_COMPILERS) + ['default'])
-                if pro['testm_conf']['is_makefile']:
+                if pro.config.is_makefile:
                     ALLOW_COMPILERS = {'gcc', 'g++', 'clang', 'clang++', 'default'}
 
-                new_limits = {}
-                for comp_type, limit in limits.items():
-                    if comp_type not in ALLOW_COMPILERS:
+                new_limits: dict[str, Limit] = {}
+                for compiler_type, limit in limits.items():
+                    if compiler_type not in ALLOW_COMPILERS:
                         continue
+                    new_limits[compiler_type] = Limit(0, 0)
                     try:
-                        limit['timelimit'] = max(int(limit['timelimit']), 0)
-                        limit['memlimit'] = max(int(limit['memlimit']) * 1024, 0)
+                        new_limits[compiler_type].time = max(int(limit['time']), 0)
+                        new_limits[compiler_type].memory = max(int(limit['memory']) * 1024, 0)
                     except (ValueError, KeyError):
+                        new_limits.pop(compiler_type)
                         continue
-
-                    new_limits[comp_type] = limit
 
                 if 'default' not in new_limits:
                     return self.error(('Eparam', 'Missing default limit config'))
 
-                pro['testm_conf']['limit'] = new_limits
-                await ProService.inst.update_test_config(pro_id, pro['testm_conf'])
+                pro.config.limits = new_limits
+                await ProService.inst.update_pro_config(pro_id, pro.config)
 
                 await LogService.inst.add_log(
                     f"{self.acct.name} has sent a request to update the problem #{pro_id}",
                     'manage.pro.update.limit',
                     {
-                        'limits': new_limits
+                        'limits': {
+                            comp: asdict(limit)
+                            for comp, limit in pro.config.limits.items()
+                        }
                     }
                 )
 
                 self.error(('S', ''))
 
         elif page is None:  # pro-list
-            if reqtype not in ['rechal', 'rechalall']:
+            if reqtype not in ['rechal', 'compiler_type']:
                 return self.error(('Eunk', 'Unknown error'))
 
             is_all_chal = False
@@ -846,13 +843,13 @@ class ManageProHandler(RequestHandler):
                     sql = ""
                     log_type = "manage.chal.rechalall"
                 else:
-                    sql = '''AND "challenge_state"."chal_id" IS NULL'''
+                    sql = '''AND "total_result"."chal_id" IS NULL'''
                     log_type = "manage.chal.rechal"
                 result = await con.fetch(
                     f'''
                         SELECT "challenge"."chal_id", "challenge"."compiler_type" FROM "challenge"
-                        LEFT JOIN "challenge_state"
-                        ON "challenge"."chal_id" = "challenge_state"."chal_id"
+                        LEFT JOIN "total_result"
+                        ON "challenge"."chal_id" = "total_result"."chal_id"
                         WHERE "pro_id" = $1 {sql};
                     ''',
                     pro_id,
@@ -864,15 +861,9 @@ class ManageProHandler(RequestHandler):
 
             # TODO: send notify to user
             async def _rechal(rechals):
-                for chal_id, comp_type in rechals:
+                for chal_id, compiler_type in rechals:
                     _, _ = await ChalService.inst.reset_chal(chal_id)
-                    _, _ = await ChalService.inst.emit_chal(
-                        chal_id,
-                        pro_id,
-                        pro['testm_conf'],
-                        comp_type,
-                        ChalConst.NORMAL_REJUDGE_PRI,
-                    )
+                    _, _ = await ChalService.inst.emit_chal(chal_id, pro_id, pro.config, compiler_type, ChalConst.NORMAL_REJUDGE_PRI)
 
             await asyncio.create_task(_rechal(rechals=result))
 

--- a/src/handlers/pro.py
+++ b/src/handlers/pro.py
@@ -2,33 +2,11 @@ from handlers.base import RequestHandler, reqenv, require_permission
 from services.chal import ChalConst
 from services.judge import JudgeServerClusterService
 from services.log import LogService
-from services.pro import ProClassService, ProClassConst, ProConst, ProService
+from services.pro import ProClassService, ProClassConst, ProConst, ProService, Problem
 from services.rate import RateService
 from services.user import UserService, UserConst
 
 PERMISSION_DENIED_ERROR = (('Eacces', 'Permission denied'))
-
-def user_ac_cmp(pro):
-    user_ac_chal_cnt = pro['rate_data']['user_ac_chal_cnt']
-    user_all_chal_cnt = pro['rate_data']['user_all_chal_cnt']
-
-    if user_ac_chal_cnt and user_all_chal_cnt:
-        return user_ac_chal_cnt / user_all_chal_cnt
-
-    else:
-        return -1
-
-
-def chal_ac_cmp(pro):
-    ac_chal_cnt = pro['rate_data']['ac_chal_cnt']
-    all_chal_cnt = pro['rate_data']['all_chal_cnt']
-
-    if ac_chal_cnt and all_chal_cnt:
-        return ac_chal_cnt / all_chal_cnt
-
-    else:
-        return -1
-
 
 class ProsetHandler(RequestHandler):
     @reqenv
@@ -49,6 +27,10 @@ class ProsetHandler(RequestHandler):
             'name': search_name,
             'tags': search_tags,
         }
+        if search_name:
+            search_name = search_name.lower()
+        if search_tags:
+            search_tags = search_tags.lower()
 
         proclass_id = int(self.get_argument('proclass_id', default=0))
         if proclass_id == 0:
@@ -72,72 +54,82 @@ class ProsetHandler(RequestHandler):
                 return self.error(PERMISSION_DENIED_ERROR)
 
             p_list = proclass['list']
-            prolist = list(filter(lambda pro: pro['pro_id'] in p_list, prolist))
+            prolist = list(filter(lambda pro: pro.pro_id in p_list, prolist))
             if proclass['acct_id']:
                 _, creator = await UserService.inst.info_acct(proclass['acct_id'])
                 proclass['creator_name'] = creator.name
 
-        if search_name:
-            search_name = search_name.lower()
-            def _find_name(name: str):
-                return name.lower().find(search_name) != -1
-            prolist = filter(lambda pro: _find_name(pro['name']), prolist)
-
-        if show_only_online_pro:
-            prolist = filter(lambda pro: pro['status'] == ProConst.STATUS_ONLINE, prolist)
-
         _, acct_states = await RateService.inst.map_rate_acct(self.acct)
+        score_map: dict[int, dict] = {}
         ac_pro_cnt = 0
-        def _set_pro_state_and_tags(pro):
-            nonlocal ac_pro_cnt
-            pro['state'] = acct_states.get(pro['pro_id'], {}).get('state')
-            ac_pro_cnt += pro['state'] == ChalConst.STATE_AC
-
-            if (self.acct.is_guest()) or (not self.acct.is_kernel() and pro['state'] != ChalConst.STATE_AC):
-                pro['tags'] = ''
-
-            return pro
-
-        prolist = map(lambda pro: _set_pro_state_and_tags(pro), prolist)
-
-        if search_tags:
-            search_tags = search_tags.lower()
-            def _find_tags(tags: str):
-                return tags.lower().find(search_tags) != -1
-            prolist = filter(lambda pro: _find_tags(pro['tagss']), prolist)
-
-        if problem_show == "onlyac":
-            prolist = filter(lambda pro: pro['state'] == ChalConst.STATE_AC, prolist)
-
-        elif problem_show == "notac":
-            prolist = filter(lambda pro: pro['state'] != ChalConst.STATE_AC, prolist)
-
-        prolist = list(prolist)
+        new_prolist: list[Problem] = []
         for pro in prolist:
-            _, rate = await RateService.inst.get_pro_ac_rate(pro['pro_id'])
-            pro['rate_data'] = rate
+            pro_id = pro.pro_id
+            pro_state = acct_states.get(pro.pro_id, {}).get('state')
+
+            if show_only_online_pro and pro.status != ProConst.STATUS_ONLINE:
+                continue
+
+            if problem_show == "onlyac" and pro_state != ChalConst.STATE_AC:
+                continue
+
+            elif problem_show == "notac" and pro_state == ChalConst.STATE_AC:
+                continue
+
+            if search_name and pro.name.lower().find(search_name) == -1:
+                continue
+
+            if search_tags and pro.tags.lower().find(search_tags) == -1:
+                continue
+
+            if (self.acct.is_guest()) or (not self.acct.is_kernel() and pro_state != ChalConst.STATE_AC):
+                pro.tags = ''
+
+            _, rate = await RateService.inst.get_pro_ac_rate(pro.pro_id)
+            score_map[pro_id] = {'state': pro_state, 'rate_data': rate}
+            new_prolist.append(pro)
+
+        prolist = new_prolist
+        def user_ac_cmp(pro: Problem):
+            pro_id = pro.pro_id
+            user_ac_chal_cnt = score_map[pro_id]['rate_data']['user_ac_chal_cnt']
+            user_all_chal_cnt = score_map[pro_id]['rate_data']['user_all_chal_cnt']
+
+            if user_ac_chal_cnt and user_all_chal_cnt:
+                return user_ac_chal_cnt / user_all_chal_cnt
+            else:
+                return -1
+
+        def chal_ac_cmp(pro: Problem):
+            pro_id = pro.pro_id
+            ac_chal_cnt = score_map[pro_id]['rate_data']['ac_chal_cnt']
+            all_chal_cnt = score_map[pro_id]['rate_data']['all_chal_cnt']
+
+            if ac_chal_cnt and all_chal_cnt:
+                return ac_chal_cnt / all_chal_cnt
+            else:
+                return -1
+
+        def cmp(pro: Problem, key: str):
+            return score_map[pro.pro_id]['rate_data'][key]
 
         if order == "chal":
-            prolist.sort(key=chal_ac_cmp)
-
+            prolist = sorted(prolist, key=chal_ac_cmp)
         elif order == "user":
-            prolist.sort(key=user_ac_cmp)
-
+            prolist = sorted(prolist, key=user_ac_cmp)
         elif order == "chalcnt":
-            prolist.sort(key=lambda pro: pro['rate_data']['all_chal_cnt'])
-
+            prolist = sorted(prolist, key=lambda pro: cmp(pro, 'all_chal_cnt'))
         elif order == "chalaccnt":
-            prolist.sort(key=lambda pro: pro['rate_data']['ac_chal_cnt'])
-
+            prolist = sorted(prolist, key=lambda pro: cmp(pro, 'ac_chal_cnt'))
         elif order == "usercnt":
-            prolist.sort(key=lambda pro: pro['rate_data']['user_all_chal_cnt'])
-
+            prolist = sorted(prolist, key=lambda pro: cmp(pro, 'user_all_chal_cnt'))
         elif order == "useraccnt":
-            prolist.sort(key=lambda pro: pro['rate_data']['user_ac_chal_cnt'])
+            prolist = sorted(prolist, key=lambda pro: cmp(pro, 'usr_ac_chal_cnt'))
 
         if order_reverse:
-            prolist.reverse()
+            prolist = reversed(prolist)
 
+        prolist = list(prolist)
         pro_total_cnt = len(prolist)
         prolist = prolist[pageoff: pageoff + 40]
 
@@ -147,6 +139,7 @@ class ProsetHandler(RequestHandler):
             pro_total_cnt=pro_total_cnt,
             ac_pro_cnt=ac_pro_cnt,
             prolist=prolist,
+            score_map=score_map,
             cur_proclass=proclass,
             pageoff=pageoff,
             flt=flt,
@@ -248,7 +241,7 @@ class ProStaticHandler(RequestHandler):
         if err:
             return self.error(err)
 
-        if pro['status'] == ProConst.STATUS_CONTEST:
+        if pro.status == ProConst.STATUS_CONTEST:
             if not (self.contest.is_running() or self.contest.is_admin(self.acct)):
                 return self.error(PERMISSION_DENIED_ERROR)
 
@@ -297,17 +290,17 @@ class ProHandler(RequestHandler):
         # NOTE: Admin can see tags
         # NOTE: User get ac can see tags
 
-        if self.acct.is_guest() or pro['tags'] is None or pro['tags'] == '':
-            pro['tags'] = ''
+        if self.acct.is_guest():
+            pro.tags = ''
 
         elif not self.acct.is_kernel():
             async with self.db.acquire() as con:
                 result = await con.fetchrow(
                     '''
-                        SELECT MIN("challenge_state"."state") AS "state"
+                        SELECT MIN("total_result"."state") AS "state"
                         FROM "challenge"
-                        INNER JOIN "challenge_state"
-                        ON "challenge"."chal_id" = "challenge_state"."chal_id"
+                        INNER JOIN "total_result"
+                        ON "challenge"."chal_id" = "total_result"."chal_id"
                         AND "challenge"."acct_id" = $1
                         INNER JOIN "problem"
                         ON "challenge"."pro_id" = $3
@@ -315,11 +308,11 @@ class ProHandler(RequestHandler):
                     ''',
                     self.acct.acct_id,
                     ChalConst.STATE_AC,
-                    int(pro['pro_id']),
+                    pro.pro_id
                 )
 
             if result['state'] is None or result['state'] != ChalConst.STATE_AC:
-                pro['tags'] = ''
+                pro.tags = ''
 
         can_submit = JudgeServerClusterService.inst.is_server_online()
         topcoder = None
@@ -360,9 +353,8 @@ class ProTagsHandler(RequestHandler):
             'manage.pro.update.tag',
         )
 
-        err, _ = await ProService.inst.update_pro(
-            pro_id, pro['name'], pro['status'], tags, pro['allow_submit']
-        )
+        pro.tags = tags
+        err, _ = await ProService.inst.update_pro(pro)
 
         if err:
             return self.error(err)

--- a/src/handlers/rank.py
+++ b/src/handlers/rank.py
@@ -33,9 +33,9 @@ class ProRankHandler(RequestHandler):
                         "challenge"."acct_id",
                         "challenge"."timestamp",
                         "account"."name" AS "acct_name",
-                        "challenge_state"."runtime",
-                        "challenge_state"."memory",
-                        ROUND("challenge_state"."rate", "problem"."rate_precision") AS rate
+                        "total_result"."time",
+                        "total_result"."memory",
+                        ROUND("total_result"."rate", "problem"."rate_precision") AS rate
 
                     FROM "challenge"
 
@@ -45,16 +45,16 @@ class ProRankHandler(RequestHandler):
                     INNER JOIN "account"
                     ON "challenge"."acct_id"="account"."acct_id"
 
-                    INNER JOIN "challenge_state"
-                    ON "challenge"."chal_id"="challenge_state"."chal_id"
+                    INNER JOIN "total_result"
+                    ON "challenge"."chal_id"="total_result"."chal_id"
 
-                    WHERE "challenge_state"."state"={ChalConst.STATE_AC} AND "challenge"."contest_id" = 0
+                    WHERE "total_result"."state"={ChalConst.STATE_AC} AND "challenge"."contest_id" = 0
 
-                    ORDER BY "challenge"."acct_id" ASC, "challenge_state"."rate" DESC,
-                    "challenge_state"."runtime" ASC, "challenge_state"."memory" ASC,
+                    ORDER BY "challenge"."acct_id" ASC, "total_result"."rate" DESC,
+                    "total_result"."time" ASC, "total_result"."memory" ASC,
                     "challenge"."timestamp" ASC
                 ) temp
-                ORDER BY "rate" DESC, "runtime" ASC, "memory" ASC,
+                ORDER BY "rate" DESC, "time" ASC, "memory" ASC,
                 "timestamp" ASC, "acct_id" ASC OFFSET $2 LIMIT $3;
                 '''
                 ,
@@ -70,9 +70,9 @@ class ProRankHandler(RequestHandler):
                 SELECT DISTINCT challenge.acct_id
                 FROM challenge
                 INNER JOIN account ON challenge.acct_id=account.acct_id
-                INNER JOIN challenge_state ON challenge.chal_id=challenge_state.chal_id
+                INNER JOIN total_result ON challenge.chal_id=total_result.chal_id
                 WHERE challenge.pro_id=$1
-                AND challenge_state.state=1
+                AND total_result.state=1
                 ) temp;
                 ''',
                 pro_id,
@@ -80,14 +80,14 @@ class ProRankHandler(RequestHandler):
             total_cnt = total_cnt[0]['count']
 
         chal_list = []
-        for rank, (chal_id, acct_id, timestamp, acct_name, runtime, memory, rate) in enumerate(result):
+        for rank, (chal_id, acct_id, timestamp, acct_name, time, memory, rate) in enumerate(result):
             chal_list.append(
                 {
                     'rank': rank + pageoff + 1,
                     'chal_id': chal_id,
                     'acct_id': acct_id,
                     'acct_name': acct_name,
-                    'runtime': int(runtime),
+                    'time': int(time),
                     'memory': int(memory),
                     'rate': rate,
                     'timestamp': timestamp.astimezone(tz),
@@ -109,9 +109,9 @@ class UserRankHandler(RequestHandler):
             f'''
             WITH accepted_tests_per_user AS (
                 SELECT DISTINCT
-                    t."acct_id", t."pro_id", t."test_idx", t."rate"
+                    t."acct_id", t."pro_id", t."subtask_id", t."rate"
                 FROM
-                    "test" t
+                    "subtask_result" t
                 INNER JOIN "problem"
                     ON t."pro_id" = "problem"."pro_id"
                 WHERE
@@ -124,7 +124,7 @@ class UserRankHandler(RequestHandler):
                     test_valid_rate
                 INNER JOIN accepted_tests_per_user
                     ON "test_valid_rate"."pro_id" = accepted_tests_per_user."pro_id"
-                    AND "test_valid_rate"."test_idx" = accepted_tests_per_user."test_idx"
+                    AND "test_valid_rate"."test_idx" = accepted_tests_per_user."subtask_id"
                 GROUP BY acct_id
             ), user_stats AS (
                 SELECT
@@ -140,7 +140,7 @@ class UserRankHandler(RequestHandler):
                 INNER JOIN
                     problem p ON p.pro_id = c.pro_id
                 INNER JOIN
-                    challenge_state cs ON c.chal_id = cs.chal_id
+                    total_result cs ON c.chal_id = cs.chal_id
                 INNER JOIN
                     user_total_rate ON user_total_rate.acct_id = c.acct_id
                 WHERE

--- a/src/handlers/submit.py
+++ b/src/handlers/submit.py
@@ -48,10 +48,10 @@ class SubmitHandler(RequestHandler):
         if err:
             return self.error(err)
 
-        if not pro['allow_submit']:
+        if not pro.allow_submit:
             return self.error(('Eacces', 'Problem did not allow submit'))
 
-        if pro['testm_conf']['is_makefile']:
+        if pro.config.is_makefile:
             allow_compilers = list(filter(lambda compiler: compiler in ['gcc', 'g++', 'clang', 'clang++'], allow_compilers))
 
         await self.render('submit', pro=pro,
@@ -77,7 +77,7 @@ class SubmitHandler(RequestHandler):
         if reqtype == 'submit':
             pro_id = int(self.get_argument('pro_id'))
             code = self.get_argument('code')
-            comp_type = str(self.get_argument('comp_type'))
+            compiler_type = str(self.get_argument('compiler_type'))
 
             if self.contest:
                 pri = ChalConst.CONTEST_PRI
@@ -92,22 +92,22 @@ class SubmitHandler(RequestHandler):
                 if self.acct.is_kernel():
                     allow_statuses = ProConst.PRO_STATUS_KERNEL_USER
 
-            if err := await self.is_allow_submit(code, comp_type, pro_id):
+            if err := await self.is_allow_submit(code, compiler_type, pro_id):
                 return self.error(err)
 
             err, pro = await ProService.inst.get_pro(pro_id, allow_statuses)
             if err:
                 return self.error(err)
 
-            if not pro['allow_submit']:
+            if not pro.allow_submit:
                 return self.error(('Eacces', 'Problem did not allow submit'))
 
-            err, chal_id = await ChalService.inst.add_chal(pro_id, self.acct.acct_id, contest_id, comp_type, code)
+            err, chal_id = await ChalService.inst.add_chal(pro_id, self.acct.acct_id, contest_id, compiler_type, code)
             if err:
                 return self.error(err)
 
-            if self.acct.last_compiler != comp_type:
-                self.acct.last_compiler = comp_type
+            if self.acct.last_compiler != compiler_type:
+                self.acct.last_compiler = compiler_type
                 err, _ = await UserService.inst.update_acct(self.acct)
                 if err:
                     return self.error(err)
@@ -125,8 +125,8 @@ class SubmitHandler(RequestHandler):
                 err, _ = await ChalService.inst.reset_chal(chal_id)
                 err, chal = await ChalService.inst.get_chal(chal_id)
 
-                pro_id = chal['pro_id']
-                comp_type = chal['comp_type']
+                pro_id = chal.pro_id
+                compiler_type = chal.compiler_type
                 err, pro = await ProService.inst.get_pro(pro_id, allow_statuses)
                 if err:
                     return self.error(err)
@@ -134,22 +134,16 @@ class SubmitHandler(RequestHandler):
         else:
             return self.error(('Eunk', 'Unknown error'))
 
-        err, _ = await ChalService.inst.emit_chal(
-            chal_id,
-            pro_id,
-            pro['testm_conf'],
-            comp_type,
-            pri=pri
-        )
+        err, _ = await ChalService.inst.emit_chal(chal_id, pro_id, pro.config, compiler_type, pri)
         if err:
             return self.error(err)
 
-        if reqtype == 'submit' and pro['status'] == ProConst.STATUS_ONLINE:
+        if reqtype == 'submit' and pro.status == ProConst.STATUS_ONLINE:
             await self.rs.publish('challist_sub', str(1))
 
         self.error(('S', chal_id))
 
-    async def is_allow_submit(self, code: str, comp_type: str, pro_id: int):
+    async def is_allow_submit(self, code: str, compiler_type: str, pro_id: int):
         # limits variable config
         allow_compilers = ChalConst.ALLOW_COMPILERS
         submit_cd_time = 30
@@ -164,7 +158,7 @@ class SubmitHandler(RequestHandler):
             return ('Ecodemax', 'Submitted code too long')
 
         # TODO: if problem is makefile type, we should restrict compiler type
-        if comp_type not in allow_compilers:
+        if compiler_type not in allow_compilers:
             return ('Ecomp', 'The compiler is not allowed')
 
         should_check_submit_cd = (
@@ -176,7 +170,7 @@ class SubmitHandler(RequestHandler):
         name = ''
         crc32 = ''
         if self.contest:
-            name = f'contest_{self.contest.contest_id}_acct_{self.acct.acct_id}_pro_{pro_id}_compiler_{comp_type}'
+            name = f'contest_{self.contest.contest_id}_acct_{self.acct.acct_id}_pro_{pro_id}_compiler_{compiler_type}'
             crc32 = str(zlib.crc32(code.encode('utf-8')))
 
             if (await self.rs.sismember(name, crc32)):

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -4,9 +4,7 @@ import os
 import decimal
 
 from services.judge import JudgeServerClusterService
-from services.pro import ProConst
-
-TZ = datetime.timezone(datetime.timedelta(hours=+8))
+from services.pro import ProConst, ProblemConfig
 
 class ChalConst:
     STATE_AC = 1
@@ -88,6 +86,55 @@ class ChalConst:
     CONTEST_REJUDGE_PRI = 2
     NORMAL_REJUDGE_PRI = 3
 
+@dataclass(slots=True)
+class SubtaskResult:
+    """
+    - 'subtask_id' (int): Subtask result id.
+    - 'state' (int): Challenge state, between ChalConst.STATE_AC and ChalConst.STATE_NOTSTARTED.
+    - 'time' (int): Total time in milliseconds.
+    - 'memory' (int): Memory usage in kilobytes.
+    - 'response' (str): Compiler or checker message.
+    - 'rate' (decimal.Decimal), rounded by problem.rate_precision
+    """
+    subtask_id: int
+    state: int
+    time: int
+    memory: int
+    response: str
+    rate: decimal.Decimal
+
+    def __post_init__(self):
+        assert ChalConst.STATE_AC <= self.state <= ChalConst.STATE_NOTSTARTED
+        assert self.time >= 0
+        assert self.memory >= 0
+
+@dataclass(slots=True)
+class TotalResult:
+    state: int
+    time: int
+    memory: int
+    rate: decimal.Decimal
+
+    def __post_init__(self):
+        assert ChalConst.STATE_AC <= self.state <= ChalConst.STATE_NOTSTARTED
+        assert self.time >= 0
+        assert self.memory >= 0
+
+@dataclass(slots=True)
+class Challenge:
+    chal_id: int
+    pro_id: int
+    acct_id: int
+    contest_id: int
+    acct_name: str
+    compiler_type: str
+    timestamp: datetime.datetime
+    subtask_results: dict[int, SubtaskResult] | None
+    total_result: TotalResult | None
+
+    def __post_init__(self):
+        assert self.compiler_type in ChalConst.ALLOW_COMPILERS
+
 
 @dataclass
 class ChalSearchingParam:
@@ -154,9 +201,9 @@ class ChalSearchingParam:
 
         if self.state != 0:
             if self.state == ChalConst.STATE_NOTSTARTED:
-                query.append(' AND "challenge_state"."state" IS NULL ')
+                query.append(' AND "total_result"."state" IS NULL ')
             else:
-                query.append(f' AND "challenge_state"."state" = {self.state} ')
+                query.append(f' AND "total_result"."state" = {self.state} ')
 
         if self.compiler != 'all':
             query.append(f' AND "challenge"."compiler_type"=\'{self.compiler}\' ')
@@ -252,8 +299,7 @@ class ChalSearchingParamBuilder:
         """Returns the constructed `ChalSearchingParam` object."""
         return self.param
 
-from typing import Any
-ReturnType = tuple[tuple[str, Any], None] | tuple[None, Any]
+ErrorType = tuple[tuple[str, str], None]
 
 class ChalService:
     def __init__(self, db, rs):
@@ -262,7 +308,7 @@ class ChalService:
 
         ChalService.inst = self
 
-    async def add_chal(self, pro_id: int, acct_id: int, contest_id: int, comp_type: str, code: str):
+    async def add_chal(self, pro_id: int, acct_id: int, contest_id: int, compiler_type: str, code: str) -> tuple[None, int] | ErrorType:
         """
         Add a new challenge entry and save the submitted source code.
 
@@ -270,7 +316,7 @@ class ChalService:
             pro_id (int): Problem ID.
             acct_id (int): Account ID (user submitting the challenge).
             contest_id (int): Contest ID.
-            comp_type (str): Compiler type (must be in ChalConst.ALLOW_COMPILERS).
+            compiler_type (str): Compiler type (must be in ChalConst.ALLOW_COMPILERS).
             code (str): Source code content as string.
 
         Returns:
@@ -279,7 +325,7 @@ class ChalService:
                 On failure, (error_code, None).
         """
 
-        assert comp_type in ChalConst.ALLOW_COMPILERS
+        assert compiler_type in ChalConst.ALLOW_COMPILERS
 
         pro_id = int(pro_id)
         acct_id = int(acct_id)
@@ -292,7 +338,7 @@ class ChalService:
                 ''',
                 pro_id,
                 acct_id,
-                comp_type,
+                compiler_type,
                 contest_id,
             )
         if len(result) != 1:
@@ -301,7 +347,7 @@ class ChalService:
 
         chal_id = result['chal_id']
 
-        file_ext = ChalConst.FILE_EXTENSION[comp_type]
+        file_ext = ChalConst.FILE_EXTENSION[compiler_type]
 
         os.mkdir(f'code/{chal_id}')
         with open(f"code/{chal_id}/main.{file_ext}", 'wb') as code_f:
@@ -309,7 +355,7 @@ class ChalService:
 
         return None, chal_id
 
-    async def reset_chal(self, chal_id: int):
+    async def reset_chal(self, chal_id: int) -> tuple[None, None]:
         """
         Reset a challenge by deleting all its associated tests and updating its state.
 
@@ -322,12 +368,12 @@ class ChalService:
 
         chal_id = int(chal_id)
         async with self.db.acquire() as con:
-            await con.execute('DELETE FROM "test" WHERE "chal_id" = $1;', chal_id)
+            await con.execute('DELETE FROM "subtask_result" WHERE "chal_id" = $1;', chal_id)
 
-        await self.update_challenge_state(chal_id)
+        await self.update_total_result(chal_id)
         return None, None
 
-    async def get_chal_state(self, chal_id: int):
+    async def get_subtask_results(self, chal_id: int) -> tuple[None, dict[int, SubtaskResult]]:
         """
         Retrieve detailed test results of a challenge.
 
@@ -335,52 +381,37 @@ class ChalService:
             chal_id (int): Challenge ID.
 
         Returns:
-            tuple[Optional[tuple[str, str]], Optional[list[dict]]]:
-                On success, (None, list) where each dict represents a test with keys:
-                    - 'test_idx' (int): Test index.
-                    - 'state' (int): Challenge state, between ChalConst.STATE_AC and ChalConst.STATE_NOTSTARTED.
-                    - 'runtime' (int): Total runtime in milliseconds.
-                    - 'memory' (int): Memory usage in kilobytes.
-                    - 'response' (str): Compiler or checker message.
-                    - 'rate' (decimal.Decimal), rounded by problem.rate_precision
+            tuple[Optional[tuple[str, str]], Optional[dict[int, SubtaskResult]]:
+                On success, (None, dict[int, SubtaskResult]) where each dict represents a subtask.
                 On failure, (error_code, None).
         """
         chal_id = int(chal_id)
         async with self.db.acquire() as con:
             result = await con.fetch(
                 '''
-                    SELECT "test"."test_idx", "state", "runtime", "memory", "response",
-                    ROUND(COALESCE(test.rate, tvr.rate), problem.rate_precision)
-                    FROM "test"
+                    SELECT subtask_result.subtask_id, state, time, memory, response,
+                    ROUND(COALESCE(subtask_result.rate, tvr.rate), problem.rate_precision)
+                    FROM subtask_result
                     INNER JOIN test_valid_rate AS tvr
-                    ON test.pro_id = tvr.pro_id AND test.test_idx = tvr.test_idx
+                    ON subtask_result.pro_id = tvr.pro_id AND subtask_result.subtask_id = tvr.test_idx
                     INNER JOIN problem
-                    ON test.pro_id = problem.pro_id
-                    WHERE "chal_id" = $1 ORDER BY "test_idx" ASC;
+                    ON subtask_result.pro_id = problem.pro_id
+                    WHERE "chal_id" = $1 ORDER BY "subtask_id" ASC;
                 ''',
                 chal_id,
             )
 
-        tests = []
-        for test_idx, state, runtime, memory, response, rate in result:
+        results: dict[int, SubtaskResult] = {}
+        for subtask_id, state, time, memory, response, rate in result:
             r = 0
             if state in [ChalConst.STATE_AC, ChalConst.STATE_PC]:
                 r = rate
 
-            tests.append(
-                {
-                    'test_idx': test_idx,
-                    'state': state,
-                    'runtime': int(runtime),
-                    'memory': int(memory),
-                    'response': response,
-                    'rate': r,
-                }
-            )
+            results[subtask_id] = SubtaskResult(subtask_id, state, int(time), int(memory), response, decimal.Decimal(r))
 
-        return None, tests
+        return None, results
 
-    async def get_chal(self, chal_id: int, with_test=False) -> ReturnType:
+    async def get_chal(self, chal_id: int, with_result=False) -> tuple[None, Challenge] | ErrorType:
         """
         Retrieve challenge info with optional test details.
 
@@ -389,16 +420,8 @@ class ChalService:
             with_test (bool): Whether to include detailed test results.
 
         Returns:
-            tuple[Optional[tuple[str, str]], Optional[dict]]:
-                On success, (None, dict) where dict contains:
-                    - 'chal_id' (int): Challenge ID.
-                    - 'pro_id' (int): Problem ID.
-                    - 'acct_id' (int): Account ID.
-                    - 'contest_id' (int): Contest ID.
-                    - 'comp_type' (str): Compiler type, must be in ChalConst.ALLOW_COMPILER.
-                    - 'timestamp' (datetime.datetime): Timestamp of challenge submission.
-                    - 'acct_name' (str): Account name of submitter.
-                    - 'testl' (list[dict], optional): Please see `get_chal_state()`
+            tuple[Optional[tuple[str, str]], Optional[Challenge]]:
+                On success, (None, Challenge)
                 On failure, (error_code, None).
         """
 
@@ -419,7 +442,7 @@ class ChalService:
             return ('Enoext', 'Challenge Not Found'), None
         result = result[0]
 
-        pro_id, acct_id, timestamp, comp_type, contest_id, acct_name = (
+        pro_id, acct_id, timestamp, compiler_type, contest_id, acct_name = (
             result['pro_id'],
             result['acct_id'],
             result['timestamp'],
@@ -428,25 +451,14 @@ class ChalService:
             result['acct_name'],
         )
 
-        testl = []
-        if with_test:
-            _, testl = await self.get_chal_state(chal_id)
+        subtask_results = {}
+        if with_result:
+            _, subtask_results = await self.get_subtask_results(chal_id)
 
-        return (
-            None,
-            {
-                'chal_id': chal_id,
-                'pro_id': pro_id,
-                'acct_id': acct_id,
-                'contest_id': contest_id,
-                'acct_name': acct_name,
-                'timestamp': timestamp.astimezone(TZ),
-                'testl': testl,
-                'comp_type': comp_type,
-            },
-        )
+        return None, Challenge(chal_id, pro_id, acct_id, contest_id, acct_name, compiler_type,
+                               timestamp, subtask_results, total_result=None)
 
-    async def emit_chal(self, chal_id: int, pro_id: int, testm_conf: dict, comp_type: str, pri: int):
+    async def emit_chal(self, chal_id: int, pro_id: int, conf: ProblemConfig, compiler_type: str, pri: int) -> tuple[None, None] | ErrorType:
         """
         Create and submit tests for a challenge based on the test metadata configuration,
         then send the challenge to the judging cluster.
@@ -455,14 +467,14 @@ class ChalService:
             chal_id (int): Challenge ID.
             pro_id (int): Problem ID.
             testm_conf (dict): Test metadata configuration.
-            comp_type (str): Compiler type (must be in ChalConst.ALLOW_COMPILERS).
+            compiler_type (str): Compiler type (must be in ChalConst.ALLOW_COMPILERS).
             pri (int): Priority level (within ChalConst.NORMAL_PRI and ChalConst.NORMAL_REJUDGE_PRI).
 
         Returns:
             tuple[None, None]: Always returns (None, None) on completion.
         """
 
-        assert comp_type in ChalConst.ALLOW_COMPILERS
+        assert compiler_type in ChalConst.ALLOW_COMPILERS
         assert ChalConst.NORMAL_PRI <= pri <= ChalConst.NORMAL_REJUDGE_PRI
 
         chal_id = int(chal_id)
@@ -481,45 +493,45 @@ class ChalService:
         result = result[0]
 
         acct_id, contest_id, timestamp = int(result['acct_id']), int(result['contest_id']), result['timestamp']
-        limit = testm_conf['limit']
-        timelimit = limit.get(comp_type, limit['default'])['timelimit']
-        memlimit = limit.get(comp_type, limit['default'])['memlimit']
+        limits = conf.limits
+        timelimit = limits.get(compiler_type, limits['default']).time
+        memlimit = limits.get(compiler_type, limits['default']).memory
 
         async with self.db.acquire() as con:
             testl = []
             insert_values = []
-            for test_group_idx, test in testm_conf['test_group'].items():
+            for subtask_id, subtask_conf in conf.subtask_configs.items():
                 testl.append(
                     {
-                        'test_idx': test_group_idx,
+                        'test_idx': subtask_id,
                         'timelimit': timelimit,
                         'memlimit': memlimit,
-                        'metadata': {'data': [testm_conf['testdatas'][testdata_id]['inputfile'].removesuffix('.in') for testdata_id in test['testdatas']]},
+                        'metadata': {'data': [conf.testdatas[testdata.testdata_id].inputfile.removesuffix('.in') for testdata in subtask_conf.testdatas]},
                     }
                 )
-                insert_values.append((chal_id, acct_id, pro_id, test_group_idx, ChalConst.STATE_JUDGE, timestamp))
+                insert_values.append((chal_id, acct_id, pro_id, subtask_id, ChalConst.STATE_JUDGE, timestamp))
 
             await con.executemany(
-            '''INSERT INTO "test"
-                ("chal_id", "acct_id", "pro_id", "test_idx", "state", "timestamp")
+            '''INSERT INTO "subtask_result"
+                ("chal_id", "acct_id", "pro_id", "subtask_id", "state", "timestamp")
                 VALUES ($1, $2, $3, $4, $5, $6);''',
                 insert_values
             )
 
-        await self.update_challenge_state(chal_id)
+        await self.update_total_result(chal_id)
 
-        file_ext = ChalConst.FILE_EXTENSION[comp_type]
+        file_ext = ChalConst.FILE_EXTENSION[compiler_type]
 
         if not os.path.isfile(f"code/{chal_id}/main.{file_ext}"):
-            for test in testl:
-                await self.update_test(chal_id, test['test_idx'], ChalConst.STATE_ERR, 0, 0, None, '', rate_is_cms_type=False, refresh_db=False)
-                await self.update_challenge_state(chal_id)
+            for subtask_conf in testl:
+                await self.update_subtask_result(chal_id,
+                                                 SubtaskResult(subtask_conf['test_idx'], ChalConst.STATE_ERR, time=0, memory=0, response='', rate=decimal.Decimal(0)),
+                                                 rate_is_cms_type=False, refresh_db=False)
+            await self.update_total_result(chal_id)
             return None, None
 
-        chalmeta = testm_conf['chalmeta']
-
-        if testm_conf['is_makefile']:
-            comp_type = 'makefile'
+        if conf.is_makefile:
+            compiler_type = 'makefile'
 
         await JudgeServerClusterService.inst.send(
             {
@@ -528,9 +540,9 @@ class ChalService:
                 'test': testl,
                 'code_path': f'{chal_id}/main.{file_ext}',
                 'res_path': f'{pro_id}/res',
-                'metadata': chalmeta,
-                'comp_type': comp_type,
-                'check_type': ProConst.CHECKER_TYPE[testm_conf['check_type']],
+                'metadata': conf.chalmeta,
+                'comp_type': compiler_type,
+                'check_type': ProConst.CHECKER_TYPE[conf.checker_type],
             },
             pro_id,
             contest_id,
@@ -540,7 +552,8 @@ class ChalService:
 
         return None, None
 
-    async def list_chal(self, off: int, num: int, flt: ChalSearchingParam):
+    async def list_chal(self, off: int, num: int, flt: ChalSearchingParam) -> tuple[None, list[Challenge]]:
+        # TODO: docstirng without challenge.subtask_result
         """
         List challenges with filtering, pagination, and joined related info.
 
@@ -550,18 +563,7 @@ class ChalService:
             flt (ChalSearchingParam): Filter parameters.
 
         Returns:
-            tuple[None, list[dict]]: On success, returns (None, challist) where each item is a dict with keys:
-                - 'chal_id' (int): Challenge ID.
-                - 'pro_id' (int): Problem ID.
-                - 'acct_id' (int): Account ID.
-                - 'contest_id' (int): Contest ID.
-                - 'comp_type' (str): Compiler type, must be in ChalConst.ALLOW_COMPILER.
-                - 'timestamp' (datetime.datetime): Timestamp of challenge submission.
-                - 'acct_name' (str): Account name of submitter.
-                - 'state' (int): Challenge state, between ChalConst.STATE_AC and ChalConst.STATE_NOTSTARTED.
-                - 'runtime' (int): Total runtime in milliseconds.
-                - 'memory' (int): Memory usage in kilobytes.
-                - 'rate' (decimal.Decimal): Score or rate of the challenge, rounded by `problem.rate_precision`.
+            tuple[None, list[Challenge]]: On success, returns (None, list[Challenge]) but Challenge without subtask_results:
         """
         fltquery = flt.get_sql_query_str()
 
@@ -570,60 +572,45 @@ class ChalService:
                 f'''
                     SELECT "challenge"."chal_id", "challenge"."pro_id", "challenge"."acct_id", "challenge"."contest_id",
                     "challenge"."compiler_type", "challenge"."timestamp", "account"."name" AS "acct_name",
-                    "challenge_state"."state", "challenge_state"."runtime", "challenge_state"."memory",
-                    ROUND("challenge_state"."rate", problem.rate_precision)
+                    "total_result"."state", "total_result"."time", "total_result"."memory",
+                    ROUND("total_result"."rate", problem.rate_precision)
                     FROM "challenge"
                     INNER JOIN "account"
                     ON "challenge"."acct_id" = "account"."acct_id"
                     INNER JOIN "problem"
                     ON "challenge"."pro_id" = "problem"."pro_id"
-                    LEFT JOIN "challenge_state"
-                    ON "challenge"."chal_id" = "challenge_state"."chal_id"
+                    LEFT JOIN "total_result"
+                    ON "challenge"."chal_id" = "total_result"."chal_id"
                     WHERE 1=1 {fltquery}
                     ORDER BY "challenge"."chal_id" DESC OFFSET {off} LIMIT {num};
                 '''
             )
 
-        challist = []
-        for chal_id, pro_id, acct_id, contest_id, comp_type, timestamp, acct_name, state, runtime, memory, rate in result:
+        challist: list[Challenge] = []
+        for chal_id, pro_id, acct_id, contest_id, compiler_type, timestamp, acct_name, state, time, memory, rate in result:
             if state is None:
                 state = ChalConst.STATE_NOTSTARTED
 
-            if runtime is None:
-                runtime = 0
+            if time is None:
+                time = 0
             else:
-                runtime = int(runtime)
+                time = int(time)
 
             if memory is None:
                 memory = 0
             else:
                 memory = int(memory)
 
-            tz = datetime.timezone(datetime.timedelta(hours=+8))
-
-            challist.append(
-                {
-                    'chal_id': chal_id,
-                    'pro_id': pro_id,
-                    'acct_id': acct_id,
-                    'contest_id': contest_id,
-                    'comp_type': ChalConst.COMPILER_NAME[comp_type],
-                    'timestamp': timestamp.astimezone(tz),
-                    'acct_name': acct_name,
-                    'state': state,
-                    'runtime': runtime,
-                    'memory': memory,
-                    'rate': rate,
-                }
-            )
-
+            challist.append(Challenge(chal_id, pro_id, acct_id, contest_id, acct_name,
+                                      compiler_type, timestamp, subtask_results=None,
+                                      total_result=TotalResult(state, time, memory, rate)))
         return None, challist
 
-    async def get_calculated_chal_state(self, chal_id: int, allow_pro_statuses: list[int]):
+    async def get_total_result(self, chal_id: int, allow_pro_statuses: list[int]) -> tuple[None, TotalResult] | tuple[tuple[str, str], None]:
         """
         Retrieve the aggregated state of a challenge filtered by allowed problem statuses.
 
-        This method queries the `challenge_state` table joined with `problem` to ensure
+        This method queries the `total_result` table joined with `problem` to ensure
         that only challenges related to problems with statuses in `allow_pro_statuses` are considered.
 
         Args:
@@ -632,13 +619,8 @@ class ChalService:
                 Each status should be between `ProConst.STATUS_ONLINE` and `ProConst.STATUS_HIDDEN`.
 
         Returns:
-            tuple[Optional[tuple[str, str]], Optional[dict]]:
-                On success, returns (None, dict) where dict contains:
-                    - 'chal_id' (int): Challenge ID.
-                    - 'state' (int): Aggregated state of the challenge.
-                    - 'runtime' (int): Total runtime in milliseconds.
-                    - 'memory' (int): Total memory usage in kilobytes.
-                    - 'rate' (Decimal): Aggregated rate/score.
+            tuple[Optional[tuple[str, str]], Optional[Challenge]]:
+                On success, returns (None, Challenge) but without subtask_results:
                 On failure (e.g., challenge not found), returns (error_code, None).
         """
 
@@ -651,14 +633,20 @@ class ChalService:
         async with self.db.acquire() as con:
             result = await con.fetch(
                 f'''
-                    SELECT "challenge"."chal_id",
-                    "challenge_state"."state", "challenge_state"."runtime", "challenge_state"."memory",
-                    ROUND("challenge_state"."rate", problem.rate_precision) AS "rate"
-                    FROM "challenge"
-                    INNER JOIN "account" ON "challenge"."acct_id" = "account"."acct_id"
-                    INNER JOIN "problem" ON "challenge"."pro_id" = "problem"."pro_id"
-                    INNER JOIN "challenge_state" ON "challenge"."chal_id" = "challenge_state"."chal_id"
-                    WHERE "problem"."status" IN ({",".join(map(str, allow_pro_statuses))}) AND "challenge_state"."chal_id" = $1;
+                    SELECT
+                        cs.state,
+                        cs.time,
+                        cs.memory,
+                        ROUND(cs.rate, p.rate_precision) AS rate
+                    FROM
+                        challenge c
+                    INNER JOIN
+                        problem p ON c.pro_id = p.pro_id
+                    INNER JOIN
+                        total_result cs ON c.chal_id = cs.chal_id
+                    WHERE
+                        p.status IN ({",".join(map(str, allow_pro_statuses))})
+                        AND cs.chal_id = $1;
                 ''',
                 chal_id,
             )
@@ -667,13 +655,8 @@ class ChalService:
             return ('Enoext', 'Challenge not found'), None
         result = result[0]
 
-        return None, {
-            'chal_id': chal_id,
-            'state': result['state'],
-            'runtime': int(result['runtime']),
-            'memory': int(result['memory']),
-            'rate': result['rate'],
-        }
+        return None, TotalResult(result['state'], result['time'], result['memory'], result['rate'])
+
 
     async def get_chals_count(self, flt: ChalSearchingParam):
         """
@@ -683,8 +666,8 @@ class ChalService:
             flt (ChalSearchingParam): Filter parameters.
 
         Returns:
-            tuple[Optional[tuple[str, str]], Optional[dict]]:
-                On success, (None, {'total_chal': int}).
+            tuple[Optional[tuple[str, str]], Optional[int]]:
+                On success, (None, int).
                 On failure, (error_code, None).
         """
 
@@ -699,8 +682,8 @@ class ChalService:
                         ON "challenge"."acct_id" = "account"."acct_id"
                         INNER JOIN "problem"
                         ON "challenge"."pro_id" = "problem"."pro_id"
-                        LEFT JOIN "challenge_state"
-                        ON "challenge"."chal_id"="challenge_state"."chal_id"
+                        LEFT JOIN "total_result"
+                        ON "challenge"."chal_id"="total_result"."chal_id"
                         WHERE 1=1 {fltquery};
                     '''
                 )
@@ -710,78 +693,57 @@ class ChalService:
             return ('Eunk', 'Unknown error'), None
 
         total_chal = result[0]['count']
-        return None, {'total_chal': total_chal}
+        return None, total_chal
 
-    async def update_test(self, chal_id: int, test_idx: int, state: int, runtime: int, memory: int,
-                          rate: decimal.Decimal, response: str, rate_is_cms_type=False, refresh_db=True):
-        """
-        Update a single test entry with state, runtime, memory, response, and rate information.
-
-        Args:
-            chal_id (int): Challenge ID.
-            test_idx (int): Test index.
-            state (int): Test state (must be within ChalConst.STATE_AC and ChalConst.STATE_NOTSTARTED).
-            runtime (int): Runtime in milliseconds.
-            memory (int): Memory usage in kilobytes.
-            rate (decimal.Decimal): Rate/score value.
-            response (str): Compiler or checker message.
-            rate_is_cms_type (bool): If True, apply weighted rate calculation.
-            refresh_db (bool): If True, refresh challenge state after updating.
-
-        Returns:
-            tuple[None, None]: Always returns (None, None).
-        """
-
-        assert ChalConst.STATE_AC <= state <= ChalConst.STATE_NOTSTARTED
-
+    async def update_subtask_result(self, chal_id: int, subtask: SubtaskResult, rate_is_cms_type=False, refresh_db=True) -> tuple[None, None]:
         chal_id = int(chal_id)
         async with self.db.acquire() as con:
             await con.execute(
                 '''
-                    UPDATE "test"
-                    SET "state" = $1, "runtime" = $2, "memory" = $3, "response" = $4, "rate" = $5
-                    WHERE "chal_id" = $6 AND "test_idx" = $7;
+                    UPDATE "subtask_result"
+                    SET "state" = $1, "time" = $2, "memory" = $3, "response" = $4, "rate" = $5
+                    WHERE "chal_id" = $6 AND "subtask_id" = $7;
                 ''',
-                state,
-                runtime,
-                memory,
-                response,
-                rate,
+                subtask.state,
+                subtask.time,
+                subtask.memory,
+                subtask.response,
+                None if subtask.rate.is_infinite() else subtask.rate,
                 chal_id,
-                test_idx,
+                subtask.subtask_id,
             )
 
             if rate_is_cms_type:
                 await con.execute(
                     '''
-                        UPDATE "test"
-                        SET "rate" = $1::decimal * "test_config"."weight"::decimal
-                        FROM "test_config"
-                        WHERE "test"."chal_id" = $2 AND
-                              "test_config"."pro_id" = "test"."pro_id" AND
-                              "test_config"."test_idx" = $3 AND
-                              "test"."test_idx" = $3;
+                        UPDATE "subtask_result"
+                        SET "rate" = $1::decimal * "subtask_config"."rate"::decimal
+                        FROM "subtask_config"
+                        WHERE "subtask_result"."chal_id" = $2 AND
+                              "subtask_config"."pro_id" = "subtask_result"."pro_id" AND
+                              "subtask_config"."subtask_id" = $3 AND
+                              "subtask_result"."subtask_id" = $3;
                     ''',
-                    rate, chal_id, test_idx
+                    subtask.rate, chal_id, subtask.subtask_id
                 )
 
         if refresh_db:
-            await self.update_challenge_state(chal_id)
+            await self.update_total_result(chal_id)
 
         return None, None
 
-    async def update_challenge_state(self, chal_id: int):
+    async def update_total_result(self, chal_id: int):
         """
         Trigger the database function to aggregate and update the overall state of a challenge.
 
-        This function calls the PostgreSQL stored procedure `update_challenge_state(p_chal_id INTEGER)`
+        This function calls the PostgreSQL stored procedure `update_total_result(p_chal_id INTEGER)`
         which calculates the following aggregates from all tests belonging to the challenge:
         - The maximum test state (indicating the overall challenge status).
-        - The sum of runtimes across tests.
+        - The sum of time across tests.
         - The sum of memory usage across tests.
         - The sum of rates/scores, considering special scores or default rates.
 
-        The aggregated results are then upserted into the `challenge_state` table,
+        The aggregated results are then upserted into the `total_result` table,
         updating only when values have changed to avoid unnecessary writes.
 
         Args:
@@ -791,4 +753,4 @@ class ChalService:
             None
         """
 
-        await self.db.execute(f'SELECT update_challenge_state({chal_id});')
+        await self.db.execute(f'SELECT update_total_result({chal_id});')

--- a/src/services/code.py
+++ b/src/services/code.py
@@ -24,7 +24,7 @@ class CodeService:
                 return ('Enoext', 'Challenge not found'), None, None
             result = result[0]
 
-            target_acct_id, pro_id, contest_id, comp_type = int(result['acct_id']), int(result['pro_id']), int(
+            target_acct_id, pro_id, contest_id, compiler_type = int(result['acct_id']), int(result['pro_id']), int(
                 result['contest_id']), result['compiler_type']
 
         owner = await self.rs.get(f'{pro_id}_owner')
@@ -44,7 +44,7 @@ class CodeService:
                 can_see = True
 
         if can_see:
-            file_ext = ChalConst.FILE_EXTENSION[comp_type]
+            file_ext = ChalConst.FILE_EXTENSION[compiler_type]
 
             try:
                 with open(f'code/{chal_id}/main.{file_ext}', 'rb') as code_f:
@@ -56,4 +56,4 @@ class CodeService:
         else:
             return ('Eacces', 'Permission denied'), None, None
 
-        return None, code, comp_type
+        return None, code, compiler_type

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -388,11 +388,11 @@ class ContestService:
                 "challenge"."pro_id",
                 "challenge"."acct_id",
                 "challenge"."timestamp",
-                ROUND("challenge_state"."rate", problem.rate_precision) AS rate,
+                ROUND("total_result"."rate", problem.rate_precision) AS rate,
 
                 ROW_NUMBER() OVER (
                     PARTITION BY "challenge"."pro_id", "challenge"."acct_id"
-                    ORDER BY "challenge_state"."rate" DESC, "challenge"."timestamp" ASC
+                    ORDER BY "total_result"."rate" DESC, "challenge"."timestamp" ASC
                 ) AS rank,
 
                 COUNT(*) OVER (
@@ -403,11 +403,11 @@ class ContestService:
             FROM "challenge"
             INNER JOIN "contest_users"
                 ON "contest_users"."contest_id" = $1 AND "contest_users"."acct_id" = "challenge"."acct_id"
-                AND "contest_users"."status" = {UserStatus.APPROVED.value} OR "contest_users"."status" = {UserStatus.ADMIN}
+                AND "contest_users"."status" = {UserStatus.APPROVED} OR "contest_users"."status" = {UserStatus.ADMIN}
 
-            INNER JOIN "challenge_state"
+            INNER JOIN "total_result"
                 ON "challenge"."contest_id" = $1 AND "challenge"."pro_id" = $2
-                AND "challenge"."timestamp" < $3 AND "challenge"."chal_id" = "challenge_state"."chal_id"
+                AND "challenge"."timestamp" < $3 AND "challenge"."chal_id" = "total_result"."chal_id"
             INNER JOIN "problem"
             ON "problem"."pro_id" = $2
         )
@@ -447,8 +447,8 @@ class ContestService:
             WHERE contest_id = $1 AND timestamp < $3
         ),
         problem_tests AS (
-            SELECT pro_id, test_idx, weight
-            FROM test_config
+            SELECT pro_id, subtask_id, rate
+            FROM subtask_config
             WHERE pro_id = $2
         ),
         individual_test_results AS (
@@ -456,16 +456,15 @@ class ContestService:
                 cc.acct_id,
                 cc.chal_id,
                 pt.pro_id,
-                pt.test_idx,
-                pt.weight,
+                pt.subtask_id,
                 CASE
-                    WHEN t.state = 1 AND t.rate IS NULL THEN pt.weight
+                    WHEN t.state = 1 AND t.rate IS NULL THEN pt.rate
                     WHEN t.state = 1 AND t.rate IS NOT NULL THEN t.rate
                     ELSE 0
                 END AS rate,
                 t.timestamp
             FROM problem_tests pt
-            JOIN test t ON pt.pro_id = t.pro_id AND pt.test_idx = t.test_idx
+            JOIN subtask_result t ON pt.pro_id = t.pro_id AND pt.subtask_id = t.subtask_id
             JOIN contest_challenges cc ON t.chal_id = cc.chal_id
         ),
         ranked_results AS (
@@ -473,10 +472,10 @@ class ContestService:
                 acct_id,
                 chal_id,
                 pro_id,
-                test_idx,
+                subtask_id,
                 rate,
                 timestamp,
-                ROW_NUMBER() OVER (PARTITION BY acct_id, pro_id, test_idx ORDER BY rate DESC, timestamp ASC) AS rank
+                ROW_NUMBER() OVER (PARTITION BY acct_id, pro_id, subtask_id ORDER BY rate DESC, timestamp ASC) AS rank
             FROM individual_test_results
         ),
         best_individual_results AS (
@@ -484,7 +483,7 @@ class ContestService:
                 acct_id,
                 chal_id,
                 pro_id,
-                test_idx,
+                subtask_id,
                 rate AS best_rate,
                 timestamp
             FROM ranked_results

--- a/src/services/judge.py
+++ b/src/services/judge.py
@@ -51,61 +51,59 @@ class JudgeServerService:
             await self.response_handle(ret)
 
     async def response_handle(self, ret):
-        from services.chal import ChalService, ChalConst
+        from services.chal import ChalService, ChalConst, SubtaskResult
 
         res = json.loads(ret)
 
-        if res['results'] is not None:
-            for test_idx, result in enumerate(res['results']):
+        try:
+            if res['results'] is not None:
+                for subtask_id, result in enumerate(res['results']):
+                    score = decimal.Decimal('inf')
+                    is_cms_type = False
+                    if 'score_type' in result and result['score_type'] in ["CMS", "CF"]:
+                        is_cms_type = result['score_type'] == "CMS"
+                        if 'score' in result:
+                            try:
+                                score = decimal.Decimal(result['score'])
+                            except decimal.InvalidOperation:
+                                result['status'] = ChalConst.STATE_SJE
 
-                score = None
-                is_cms_type = False
-                if 'score_type' in result and result['score_type'] in ["CMS", "CF"]:
-                    is_cms_type = result['score_type'] == "CMS"
-                    if 'score' in result:
-                        try:
-                            score = decimal.Decimal(result['score'])
-                        except decimal.InvalidOperation:
-                            score = None
-                            result['status'] = ChalConst.STATE_SJE
+                    _, ret = await ChalService.inst.update_subtask_result(
+                        res['chal_id'],
+                        SubtaskResult(subtask_id, result['status'], int(result['time'] / 10 ** 6),
+                                    result['memory'], result['verdict'], score),
+                        rate_is_cms_type=is_cms_type,
+                        refresh_db=False,
+                    )
 
-                _, ret = await ChalService.inst.update_test(
-                    res['chal_id'],
-                    test_idx,
-                    result['status'],
-                    int(result['time'] / 10 ** 6),  # ns to ms
-                    result['memory'],
-                    score,
-                    result['verdict'],
-                    rate_is_cms_type=is_cms_type,
-                    refresh_db=False,
+                self.running_chal_cnt -= 1
+                await ChalService.inst.update_total_result(res['chal_id'])
+
+                await self.rs.publish('chalstatesub', res['chal_id'])
+                await self.rs.publish('challiststatesub', res['chal_id'])
+                await self.rs.publish(
+                    'judgechalcnt_sub',
+                    json.dumps(
+                        {
+                            "judge_id": self.judge_id,
+                            "chal_cnt": self.running_chal_cnt,
+                        }
+                    ),
                 )
 
-            self.running_chal_cnt -= 1
-            await ChalService.inst.update_challenge_state(res['chal_id'])
+                pro_id = self.chal_map[res['chal_id']]['pro_id']
+                contest_id = self.chal_map[res['chal_id']]['contest_id']
+                if contest_id != 0:
+                    await self.rs.publish('contestnewchalsub', contest_id)
+                    await self.rs.hdel(f'contest_{contest_id}_scores', str(pro_id))
 
-            await self.rs.publish('chalstatesub', res['chal_id'])
-            await self.rs.publish('challiststatesub', res['chal_id'])
-            await self.rs.publish(
-                'judgechalcnt_sub',
-                json.dumps(
-                    {
-                        "judge_id": self.judge_id,
-                        "chal_cnt": self.running_chal_cnt,
-                    }
-                ),
-            )
-
-            pro_id = self.chal_map[res['chal_id']]['pro_id']
-            contest_id = self.chal_map[res['chal_id']]['contest_id']
-            if contest_id != 0:
-                await self.rs.publish('contestnewchalsub', contest_id)
-                await self.rs.hdel(f'contest_{contest_id}_scores', str(pro_id))
-
-            # NOTE: Recalculate problem rate
-            await self.rs.hdel('pro_rate', f"pro_id_{pro_id}_contest_id_{contest_id}")
-            await self.rs.hdel('pro_topcoder', str(pro_id))
-            self.chal_map.pop(res['chal_id'])
+                # NOTE: Recalculate problem rate
+                await self.rs.hdel('pro_rate', f"pro_id_{pro_id}_contest_id_{contest_id}")
+                await self.rs.hdel('pro_topcoder', str(pro_id))
+                self.chal_map.pop(res['chal_id'])
+        except Exception as e:
+            import traceback
+            traceback.print_exception(e)
 
     async def disconnect_server(self):
         if not self.status:

--- a/src/services/pack.py
+++ b/src/services/pack.py
@@ -93,6 +93,7 @@ class PackService:
                     dfs(os.path.join(path, name))
                 else:
                     err = check_file_illegal(os.path.join(path, name))
+        dfs(dst)
 
 
         return err, None

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -2,12 +2,14 @@ import os
 import re
 import json
 import shutil
+from dataclasses import asdict, dataclass
 
 from msgpack import packb, unpackb
 
 import config
 from services.pack import PackService
 
+ErrorType = tuple[tuple[str, str], None]
 
 class ProConst:
     """
@@ -51,6 +53,80 @@ class ProConst:
     PRO_STATUS_KERNEL_USER = [STATUS_ONLINE, STATUS_HIDDEN]
     PRO_STATUS_CONTEST_USER = [STATUS_ONLINE, STATUS_CONTEST]
 
+@dataclass(slots=True)
+class Testdata:
+    testdata_id: int
+    inputfile: str
+    outputfile: str
+
+
+@dataclass(slots=True)
+class SubtaskConfig:
+    subtask_id: int
+    testdatas: list[Testdata]
+    rate: int
+
+
+@dataclass(slots=True)
+class Limit:
+    time: int
+    memory: int
+
+    def __post_init__(self):
+        assert self.time >= 0
+        assert self.memory >= 0
+
+
+@dataclass(slots=True)
+class ProblemConfig:
+    """
+    - is_makefile (bool): Whether the problem uses a Makefile-based compilation.
+    See: https://wiki.tfcis.org/TOJ#Makefile%E9%A1%8C%E7%9B%AE_(%E7%B7%A8%E8%AD%AF%E4%BA%92%E5%8B%95%E9%A1%8C)
+
+    - chalmeta (str): For IORedir Problem
+    See: https://wiki.tfcis.org/TOJ#IORedir
+
+    - checker_type (int): One of the values defined in ProConst.CHECKER_TYPE, indicating
+    the type of checker (e.g., diff, float-diff, ioredir).
+
+    - limits (dict[str, Limit]): Per-language time and memory limits.
+        - Keys are compiler types (e.g., "gcc", "clang", "default").
+            Allowed compilers can be found in `ChalConst.ALLOW_COMPILERS`.
+        - Must include a "default" configuration.
+
+    - rate_precision (int): Precision of the score (e.g., 0 for integers, 2 for 2 decimal places).
+
+    - subtask_configs (dict[int, SubtaskConfig]): Configuration for each subtask. Each key is
+    a subtask id.
+
+    - testdatas (dict[int, Testdata]): Configuration for each testdata. Each key is
+    a testdata id.
+    """
+    chalmeta: str
+    limits: dict[str, Limit]
+    checker_type: int
+    is_makefile: bool
+    subtask_configs: dict[int, SubtaskConfig]
+    testdatas: dict[int, Testdata]
+    rate_precision: int
+
+    def __post_init__(self):
+        assert 'default' in self.limits
+        assert ProConst.RATE_PRECISION_MIN <= self.rate_precision <= ProConst.RATE_PRECISION_MAX
+        assert self.checker_type in ProConst.CHECKER_TYPE
+
+
+@dataclass(slots=True)
+class Problem:
+    pro_id: int
+    name: str
+    status: int
+    tags: str
+    allow_submit: bool
+    config: ProblemConfig | None
+
+    def __post_init__(self):
+        assert ProConst.STATUS_ONLINE <= self.status <= ProConst.STATUS_HIDDEN
 
 class ProService:
     def __init__(self, db, rs):
@@ -58,7 +134,7 @@ class ProService:
         self.rs = rs
         ProService.inst = self
 
-    async def get_pro(self, pro_id: int, allow_statuses: list[int]):
+    async def get_pro(self, pro_id: int, allow_statuses: list[int]) -> tuple[None, Problem] | ErrorType:
         """
         Fetch problem configuration and metadata by ID, ensuring it's in the allowed status.
 
@@ -67,9 +143,8 @@ class ProService:
             allow_statuses (list[int]): Allowed problem statuses for access.
 
         Returns:
-            Tuple[Optional[Tuple[str, str]], Optional[dict]]:
+            Tuple[Optional[Tuple[str, str]], Optional[Problem]]:
                 - Error code and message if any error occurs.
-                - A dictionary containing problem metadata if successful.
         """
 
         for status in allow_statuses:
@@ -80,7 +155,7 @@ class ProService:
             result = await con.fetch(
                 """
                     SELECT "name", "status", "tags", "allow_submit",
-                    "check_type", "is_makefile", "chalmeta", "limit", "rate_precision"
+                    "checker_type", "is_makefile", "chalmeta", "limits", "rate_precision"
                     FROM "problem" WHERE "pro_id" = $1;
                 """,
                 pro_id,
@@ -89,74 +164,75 @@ class ProService:
                 return ("Enoext", "Problem not found"), None
             result = result[0]
 
-            name, status, tags, allow_submit, check_type, is_makefile, rate_precision, limit, chalmeta = (
+            (
+                name,
+                status,
+                tags,
+                allow_submit,
+                checker_type,
+                is_makefile,
+                rate_precision,
+                limits,
+                chalmeta,
+            ) = (
                 result["name"],
                 result["status"],
                 result["tags"],
                 result["allow_submit"],
-                result["check_type"],
+                result["checker_type"],
                 result["is_makefile"],
                 result["rate_precision"],
-                json.loads(result["limit"]),
+                json.loads(result["limits"]),
                 json.loads(result["chalmeta"]),
             )
+            if tags is None:
+                tags = ""
 
             if status not in allow_statuses:
                 return ("Eacces", "Permission denied"), None
 
             result = await con.fetch(
                 """
-                    SELECT "test_idx", "weight", "testdatas"
-                    FROM "test_config" WHERE "pro_id" = $1 ORDER BY "test_idx" ASC;
-                """,
-                pro_id,
-            )
-
-            test_groups = {}
-            for test_group_idx, weight, testdatas in result:
-                test_groups[test_group_idx] = {
-                    "weight": weight,
-                    "testdatas": testdatas,
-                }
-
-            result = await con.fetch(
-                """
                     SELECT "id", "inputfile", "outputfile"
                     FROM "testdata" WHERE "pro_id" = $1;
                 """,
-                pro_id
+                pro_id,
             )
-            testdatas = {}
+            testdatas: dict[int, Testdata] = {}
             for id, inputfile, outputfile in result:
-                testdatas[id] = {
-                    "id": id,
-                    "inputfile": inputfile,
-                    "outputfile": outputfile,
-                }
+                testdatas[id] = Testdata(id, inputfile, outputfile)
 
-        testm_conf = {
-            "chalmeta": chalmeta,
-            "limit": limit,
-            "check_type": check_type,
-            "is_makefile": is_makefile,
-            "test_group": test_groups,
-            "rate_precision": rate_precision,
-            "testdatas": testdatas
-        }
+            result = await con.fetch(
+                """
+                    SELECT "subtask_id", "rate", "testdatas"
+                    FROM "subtask_config" WHERE "pro_id" = $1 ORDER BY "subtask_id" ASC;
+                """,
+                pro_id,
+            )
+            subtask_configs: dict[int, SubtaskConfig] = {}
+            for subtask_id, rate, testdata_ids in result:
+                subtask_configs[subtask_id] = SubtaskConfig(
+                    subtask_id,
+                    [testdatas[testdata_id] for testdata_id in testdata_ids],
+                    rate,
+                )
 
-        return (
-            None,
-            {
-                "pro_id": pro_id,
-                "name": name,
-                "status": status,
-                "testm_conf": testm_conf,
-                "tags": tags,
-                "allow_submit": allow_submit,
+        proconfig = ProblemConfig(
+            chalmeta=chalmeta,
+            limits={
+                compiler: Limit(limit["time"], limit["memory"])
+                for compiler, limit in limits.items()
             },
+            checker_type=checker_type,
+            subtask_configs=subtask_configs,
+            testdatas=testdatas,
+            rate_precision=rate_precision,
+            is_makefile=is_makefile,
         )
 
-    async def list_pro(self, allow_pro_statuses: list[int]):
+        return None, Problem(pro_id, name, status, tags, allow_submit, proconfig)
+
+    async def list_pro(self, allow_pro_statuses: list[int]) -> tuple[None, list[Problem]]:
         """
         List problems with statuses in `allow_pro_statuses`, with Redis caching.
 
@@ -175,20 +251,22 @@ class ProService:
         field = f"{allow_pro_statuses}"
         if (prolist := (await self.rs.hget("prolist", field))) is not None:
             prolist = unpackb(prolist)
+            for i in range(len(prolist)):
+                prolist[i] = Problem(**prolist[i], config=None)
 
         else:
             async with self.db.acquire() as con:
                 result = await con.fetch(
                     f"""
-                        SELECT "problem"."pro_id", "problem"."name", "problem"."status", "problem"."tags"
-                        FROM "problem"
-                        WHERE "problem"."status" IN ({",".join(map(str, allow_pro_statuses))})
-                        ORDER BY "pro_id" ASC;
+                        SELECT p.pro_id, p.name, p.status, p.tags, p.allow_submit
+                        FROM "problem" p
+                        WHERE p."status" IN ({",".join(map(str, allow_pro_statuses))})
+                        ORDER BY pro_id ASC;
                     """
                 )
 
             prolist = []
-            for pro_id, name, status, tags in result:
+            for pro_id, name, status, tags, allow_submit in result:
                 if tags is None:
                     tags = ""
 
@@ -198,10 +276,15 @@ class ProService:
                         "name": name,
                         "status": status,
                         "tags": tags,
+                        "allow_submit": allow_submit,
                     }
                 )
 
             await self.rs.hset("prolist", field, packb(prolist))
+
+            for i in range(len(prolist)):
+                prolist[i] = Problem(**prolist[i], config=None)
+
 
         return None, prolist
 
@@ -256,16 +339,13 @@ class ProService:
 
         return None, pro_id
 
-    async def update_pro(self, pro_id: int, name: str, status: int, tags="", allow_submit=True):
+    async def update_pro(self, pro: Problem):
         """
         Update problem metadata such as name, status, tags, and submission permission.
 
         Args:
             pro_id (int): The ID of the problem to update.
-            name (str): New name.
-            status (int): New status (online/contest/hidden).
-            tags (str, optional): Tag string. Defaults to "".
-            allow_submit (bool, optional): Submission permission. Defaults to True.
+            pro (Problem): The problem
 
         Returns:
             Tuple[Optional[Tuple[str, str]], None]:
@@ -273,15 +353,14 @@ class ProService:
                 - None if successful.
         """
 
-        assert ProConst.STATUS_ONLINE <= status <= ProConst.STATUS_HIDDEN
-        name_len = len(name)
+        name_len = len(pro.name)
         if name_len < ProConst.NAME_MIN:
             return ("Enamemin", "Problem name too short"), None
         if name_len > ProConst.NAME_MAX:
             return ("Enamemax", "Problem name too long"), None
-        if status < ProConst.STATUS_ONLINE or status > ProConst.STATUS_HIDDEN:
+        if pro.status < ProConst.STATUS_ONLINE or pro.status > ProConst.STATUS_HIDDEN:
             return ("Eparam", "Invalid problem status"), None
-        if tags and not re.match(r"^[a-zA-Z0-9-_, ]+$", tags):
+        if pro.tags and not re.match(r"^[a-zA-Z0-9-_, ]+$", pro.tags):
             return ("Etags", "Invalid problem tag"), None
 
         async with self.db.acquire() as con:
@@ -291,48 +370,22 @@ class ProService:
                     SET "name" = $1, "status" = $2, "tags" = $3, "allow_submit" = $4
                     WHERE "pro_id" = $5 RETURNING "pro_id";
                 """,
-                name,
-                status,
-                tags,
-                allow_submit,
-                int(pro_id),
+                pro.name, pro.status, pro.tags, pro.allow_submit, pro.pro_id
             )
             if len(result) != 1:
                 return ("Enoext", "Problem not found"), None
-
 
         await self.rs.delete("prolist")
 
         return None, None
 
-    async def update_test_config(self, pro_id: int, testm_conf: dict):
+    async def update_pro_config(self, pro_id: int, config: ProblemConfig):
         """
         Update the test configuration (testm_conf) for a given problem.
 
         Args:
             pro_id (int): The ID of the problem to update.
-            testm_conf (dict): The test configuration, with the following structure:
-
-                - is_makefile (bool): Whether the problem uses a Makefile-based compilation.
-                See: https://wiki.tfcis.org/TOJ#Makefile%E9%A1%8C%E7%9B%AE_(%E7%B7%A8%E8%AD%AF%E4%BA%92%E5%8B%95%E9%A1%8C)
-
-                - check_type (int): One of the values defined in ProConst.CHECKER_TYPE, indicating
-                the type of checker (e.g., diff, float-diff, ioredir).
-
-                - limit (dict[str, dict[str, int]]): Per-language time and memory limits.
-                    - Keys are compiler types (e.g., "gcc", "clang", "default").
-                        Allowed compilers can be found in `ChalConst.ALLOW_COMPILERS`.
-                    - Each value must contain:
-                        - "timelimit" (int): Time limit in seconds (>= 0)
-                        - "memlimit" (int): Memory limit in kilobytes (>= 0)
-                    - Must include a "default" configuration.
-
-                - rate_precision (int): Precision of the score (e.g., 0 for integers, 2 for 2 decimal places).
-
-                - test_group (dict[int, dict]): Configuration for each test group (subtask). Each key is
-                a test group index, and each value is a dict:
-                    - "weight" (int): The score weight of this test group.
-                    - "metadata" (dict): Metadata describing the test cases, e.g., input/output file names.
+            config (ProblemConfig): The problem configuration.
 
         Returns:
             Tuple[None, None]: Always returns (None, None) on success.
@@ -346,53 +399,64 @@ class ProService:
 
         insert_test_config_values = []
         insert_testdatas_values = []
-        is_makefile = testm_conf['is_makefile']
-        check_type = testm_conf['check_type']
-        chalmeta = testm_conf['chalmeta']
-        limit = testm_conf['limit']
-        rate_precision = testm_conf['rate_precision']
-        for test_group_idx, test_group_conf in testm_conf['test_group'].items():
-            weight = test_group_conf['weight']
-            insert_test_config_values.append((pro_id, test_group_idx, weight, test_group_conf['testdatas']))
+        for subtask_id, subtask_config in config.subtask_configs.items():
+            rate = subtask_config.rate
+            insert_test_config_values.append(
+                (pro_id, subtask_id, rate, [testdata.testdata_id for testdata in subtask_config.testdatas])
+            )
 
-        for testdata in testm_conf['testdatas'].values():
-            insert_testdatas_values.append((pro_id, testdata['id'], testdata['inputfile'], testdata['outputfile']))
+        for testdata in config.testdatas.values():
+            insert_testdatas_values.append(
+                (pro_id, testdata.testdata_id, testdata.inputfile, testdata.outputfile)
+            )
 
         async with self.db.acquire() as con:
-            await con.execute('DELETE FROM "test_config" WHERE "pro_id" = $1;', int(pro_id))
-            await con.execute('DELETE FROM "testdata" WHERE "pro_id" = $1;', int(pro_id))
             await con.execute(
-                'UPDATE "problem" SET is_makefile = $1, check_type = $2, chalmeta = $3, "limit" = $4, "rate_precision" = $5 WHERE pro_id = $6',
-                is_makefile, check_type, json.dumps(chalmeta), json.dumps(limit), rate_precision, pro_id
+                'DELETE FROM "subtask_config" WHERE "pro_id" = $1;', int(pro_id)
+            )
+            await con.execute(
+                'DELETE FROM "testdata" WHERE "pro_id" = $1;', int(pro_id)
+            )
+            await con.execute(
+                'UPDATE problem SET is_makefile = $1, checker_type = $2, chalmeta = $3, limits = $4, rate_precision = $5 WHERE pro_id = $6',
+                config.is_makefile,
+                config.checker_type,
+                json.dumps(config.chalmeta),
+                json.dumps({
+                    comp: asdict(limit)
+                    for comp, limit in config.limits.items()
+                }),
+                config.rate_precision,
+                pro_id,
             )
 
             if insert_test_config_values:
                 await con.executemany(
-                    '''INSERT INTO "test_config"
-                        ("pro_id", "test_idx", "weight", "testdatas")
-                        VALUES ($1, $2, $3, $4);''',
-                    insert_test_config_values
+                    """INSERT INTO "subtask_config"
+                        ("pro_id", "subtask_id", "rate", "testdatas")
+                        VALUES ($1, $2, $3, $4);""",
+                    insert_test_config_values,
                 )
 
             if insert_testdatas_values:
                 await con.executemany(
-                    '''
+                    """
                         INSERT INTO "testdata" ("pro_id", "id", "inputfile", "outputfile")
                         VALUES ($1, $2, $3, $4);
-                    ''',
-                    insert_testdatas_values
+                    """,
+                    insert_testdatas_values,
                 )
 
-
         await self.db.execute("REFRESH MATERIALIZED VIEW test_valid_rate;")
-        await self.rs.delete('rate')
-        await self.rs.hdel('pro_rate', pro_id)
+        await self.rs.delete("rate")
+        await self.rs.hdel("pro_rate", pro_id)
 
         return None, None
 
     async def unpack_pro(self, pro_id: int, pack_token: str):
         """
         Unpack and apply a packed problem archive.
+        If failed, this function will call PackService.inst.clear() to clear tmp file and clear problem/{pro_id}.
 
         Args:
             pro_id (int): The ID of the problem to unpack into.
@@ -405,6 +469,7 @@ class ProService:
         """
 
         from services.chal import ChalConst
+
         failed = True
         try:
             err, _ = await PackService.inst.unpack(pack_token, f"problem/{pro_id}", True)
@@ -427,97 +492,85 @@ class ProService:
             except json.decoder.JSONDecodeError:
                 return ("Econf", "Problem config json syntax error"), None
 
-            testm_conf = {
-                'rate_precision': 0,
-            }
+            is_makefile = False
+            if "compile" in conf:
+                is_makefile = conf["compile"] == "makefile"
+            elif "is_makefile" in conf:
+                is_makefile = conf["is_makefile"]
 
-            testm_conf['is_makefile'] = False
-            if 'compile' in conf:
-                testm_conf['is_makefile'] = conf["compile"] == 'makefile'
-            elif 'is_makefile' in conf:
-                testm_conf['is_makefile'] = conf["is_makefile"]
-
-            testm_conf['check_type'] = ProConst.STR_2_CHECKER_TYPE[conf["check"]]
-
-            ALLOW_COMPILERS = set(list(ChalConst.ALLOW_COMPILERS) + ['default'])
-            if testm_conf['is_makefile']:
-                ALLOW_COMPILERS = {'default', 'gcc', 'g++', 'clang', 'clang++'}
+            ALLOW_COMPILERS = set(list(ChalConst.ALLOW_COMPILERS) + ["default"])
+            if is_makefile:
+                ALLOW_COMPILERS = {"default", "gcc", "g++", "clang", "clang++"}
 
             if "limit" in conf:
                 limits = {}
-                for comp_type, limit in conf["limit"].items():
-                    if comp_type not in ALLOW_COMPILERS:
+                for compiler_type, conf_limit in conf["limit"].items():
+                    if compiler_type not in ALLOW_COMPILERS:
                         continue
 
+                    limit = Limit(0, 0)
                     try:
-                        limit['timelimit'] = max(int(limit['timelimit']), 0)
-                        limit['memlimit'] = max(int(limit['memlimit']) * 1024, 0)
-                    except KeyError as e:
-                        limit[e.args[0]] = 0
+                        limit.time = max(int(conf_limit["timelimit"]), 0)
+                        limit.memory = max(int(conf_limit["memlimit"]) * 1024, 0)
                     except ValueError:
                         continue
 
-                    limits[comp_type] = limit
+                    limits[compiler_type] = limit
 
-                if 'default' not in limits:
+                if "default" not in limits:
                     return ("Econf", "Problem limit config require default value"), None
 
-            elif 'timelimit' in conf and 'memlimit' in conf:
+            elif "timelimit" in conf and "memlimit" in conf:
                 try:
                     limits = {
-                        'default': {
-                            'timelimit': int(conf["timelimit"]),
-                            'memlimit': int(conf["memlimit"]) * 1024
-                        }
+                        "default": Limit(int(conf["timelimit"]), int(conf["memlimit"]) * 1024)
                     }
                 except ValueError:
                     return ("Econf", "Problem limit config have invalid value"), None
             else:
-                    return ("Econf", "Problem config require limit or timelimit/memlimit"), None
-            testm_conf['limit'] = limits
+                return (
+                    "Econf",
+                    "Problem config require limit or timelimit/memlimit",
+                ), None
 
-            if 'metadata' in conf:
-                testm_conf['chalmeta'] = conf["metadata"]  # INFO: ioredir data
+            chalmeta = conf["metadata"]  # INFO: ioredir data
 
-            test_group = {}
-            testdatas: dict[str, int] = {}
+            subtask_configs: dict[int, SubtaskConfig] = {}
+            testdatas: dict[int, Testdata] = {}
+            testdata_name_2_id: dict[str, int] = {}
             testdata_id_counter = 0
             for test_idx, test_conf in enumerate(conf["test"]):
-                for i in range(len(test_conf["data"])):
-                    test_conf["data"][i] = str(test_conf["data"][i])
-                    if test_conf["data"][i] not in testdatas:
-                        testdatas[test_conf["data"][i]] = testdata_id_counter
+                for t in test_conf["data"]:
+                    if t not in testdata_name_2_id:
+                        t = os.path.basename(str(t))
+                        testdata_name_2_id[t] = testdata_id_counter
+                        testdatas[testdata_id_counter] = Testdata(testdata_id_counter, f"{t}.in", f"{t}.out")
                         testdata_id_counter += 1
 
-                test_group[test_idx] = {
-                    'weight': int(test_conf['weight']),
-                    'testdatas': []
-                }
+                subtask_configs[test_idx] = SubtaskConfig(test_idx, [], int(test_conf["weight"]))
+
 
             for test_idx, test_conf in enumerate(conf["test"]):
-                for i in range(len(test_conf["data"])):
-                    test_group[test_idx]['testdatas'].append(testdatas[test_conf["data"][i]])
+                for t in test_conf["data"]:
+                    t = os.path.basename(str(t))
+                    subtask_configs[test_idx].testdatas.append(testdatas[testdata_name_2_id[t]])
 
-            testm_conf['testdatas'] = {}
 
-            for testdata, testdata_id in testdatas.items():
-                testm_conf['testdatas'][testdata_id] = {
-                    'id': testdata_id,
-                    'inputfile': f"{testdata}.in",
-                    'outputfile': f"{testdata}.out",
-                }
-
-            testm_conf['test_group'] = test_group
+            proconfig = ProblemConfig(chalmeta, limits, ProConst.STR_2_CHECKER_TYPE[conf["check"]],
+                                      is_makefile, subtask_configs, testdatas, rate_precision=0)
             failed = False
 
         finally:
+            # NOTE: Like golang defer
             if failed and os.path.exists(f"problem/{pro_id}"):
                 shutil.rmtree(f"problem/{pro_id}")
+            await PackService.inst.clear(pack_token)
 
-        await self.update_test_config(pro_id, testm_conf)
+        await self.update_pro_config(pro_id, proconfig)
         await self.rs.delete("prolist")
 
         return None, None
+
 
 class ProClassConst:
     OFFICIAL_PUBLIC = 0
@@ -544,8 +597,9 @@ class ProClassService:
 
             if len(res) != 1:
                 return ("Enoext", "Problem class not found"), None
+            res = res[0]
 
-        return None, res[0]
+        return None, res
 
     async def get_proclass_list(self):
         async with self.db.acquire() as con:
@@ -571,10 +625,12 @@ class ProClassService:
 
     async def remove_proclass(self, proclass_id: int):
         async with self.db.acquire() as con:
-            result: str = await con.execute('DELETE FROM "proclass" WHERE "proclass_id" = $1', int(proclass_id))
-            affected_row_cnt = int(result.split(" ")[1]) # NOTE: DELETE \d+
+            result: str = await con.execute(
+                'DELETE FROM "proclass" WHERE "proclass_id" = $1', int(proclass_id)
+            )
+            affected_row_cnt = int(result.split(" ")[1])  # NOTE: DELETE \d+
             if affected_row_cnt == 0:
-                return ('Enoext', 'Bulletin not found'), None
+                return ("Enoext", "Bulletin not found"), None
 
     async def update_proclass(self, proclass_id, name, p_list, desc, proclass_type):
         proclass_id = int(proclass_id)

--- a/src/services/rate.py
+++ b/src/services/rate.py
@@ -31,7 +31,7 @@ class RateService:
                             challenge c
                         INNER JOIN problem
                             ON c.pro_id = problem.pro_id
-                        INNER JOIN challenge_state cs
+                        INNER JOIN total_result cs
                             ON c.chal_id = cs.chal_id
                         WHERE
                             c.acct_id = $1 AND
@@ -53,9 +53,9 @@ class RateService:
                     f'''
                     WITH accepted_tests AS (
                         SELECT DISTINCT
-                            t."acct_id", t."pro_id", t."test_idx", t."rate"
+                            t."acct_id", t."pro_id", t."subtask_id", t."rate"
                         FROM
-                            "test" t
+                            "subtask_result" t
                         INNER JOIN "problem"
                             ON t."pro_id" = "problem"."pro_id"
                         WHERE
@@ -69,7 +69,7 @@ class RateService:
                         test_valid_rate
                     INNER JOIN accepted_tests at
                         ON "test_valid_rate"."pro_id" = at."pro_id"
-                        AND "test_valid_rate"."test_idx" = at."test_idx"
+                        AND "test_valid_rate"."test_idx" = at."subtask_id"
                     ''',
                     acct_id
                 )
@@ -102,39 +102,39 @@ class RateService:
                 "contest_users"
             ON "contest_users"."contest_id" = $2 AND
                "contest_users"."acct_id" = "challenge"."acct_id" AND
-               "contest_users"."status" = {UserStatus.APPROVED.value}
+               "contest_users"."status" = {UserStatus.APPROVED}
 
             '''
 
         ALL_CHAL_SQL = f"""
         SELECT COUNT(*) FROM "challenge" INNER JOIN "account" ON "challenge"."acct_id" = "account"."acct_id"
-        LEFT JOIN "challenge_state"
-        ON "challenge"."chal_id" = "challenge_state"."chal_id"
+        LEFT JOIN "total_result"
+        ON "challenge"."chal_id" = "total_result"."chal_id"
         {contest_user_filter_sql}
         WHERE "challenge"."pro_id" = $1 AND "challenge"."contest_id" = $2;
         """
         AC_CHAL_SQL = f"""
         SELECT COUNT(*) FROM "challenge" INNER JOIN "account" ON "challenge"."acct_id" = "account"."acct_id"
-        LEFT JOIN "challenge_state"
-        ON "challenge"."chal_id" = "challenge_state"."chal_id"
+        LEFT JOIN "total_result"
+        ON "challenge"."chal_id" = "total_result"."chal_id"
         {contest_user_filter_sql}
-        WHERE "challenge"."pro_id" = $1 AND "challenge"."contest_id" = $2 AND "challenge_state"."state" = {ChalConst.STATE_AC};
+        WHERE "challenge"."pro_id" = $1 AND "challenge"."contest_id" = $2 AND "total_result"."state" = {ChalConst.STATE_AC};
         """
 
         # problem user ac rate
         USER_ALL_CHAL_SQL = f"""
         SELECT COUNT(*) FROM (SELECT DISTINCT "account"."acct_id" FROM "challenge" INNER JOIN "account" ON "challenge"."acct_id" = "account"."acct_id"
-        LEFT JOIN "challenge_state"
-        ON "challenge"."chal_id" = "challenge_state"."chal_id"
+        LEFT JOIN "total_result"
+        ON "challenge"."chal_id" = "total_result"."chal_id"
         {contest_user_filter_sql}
         WHERE "challenge"."pro_id" = $1 AND "challenge"."contest_id" = $2) as user_cnt;
         """
         USER_AC_CHAL_SQL = f"""
         SELECT COUNT(*) FROM (SELECT DISTINCT "account"."acct_id" FROM "challenge" INNER JOIN "account" ON "challenge"."acct_id" = "account"."acct_id"
-        LEFT JOIN "challenge_state"
-        ON "challenge"."chal_id" = "challenge_state"."chal_id"
+        LEFT JOIN "total_result"
+        ON "challenge"."chal_id" = "total_result"."chal_id"
         {contest_user_filter_sql}
-        WHERE "challenge"."pro_id" = $1 AND "challenge"."contest_id" = $2 AND "challenge_state"."state" = {ChalConst.STATE_AC}) as user_cnt;
+        WHERE "challenge"."pro_id" = $1 AND "challenge"."contest_id" = $2 AND "total_result"."state" = {ChalConst.STATE_AC}) as user_cnt;
         """
 
         key = "pro_rate"
@@ -175,7 +175,7 @@ class RateService:
         The topcoder is determined from non-contest (`contest_id = 0`) accepted (`state = AC`) challenges
         by selecting each user's best challenge, ranked primarily by:
         - highest rate
-        - lowest runtime
+        - lowest time
         - lowest memory usage
         - earliest chal_id (tie-breaker)
         This algorithm same as `ProRankHandler`.
@@ -205,23 +205,23 @@ class RateService:
                             SELECT DISTINCT ON ("challenge"."acct_id")
                                 "challenge"."chal_id",
                                 "challenge"."acct_id",
-                                "challenge_state"."runtime",
-                                "challenge_state"."memory",
-                                "challenge_state"."rate"
+                                "total_result"."time",
+                                "total_result"."memory",
+                                "total_result"."rate"
 
                                 FROM "challenge"
 
-                                INNER JOIN "challenge_state"
-                                ON "challenge"."chal_id"="challenge_state"."chal_id"
+                                INNER JOIN "total_result"
+                                ON "challenge"."chal_id"="total_result"."chal_id"
 
-                                WHERE "challenge_state"."state"={ChalConst.STATE_AC} AND "challenge"."contest_id"=0 AND "challenge"."pro_id"=$1
+                                WHERE "total_result"."state"={ChalConst.STATE_AC} AND "challenge"."contest_id"=0 AND "challenge"."pro_id"=$1
 
-                                ORDER BY "challenge"."acct_id" ASC, "challenge_state"."rate" DESC,
-                                "challenge_state"."runtime" ASC, "challenge_state"."memory" ASC,
+                                ORDER BY "challenge"."acct_id" ASC, "total_result"."rate" DESC,
+                                "total_result"."time" ASC, "total_result"."memory" ASC,
                                 "challenge"."chal_id" ASC
                         ) temp
 
-                        ORDER BY "rate" DESC, "runtime" ASC, "memory" ASC,
+                        ORDER BY "rate" DESC, "time" ASC, "memory" ASC,
                         "chal_id" ASC, "acct_id" ASC LIMIT 1
                         ) temp2
 
@@ -263,12 +263,12 @@ class RateService:
             result = await con.fetch(
                 f'''
                     SELECT "challenge"."pro_id",
-                    ROUND(MAX("challenge_state"."rate"), (SELECT rate_precision FROM problem WHERE pro_id = challenge.pro_id)) AS "score",
-                    COUNT("challenge_state") AS "count",
-                    MIN("challenge_state"."state") as "state"
+                    ROUND(MAX("total_result"."rate"), (SELECT rate_precision FROM problem WHERE pro_id = challenge.pro_id)) AS "score",
+                    COUNT("total_result") AS "count",
+                    MIN("total_result"."state") as "state"
                     FROM "challenge"
-                    INNER JOIN "challenge_state"
-                    ON "challenge"."chal_id" = "challenge_state"."chal_id" AND "challenge"."acct_id" = $1
+                    INNER JOIN "total_result"
+                    ON "challenge"."chal_id" = "total_result"."chal_id" AND "challenge"."acct_id" = $1
                     INNER JOIN "problem"
                     ON "challenge"."pro_id" = "problem"."pro_id" {problem_status_sql}
                     WHERE "challenge"."contest_id" = $2 AND "challenge"."timestamp" >= $3 AND "challenge"."timestamp" <= $4
@@ -301,12 +301,12 @@ class RateService:
             result = await con.fetch(
                 '''
                     SELECT "challenge"."acct_id", "challenge"."pro_id",
-                    ROUND(MAX("challenge_state"."rate"), (SELECT rate_precision FROM problem WHERE pro_id = challenge.pro_id)) AS "rate",
-                    COUNT("challenge_state") AS "count",
-                    MIN("challenge_state"."state") AS "state"
+                    ROUND(MAX("total_result"."rate"), (SELECT rate_precision FROM problem WHERE pro_id = challenge.pro_id)) AS "rate",
+                    COUNT("total_result") AS "count",
+                    MIN("total_result"."state") AS "state"
                     FROM "challenge"
-                    INNER JOIN "challenge_state"
-                    ON "challenge"."chal_id" = "challenge_state"."chal_id"
+                    INNER JOIN "total_result"
+                    ON "challenge"."chal_id" = "total_result"."chal_id"
                     INNER JOIN "problem"
                     ON "challenge"."pro_id" = "problem"."pro_id"
                     WHERE "challenge"."timestamp" >= $1 AND "challenge"."timestamp" <= $2 AND "challenge"."contest_id" = $3

--- a/src/static/templ/board.html
+++ b/src/static/templ/board.html
@@ -228,7 +228,7 @@
           <th class="_acct">User</th>
           <th class="_score">Score</th>
           {% for pro in prolist %}
-            <th class="_pro"><a href="/oj/pro/{{ pro['pro_id'] }}/">{{ pro['pro_id'] }}</a></th>
+            <th class="_pro"><a href="/oj/pro/{{ pro.pro_id }}/">{{ pro.pro_id }}</a></th>
           {% end %}
         </tr>
       </thead>
@@ -240,7 +240,7 @@
           <td class="_acct">&nbsp<a href="/oj/acct/{{ acct_id }}/">{{ acct.name }}</a></td>
           <td class="_score"><a href="/oj/chal/?acctid={{ acct_id }}">{{ acct.rate }} / {{ acct_submit[acct_id] }}</a></td>
           {% for pro in prolist %}
-            {% set pro_id = pro['pro_id'] %}
+            {% set pro_id = pro.pro_id %}
             {% if acct_id in ratemap and pro_id in ratemap[acct_id] %}
               {% set rate = ratemap[acct_id][pro_id] %}
               {% set sc = math.floor(rate['rate'] / 10) %}
@@ -258,7 +258,7 @@
         <tr>
             <td colspan="3" style="text-align:center; padding:0 0">score / submit</td>
             {% for pro in prolist %}
-            {% set pro_id = pro['pro_id'] %}
+            {% set pro_id = pro.pro_id %}
                 <td class="_pro _state">{{pro_sc_sub[pro_id][0]}} / {{pro_sc_sub[pro_id][1]}}</td>
             {% end %}
         </tr>

--- a/src/static/templ/chal.html
+++ b/src/static/templ/chal.html
@@ -1,6 +1,10 @@
 {% from services.chal import ChalConst %}
+{% import datetime %}
 <script src="/oj/third/prism.js"></script>
 <link rel="stylesheet" href="/oj/third/prism.css">
+
+{% set TZ = datetime.timezone(datetime.timedelta(hours=+8)) %}
+<!-- TODO: move timezone to config -->
 
 <script type="text/javascript">
     var ws;
@@ -11,8 +15,8 @@
     };
 
     function init() {
-        const chal_id = "{{ chal['chal_id'] }}";
-        const contest_id = "{{ chal['contest_id'] }}";
+        const chal_id = "{{ chal.chal_id }}";
+        const contest_id = "{{ chal.contest_id }}";
         ws = index.get_ws("chalnewstatesub");
 
         if ((document.querySelectorAll('td.state-{{ ChalConst.STATE_JUDGE }}').length == 0 && document.querySelectorAll('td.state-{{ ChalConst.STATE_NOTSTARTED }}') == 0)) {
@@ -23,7 +27,7 @@
                     let state = element.querySelector('td.state');
                     state.innerHTML = state_map[chal_state_data[idx]['state']];
                     state.className = `state state-${chal_state_data[idx]['state']}`;
-                    element.querySelector('td.runtime').innerHTML = chal_state_data[idx]['runtime'];
+                    element.querySelector('td.time').innerHTML = chal_state_data[idx]['time'];
                     element.querySelector('td.memory').innerHTML = Math.round((chal_state_data[idx]['memory'] / 1024));
                     element.querySelector('td.score').innerHTML = chal_state_data[idx]['rate'];
                 });
@@ -43,10 +47,10 @@
         {% if rechal == True %}
         $('#rechal').on('click', function(e) {
             let url = '';
-            {% if chal['contest_id'] == 0 %}
+            {% if chal.contest_id == 0 %}
                 url = '/oj/be/submit';
             {% else %}
-                url = '/oj/be/contests/{{ chal['contest_id'] }}/submit';
+                url = '/oj/be/contests/{{ chal.contest_id }}/submit';
             {% end %}
             $.post(url, {
                 'reqtype': 'rechal',
@@ -70,13 +74,13 @@
             if (res.status[0] == 'E') return;
 
             let code = $("#code");
-            code.attr("data-language", res.data.comp_type);
-            code.find("code").addClass(`language-${res.data.comp_type}`);
+            code.attr("data-language", res.data.compiler_type);
+            code.find("code").addClass(`language-${res.data.compiler_type}`);
             code.find("code").html(res.data.code);
             Prism.highlightAll();
 	    });
 
-        {% if user.acct_id == chal['acct_id'] %}
+        {% if user.acct_id == chal.acct_id %}
         $('#report_pro_button').on('click', function(e) {
             index.go(`/oj/report/?chal_id=${chal_id}`);
         });
@@ -101,39 +105,39 @@
             <tbody>
                 <tr>
                     <td>Challenge</td>
-                    <td>{{ chal['chal_id'] }}</td>
+                    <td>{{ chal.chal_id }}</td>
                 </tr>
                 <tr>
                     <td>Problem</td>
-                    {% if chal['contest_id'] == 0 %}
+                    {% if chal.contest_id == 0 %}
                     <td>
-                        <a href="/oj/pro/{{ pro['pro_id'] }}/">{{ pro['pro_id'] }} / {{ pro['name'] }}</a> (<a href="/oj/chal/?proid={{ pro['pro_id'] }}">chals</a>)
+                        <a href="/oj/pro/{{ pro.pro_id }}/">{{ pro.pro_id }} / {{ pro.name }}</a> (<a href="/oj/chal/?proid={{ pro.pro_id }}">chals</a>)
                     </td>
                     {% else %}
                     <td>
-                        <a href="/oj/contests/{{ chal['contest_id']}}/pro/{{ pro['pro_id'] }}/">{{ pro['pro_id'] }} / {{ pro['name'] }}</a> (<a href="/oj/contests/{{ chal['contest_id'] }}/chal/?proid={{ pro['pro_id'] }}">chals</a>)
+                        <a href="/oj/contests/{{ chal.contest_id }}/pro/{{ pro.pro_id }}/">{{ pro.pro_id }} / {{ pro.name }}</a> (<a href="/oj/contests/{{ chal.contest_id }}/chal/?proid={{ pro.pro_id }}">chals</a>)
                     </td>
                     {% end %}
                 </tr>
                 <tr>
                     <td>Compiler</td>
-                    <td>{{ chal['comp_type'] }}</td>
+                    <td>{{ chal.compiler_type }}</td>
                 </tr>
                 <tr>
                     <td>Account</td>
-                    {% if chal['contest_id'] == 0 %}
+                    {% if chal.contest_id == 0 %}
                     <td>
-                        <a href="/oj/acct/{{ chal['acct_id'] }}/">{{ chal['acct_name'] }}</a> (<a href="/oj/chal/?acctid={{ chal['acct_id'] }}">chals</a>)
+                        <a href="/oj/acct/{{ chal.acct_id }}/">{{ chal.acct_name }}</a> (<a href="/oj/chal/?acctid={{ chal.acct_id }}">chals</a>)
                     </td>
                     {% else %}
                     <td>
-                        <a href="/oj/acct/{{ chal['acct_id'] }}/">{{ chal['acct_name'] }}</a> (<a href="/oj/contests/{{ chal['contest_id'] }}/chal/?acctid={{ chal['acct_id'] }}">chals</a>)
+                        <a href="/oj/acct/{{ chal.acct_id }}/">{{ chal.acct_name }}</a> (<a href="/oj/contests/{{ chal.contest_id }}/chal/?acctid={{ chal.acct_id }}">chals</a>)
                     </td>
                     {% end %}
                 </tr>
                 <tr>
                     <td>Timestamp</td>
-                    <td class="time">{{ chal['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                    <td class="time">{{ chal.timestamp.astimezone(TZ).strftime('%Y-%m-%d %H:%M:%S') }}</td>
                 </tr>
             </tbody>
         </table>
@@ -141,30 +145,30 @@
     {% if rechal == True %}
         <button id="rechal" class="btn btn-warning">Rechallenge</button>
     {% end %}
-    {% if chal['acct_id'] == user.acct_id %}
+    {% if chal.acct_id == user.acct_id %}
         <button id="report_pro_button" class="btn btn-warning">Report Problem</button>
     {% end %}
     </div>
 
     <div class="col-lg-8">
-        <table id="test" class="table">
+        <table id="subtasks" class="table">
             <thead>
                 <tr>
-                    <th>Test</th>
+                    <th>Subtask</th>
                     <th>State</th>
-                    <th>Runtime(ms)</th>
+                    <th>Time(ms)</th>
                     <th>Memory(KB)</th>
                     <th>Score</th>
                 </tr>
             </thead>
             <tbody>
-            {% for test in chal['testl'] %}
+            {% for subtask in chal.subtask_results.values() %}
                 <tr class="states">
-                    <td class="idx">{{ '%04d' % (test['test_idx'] + 1) }}</td>
-                    <td class="state state-{{ test['state'] }}">{{ ChalConst.STATE_LONG_STR[test['state']] }}</td>
-                    <td class="runtime">{{ test['runtime'] }}</td>
-                    <td class="memory">{{ round(test['memory'] / 1024) }}</td>
-                    <td class="score">{{ test['rate'] }}</td>
+                    <td class="idx">{{ '%04d' % (subtask.subtask_id + 1) }}</td>
+                    <td class="state state-{{ subtask.state }}">{{ ChalConst.STATE_LONG_STR[subtask.state] }}</td>
+                    <td class="time">{{ subtask.time }}</td>
+                    <td class="memory">{{ round(subtask.memory / 1024) }}</td>
+                    <td class="score">{{ subtask.rate }}</td>
                 </tr>
             {% end %}
             </tbody>
@@ -173,7 +177,9 @@
 </div>
 
 
-{% if response != '' and (user.is_kernel() or chal['acct_id'] == user.acct_id) %}
+<!-- FIXME: Only user in can_see_code_user can view response -->
+<!-- TODO: Move response to code.py -->
+{% if response != '' and (user.is_kernel() or chal.acct_id == user.acct_id) %}
     <div class="panel panel-default mt-3" id="response">
         <div class="panel-heading">
             <span>Compilation Error Message</span>

--- a/src/static/templ/challist.html
+++ b/src/static/templ/challist.html
@@ -1,5 +1,7 @@
 {% import math %}
+{% import datetime %}
 {% from services.chal import ChalConst %}
+{% set TZ = datetime.timezone(datetime.timedelta(hours=+8)) %}
 
 <link rel="stylesheet" type="text/css" href="/oj/challist.css">
 
@@ -89,9 +91,9 @@
         })();
 
         (() => {
-            let update_state = ({chal_id, state, runtime, memory, rate}) => {
+            let update_state = ({chal_id, state, time, memory, rate}) => {
                 let tr = document.querySelector(`#chal${chal_id}`);
-                tr.querySelector('#runtime').innerText = parseInt(runtime);
+                tr.querySelector('#time').innerText = parseInt(time);
                 tr.querySelector('#memory').innerText = Math.round(memory / 1024);
                 tr.querySelector('#score').innerText = rate;
 
@@ -103,10 +105,14 @@
             newstate_ws = index.get_ws('challistnewstatesub');
 
             newstate_ws.onopen = (e) => {
+                let chalids = [
+                    {% for chal in challist %}
+                        {{ chal.chal_id }},
+                    {% end %}
+                ];
                 newstate_ws.send(JSON.stringify({
                     acct_id: '{{ user.acct_id }}',
-                    last_chal_id: "{{ challist[0]['chal_id'] if len(challist) > 0 else -1 }}",
-                    first_chal_id: "{{ challist[-1]['chal_id'] if len(challist) > 0 else -1 }}"
+                    chalids: chalids,
                 }));
             };
 
@@ -118,7 +124,7 @@
         {% if (flt.state == 100 or flt.state == 101) and isadmin %}
             let chalids = [
                 {% for chal in challist %}
-                    {{ chal['chal_id'] }},
+                    {{ chal.chal_id }},
                 {% end %}
             ];
             $('#rechalall').on('click', function(e) {
@@ -198,7 +204,7 @@
                     <th scope="col">Problem</th>
                     <th scope="col">Account</th>
                     <th scope="col">State</th>
-                    <th scope="col">Runtime</th>
+                    <th scope="col">Time</th>
                     <th scope="col">Memory</th>
                     <th scope="col">Score</th>
                     <th scope="col">Compiler</th>
@@ -211,22 +217,22 @@
                     <td colspan=4><a href="" style="color:#58B2DC"></a></td>
                 </tr>
             {% for chal in challist %}
-                <tr id="chal{{ chal['chal_id'] }}">
-                    {% if chal['contest_id'] == 0 %}
-                        <td><a href="/oj/chal/{{ chal['chal_id'] }}/">{{ chal['chal_id'] }}</a></td>
-                        <td><a href="/oj/pro/{{ chal['pro_id'] }}/">{{ chal['pro_id'] }}</a></td>
+                <tr id="chal{{ chal.chal_id }}">
+                    {% if chal.contest_id == 0 %}
+                        <td><a href="/oj/chal/{{ chal.chal_id }}/">{{ chal.chal_id }}</a></td>
+                        <td><a href="/oj/pro/{{ chal.pro_id }}/">{{ chal.pro_id }}</a></td>
                     {% else %}
-                        <td><a href="/oj/contests/{{ chal['contest_id'] }}/chal/{{ chal['chal_id'] }}/">{{ chal['chal_id'] }}</a></td>
-                        <td><a href="/oj/contests/{{ chal['contest_id'] }}/pro/{{ chal['pro_id'] }}/">{{ chal['pro_id'] }}</a></td>
+                        <td><a href="/oj/contests/{{ chal.contest_id }}/chal/{{ chal.chal_id }}/">{{ chal.chal_id }}</a></td>
+                        <td><a href="/oj/contests/{{ chal.contest_id }}/pro/{{ chal.pro_id }}/">{{ chal.pro_id }}</a></td>
                     {% end %}
 
-                    <td><a href="/oj/acct/{{ chal['acct_id'] }}/">{{ chal['acct_name'] }}</a></td>
-                    <td id="state" class="state-{{ chal['state'] }}">{{ ChalConst.STATE_LONG_STR[chal['state']] }}</td>
-                    <td id="runtime">{{ chal['runtime'] }}</td>
-                    <td id="memory">{{ round(chal['memory'] / 1024) }}</td>
-                    <td id="score">{{ chal['rate'] }}</td>
-                    <td>{{ chal['comp_type'] }}</td>
-                    <td class="time">{{ chal['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                    <td><a href="/oj/acct/{{ chal.acct_id }}/">{{ chal.acct_name }}</a></td>
+                    <td id="state" class="state-{{ chal.total_result.state }}">{{ ChalConst.STATE_LONG_STR[chal.total_result.state] }}</td>
+                    <td id="time">{{ chal.total_result.time }}</td>
+                    <td id="memory">{{ round(chal.total_result.memory / 1024) }}</td>
+                    <td id="score">{{ chal.total_result.rate }}</td>
+                    <td>{{ chal.compiler_type }}</td>
+                    <td class="time">{{ chal.timestamp.astimezone(TZ).strftime('%Y-%m-%d %H:%M:%S') }}</td>
                 </tr>
             {% end %}
             </tbody>
@@ -254,7 +260,7 @@
             <div class="col pt-3">
                 {% set _p_pageoff = pageoff %}
                 {% set _p_pagenum = 20 %}
-                {% set _p_total_cnt = chalstat['total_chal'] %}
+                {% set _p_total_cnt = chal_cnt %}
                 {% set _p_postfix = postfix %}
                 {% include "pagination.html" %}
             </div>

--- a/src/static/templ/contests/manage/general.html
+++ b/src/static/templ/contests/manage/general.html
@@ -140,8 +140,8 @@
         <div class="mb-1">
             <label for="contestMode" class="form-label">Contest Mode</label>
             <select id="contestMode" class="form-select">
-                <option value="{{ ContestMode.IOI.value }}"{% if contest.contest_mode == ContestMode.IOI %} selected {% end %}>IOI</option>
-                <option value="{{ ContestMode.ACM.value }}"{% if contest.contest_mode == ContestMode.ACM %} selected {% end %}>ACM</option>
+                <option value="{{ ContestMode.IOI }}"{% if contest.contest_mode == ContestMode.IOI %} selected {% end %}>IOI</option>
+                <option value="{{ ContestMode.ACM }}"{% if contest.contest_mode == ContestMode.ACM %} selected {% end %}>ACM</option>
             </select>
         </div>
 
@@ -174,9 +174,9 @@
         <div class="mb-1">
             <label for="regMode" class="form-label">Registration Mode</label>
             <select id="regMode" class="form-select">
-                <option value="{{ RegMode.INVITED.value }}"{% if contest.reg_mode == RegMode.INVITED %} selected {% end %}>Invited</option>
-                <option value="{{ RegMode.FREE_REG.value }}"{% if contest.reg_mode == RegMode.FREE_REG %} selected {% end %}>Free registration</option>
-                <option value="{{ RegMode.REG_APPROVAL.value }}"{% if contest.reg_mode == RegMode.REG_APPROVAL %} selected {% end %}>Free registration but need approval</option>
+                <option value="{{ RegMode.INVITED }}"{% if contest.reg_mode == RegMode.INVITED %} selected {% end %}>Invited</option>
+                <option value="{{ RegMode.FREE_REG }}"{% if contest.reg_mode == RegMode.FREE_REG %} selected {% end %}>Free registration</option>
+                <option value="{{ RegMode.REG_APPROVAL }}"{% if contest.reg_mode == RegMode.REG_APPROVAL %} selected {% end %}>Free registration but need approval</option>
             </select>
         </div>
 

--- a/src/static/templ/contests/manage/pro.html
+++ b/src/static/templ/contests/manage/pro.html
@@ -103,15 +103,15 @@
 					<tbody>
 					{% for pro in pro_list %}
 						<tr>
-							<th scope="row"><a href="/oj/contests/{{ contest.contest_id }}/pro/{{ pro['pro_id'] }}/">{{ pro['pro_id'] }}</a></th>
-							<td>{{ pro['name'] }}</td>
+							<th scope="row"><a href="/oj/contests/{{ contest.contest_id }}/pro/{{ pro.pro_id }}/">{{ pro.pro_id }}</a></th>
+							<td>{{ pro.name }}</td>
 							<td>
-								<button class="btn btn-warning me-2 remove" pro_id="{{ pro['pro_id'] }}">Remove</button>
-								<button class="btn btn-danger me-2 rechal" pro_id="{{ pro['pro_id'] }}">Rechallenge</button>
+								<button class="btn btn-warning me-2 remove" pro_id="{{ pro.pro_id }}">Remove</button>
+								<button class="btn btn-danger me-2 rechal" pro_id="{{ pro.pro_id }}">Rechallenge</button>
                                 <button
                                     class="btn btn-danger me-2 public"
-                                    pro_id="{{ pro['pro_id'] }}"
-                                    {% if not contest.is_end() or pro['status'] != ProConst.STATUS_CONTEST %} disabled {% end %}
+                                    pro_id="{{ pro.pro_id }}"
+                                    {% if not contest.is_end() or pro.status != ProConst.STATUS_CONTEST %} disabled {% end %}
                                 >Public Problem</button>
 							</td>
 						</tr>

--- a/src/static/templ/contests/proset.html
+++ b/src/static/templ/contests/proset.html
@@ -75,11 +75,12 @@ font-weight: bolder;
             <tbody>
             {% for idx, pro in enumerate(prolist) %}
                 <tr>
-                    <td class="id">{{ pro['pro_id'] }}</td>
-                    {% if pro['state'] is None %}
+                    {% set pro_id = pro.pro_id %}
+                    <td class="id">{{ pro_id }}</td>
+                    {% if score_map[pro_id]['state'] is None %}
                         <td>Todo</td>
                     {% else %}
-                        <td class="state-{{ pro['state'] }}">{{ ChalConst.STATE_LONG_STR[pro['state']] }}</td>
+                        <td class="state-{{ score_map[pro_id]['state'] }}">{{ ChalConst.STATE_LONG_STR[score_map[pro_id]['state']] }}</td>
                     {% end %}
 
                     {% set pro_name = pro.name %}
@@ -88,28 +89,28 @@ font-weight: bolder;
                     {% end %}
 
                     <!-- TODO: test this feature -->
-                    {% if is_end and pro['status'] == ProConst.STATUS_ONLINE %}
+                    {% if is_end and pro.status == ProConst.STATUS_ONLINE %}
                         <td class="name">
-                            <a href="/oj/pro/{{ pro['pro_id'] }}/">{{ pro_name }}</a>
+                            <a href="/oj/pro/{{ pro.pro_id }}/">{{ pro_name }}</a>
                         </td>
                     {% else %}
                         <td class="name">
-                            <a href="/oj/contests/{{ contest.contest_id }}/pro/{{ pro['pro_id'] }}/">{{ pro_name }}</a>
+                            <a href="/oj/contests/{{ contest.contest_id }}/pro/{{ pro.pro_id }}/">{{ pro_name }}</a>
                         </td>
                     {% end %}
 
-                    {% set state_idx = int(pro['score'] / 10) %}
-                    {% if pro['state'] == ChalConst.STATE_AC or state_idx > 10 %}
+                    {% set state_idx = int(score_map[pro_id]['score'] / 10) %}
+                    {% if score_map[pro_id]['state'] == ChalConst.STATE_AC or state_idx > 10 %}
                         {% set state_idx = 10 %}
                     {% elif state_idx < 0 %}
                         {% set state_idx = 0 %}
                     {% end %}
                     <td class="{{ score_color_class_map[state_idx] }} score">
-                        {{ pro['score'] }}
+                        {{ score_map[pro_id]['score'] }}
                     </td>
 
                     {% if show_ac_ratio %}
-                        {% set rate = pro['rate_data'] %}
+                        {% set rate = score_map[pro_id]['rate_data'] %}
                         <td>
                             {% if rate['user_ac_chal_cnt'] and rate['user_all_chal_cnt'] %}
                                 {{ '%.2f' % (rate['user_ac_chal_cnt'] / rate['user_all_chal_cnt'] * 100) }}%
@@ -124,9 +125,9 @@ font-weight: bolder;
                             {% else %}
                                 {{ '0.00%' }}
                             {% end %}
-                            (<a href="/oj/contests/{{ contest.contest_id }}/chal/?proid={{ pro['pro_id'] }}&state={{ ChalConst.STATE_AC }}">{{ rate['ac_chal_cnt'] }}</a>
+                            (<a href="/oj/contests/{{ contest.contest_id }}/chal/?proid={{ pro.pro_id }}&state={{ ChalConst.STATE_AC }}">{{ rate['ac_chal_cnt'] }}</a>
                             /
-                            <a href="/oj/contests/{{ contest.contest_id }}/chal/?proid={{ pro['pro_id'] }}">{{ rate['all_chal_cnt'] }}</a>)
+                            <a href="/oj/contests/{{ contest.contest_id }}/chal/?proid={{ pro.pro_id }}">{{ rate['all_chal_cnt'] }}</a>)
                         </td>
                     {% end %}
                 </tr>

--- a/src/static/templ/contests/proset.html
+++ b/src/static/templ/contests/proset.html
@@ -1,6 +1,7 @@
 {% import math %}
 {% from services.pro import ProConst %}
 {% from services.chal import ChalConst %}
+{% from utils.htmlgen import pro_idx_to_pro_alphabet %}
 
 <script type="text/javascript">
     function init() {
@@ -81,9 +82,9 @@ font-weight: bolder;
                         <td class="state-{{ pro['state'] }}">{{ ChalConst.STATE_LONG_STR[pro['state']] }}</td>
                     {% end %}
 
-                    {% set pro_name = pro['name'] %}
-                    {% if f"{chr(65+idx)}." not in pro_name and f"p{chr(65+idx)}" not in pro_name %}
-                        {% set pro_name = f"p{chr(65+idx)}. {pro_name}" %}
+                    {% set pro_name = pro.name %}
+                    {% if f"{pro_idx_to_pro_alphabet(idx)}." not in pro_name and pro_idx_to_pro_alphabet(idx) not in pro_name %}
+                        {% set pro_name = f"{pro_idx_to_pro_alphabet(idx)}. {pro_name}" %}
                     {% end %}
 
                     <!-- TODO: test this feature -->

--- a/src/static/templ/contests/scoreboard.html
+++ b/src/static/templ/contests/scoreboard.html
@@ -77,7 +77,7 @@ font-weight: bolder;
         secs %= 3600;
         mm = round(secs / 60) % 60;
 
-        return (dd > 0 ? (dd + ' Day' + (Math.abs(dd) > 1 ? 's ': ' ')) : '')
+        return (dd != 0 ? (dd + ' Day' + (Math.abs(dd) > 1 ? 's ': ' ')) : '')
                 + hh + ':' + String(mm).padStart(2, '0') + ':' + String(ss).padStart(2, '0');
     }
 

--- a/src/static/templ/info.html
+++ b/src/static/templ/info.html
@@ -258,7 +258,7 @@
     <div class="card-body">
       <ul>
         <li> rank 僅顯示每個user <b>最佳的submission</b> </li>
-        <li> 先依照 <b>Runtime</b> 排序再依照 <b>Memory</b> 排序 </li>
+        <li> 先依照 <b>Time</b> 排序再依照 <b>Memory</b> 排序 </li>
       </ul>
     </div>
   </div>

--- a/src/static/templ/log.html
+++ b/src/static/templ/log.html
@@ -10,4 +10,4 @@
 <p>{{ log['message'] }}</p>
 
 <label for="" class="form-control">Params</label>
-<p style="white-space: pre-wrap;">{{ json.dumps(log['params'], indent=4) }}</p>
+<p style="white-space: pre-wrap;">{{ json.loads(log['params']) }}</p>

--- a/src/static/templ/loglist.html
+++ b/src/static/templ/loglist.html
@@ -37,7 +37,7 @@
             {% for log in loglist %}
                 <tr>
                     <td class="id"><a href="/oj/log/{{ log['log_id'] }}/">{{ log['log_id'] }}</a></td>
-                    <td>{% raw log['message'] %}</td>
+                    <td>{{ log['message'] }}</td>
                     <td>{{ log['timestamp'] }}</td>
                 </tr>
             {% end %}

--- a/src/static/templ/manage/bulletin/bulletin-list.html
+++ b/src/static/templ/manage/bulletin/bulletin-list.html
@@ -25,13 +25,11 @@
             <tr>
                 <th scope="row">{{ bulletin['bulletin_id'] }}</th>
                 <td>
-                    <a href="/oj/bulletin/{{ bulletin['bulletin_id'] }}/"
-                        <font size=5>
+                    <a href="/oj/bulletin/{{ bulletin['bulletin_id'] }}/">
                         {% if bulletin['pinned'] %}
                             <span class="material-symbols-outlined">push_pin</span>
                         {% end %}
-                            {{ bulletin['title'] }}
-                        </font>
+                        {{ bulletin['title'] }}
                     </a>
                 </td>
                 <td style="color: {{ bulletin['color'] }}">{{ bulletin['color'] }}</td>

--- a/src/static/templ/manage/pro/pro-list.html
+++ b/src/static/templ/manage/pro/pro-list.html
@@ -62,19 +62,19 @@
 		<tbody>
 			{% for pro in prolist %}
 			<tr>
-				<th scope="row">{{ pro['pro_id'] }}</th>
-				<td><a href="/oj/pro/{{ pro['pro_id'] }}/">{{ pro['name'] }}</a></td>
+				<th scope="row">{{ pro.pro_id }}</th>
+				<td><a href="/oj/pro/{{ pro.pro_id }}/">{{ pro.name }}</a></td>
 
-				{% if pro['status'] == ProConst.STATUS_ONLINE %}
+				{% if pro.status == ProConst.STATUS_ONLINE %}
                     <td class="status-online">Online</td>
-				{% elif pro['status'] == ProConst.STATUS_CONTEST %}
+				{% elif pro.status == ProConst.STATUS_CONTEST %}
                     <td class="status-online">Contest</td>
-				{% elif pro['status'] == ProConst.STATUS_HIDDEN %}
+				{% elif pro.status == ProConst.STATUS_HIDDEN %}
                     <td class="status-hidden">Hidden</td>
 				{% end %}
 
-				<td proid={{ pro['pro_id'] }} class="control">
-					<a class="btn btn-secondary" href="/oj/manage/pro/update/?proid={{ pro['pro_id'] }}">&#x2699</a>
+				<td proid={{ pro.pro_id }} class="control">
+					<a class="btn btn-secondary" href="/oj/manage/pro/update/?proid={{ pro.pro_id }}">&#x2699</a>
 					<div class="btn-group">
 						<button type="button" class="btn btn-warning btn-sm rechal">Rechallenge</button>
 						<button type="button" class="btn btn-danger dropdown-toggle dropdown-toggle-split"

--- a/src/static/templ/manage/pro/update.html
+++ b/src/static/templ/manage/pro/update.html
@@ -4,7 +4,7 @@
 
 <script type="text/javascript" id="contjs" async>
     function init() {
-		let pro_id = "{{ pro['pro_id'] }}"
+		let pro_id = "{{ pro.pro_id }}"
 		let j_form = $('#form');
 		let j_form2 = $('#form2');
         let j_form3 = $('#form3');
@@ -97,11 +97,11 @@
             j_form2.find("tbody > tr").each(function() {
                 let j_tr = $(this);
                 let lang = j_tr.attr('language');
-                let timelimit = j_tr.find("input.time").val();
-                let memlimit = j_tr.find("input.mem").val();
+                let time = j_tr.find("input.time").val();
+                let memory = j_tr.find("input.mem").val();
                 limits[lang] = {
-                    timelimit: timelimit,
-                    memlimit: memlimit
+                    time: time,
+                    memory: memory
                 };
             });
 
@@ -161,30 +161,30 @@
 <div class="col-lg-10 ms-lg-2 mt-lg-2">
     <form id="form" class="blk-cont">
 		<label for="" class="form-label">Problem Name</label>
-		<input type="text" class="form-control name" placeholder="Problem Name" value="{{ pro['name'] }}">
+		<input type="text" class="form-control name" placeholder="Problem Name" value="{{ pro.name }}">
 
 		<label for="" class="form-label">Problem Tags</label>
-		<input type="text" class="form-control tags" placeholder="Tags" value="{{ pro.get('tags', '') or '' }}">
+		<input type="text" class="form-control tags" placeholder="Tags" value="{{ pro.tags }}">
 
 		<label for="" class="form-label">Problem Status</label>
 		<select class="form-select status">
-            <option value="{{ ProConst.STATUS_ONLINE }}" {% if pro['status'] == ProConst.STATUS_ONLINE %} selected {% end %}>Online</option>
-			<option value="{{ ProConst.STATUS_CONTEST }}" {% if pro['status'] == ProConst.STATUS_CONTEST %} selected {% end %}>Contest</option>
-			<option value="{{ ProConst.STATUS_HIDDEN }}" {% if pro['status'] == ProConst.STATUS_HIDDEN %} selected {% end %}>Hidden</option>
+            <option value="{{ ProConst.STATUS_ONLINE }}" {% if pro.status == ProConst.STATUS_ONLINE %} selected {% end %}>Online</option>
+			<option value="{{ ProConst.STATUS_CONTEST }}" {% if pro.status == ProConst.STATUS_CONTEST %} selected {% end %}>Contest</option>
+			<option value="{{ ProConst.STATUS_HIDDEN }}" {% if pro.status == ProConst.STATUS_HIDDEN %} selected {% end %}>Hidden</option>
 		</select>
 
         <label>Score Precision (0 ~ 3)</label>
-        <input type="range" class="form-range precision" min="0" max="3" step="1" value="{{ pro['testm_conf']['rate_precision'] }}">
+        <input type="range" class="form-range precision" min="0" max="3" step="1" value="{{ pro.config.rate_precision }}">
 
         <label for="" class="form-check-label">Allow Submit</label>
-        <input type="checkbox" class="form-check-input allow-submit" {% if pro['allow_submit'] %} checked {% end %}>
+        <input type="checkbox" class="form-check-input allow-submit" {% if pro.allow_submit %} checked {% end %}>
         <br />
 
         <label for="" class="form-check-label">Is Makefile Problem</label>
-        <input type="checkbox" class="form-check-input is-makefile" {% if pro['testm_conf']['is_makefile'] %} checked {% end %}>
+        <input type="checkbox" class="form-check-input is-makefile" {% if pro.config.is_makefile %} checked {% end %}>
         <br />
 
-        {% set check_type = pro['testm_conf']['check_type'] %}
+        {% set check_type = pro.config.checker_type %}
 		<label for="" class="form-label">Checker Type</label>
         <select class="form-select check-type">
             <option value="{{ ProConst.CHECKER_DIFF }}" {% if check_type == ProConst.CHECKER_DIFF %} selected {% end %}>Diff</option>
@@ -196,7 +196,7 @@
 
         <label for="" class="form-label chalmeta" {% if check_type != ProConst.CHECKER_IOREDIR %} style="display: none;" {% end %}>IORedir Settings</label>
         <textarea rows="10" cols="80" class="form-control chalmeta" {% if check_type != ProConst.CHECKER_IOREDIR %} style="display: none;" {% end %}>
-            {{ json.dumps(pro['testm_conf']['chalmeta'], indent=4) }}
+            {{ json.dumps(pro.config.chalmeta, indent=4) }}
         </textarea>
 
 		<div class="mt-3">
@@ -224,14 +224,14 @@
                 </tr>
             </thead>
             <tbody>
-                {% set limits = pro['testm_conf']['limit'] %}
+                {% set limits = pro.config.limits %}
                 <tr language="default">
                     <td>default</td>
-                    <td><input type="number" class="form-control time" value="{{ limits['default']['timelimit'] }}"></td>
-                    <td><input type="number" class="form-control mem" value="{{ limits['default']['memlimit'] // 1024 }}"></td>
+                    <td><input type="number" class="form-control time" value="{{ limits['default'].time }}"></td>
+                    <td><input type="number" class="form-control mem" value="{{ limits['default'].memory // 1024 }}"></td>
                 </tr>
                 {% set ALLOW_COMPILERS = ChalConst.ALLOW_COMPILERS %}
-                {% if pro['testm_conf']['is_makefile'] %}
+                {% if pro.config.is_makefile %}
                     {% set ALLOW_COMPILERS = ['gcc', 'g++', 'clang', 'clang++'] %}
                 {% end %}
 
@@ -239,8 +239,8 @@
                     {% if language in limits %}
                     <tr language="{{ language }}">
                         <td>{{ language }}</td>
-                        <td><input type="number" class="form-control time" value="{{ limits[language]['timelimit'] }}"></td>
-                        <td><input type="number" class="form-control mem" value="{{ limits[language]['memlimit'] // 1024 }}"></td>
+                        <td><input type="number" class="form-control time" value="{{ limits[language].time }}"></td>
+                        <td><input type="number" class="form-control mem" value="{{ limits[language].memory // 1024 }}"></td>
                     </tr>
                     {% else %}
                     <tr language="{{ language }}">
@@ -256,8 +256,8 @@
 		<button type="button" class="btn btn-primary submit">Update</button>
     </form>
 
-	<a class="btn btn-primary" href="/oj/manage/pro/updatetests/?proid={{ pro['pro_id'] }}">Edit Subtask</a>
-	<a class="btn btn-primary" href="/oj/manage/pro/updatetestdata/?proid={{ pro['pro_id'] }}">Edit Testdata</a>
-    <a class="btn btn-primary" href="/oj/manage/pro/filemanager/?proid={{ pro['pro_id'] }}">File Manager</a>
+	<a class="btn btn-primary" href="/oj/manage/pro/updatetests/?proid={{ pro.pro_id }}">Edit Subtask</a>
+	<a class="btn btn-primary" href="/oj/manage/pro/updatetestdata/?proid={{ pro.pro_id }}">Edit Testdata</a>
+    <a class="btn btn-primary" href="/oj/manage/pro/filemanager/?proid={{ pro.pro_id }}">File Manager</a>
 </div>
 {% end %}

--- a/src/static/templ/manage/pro/updatetestdata.html
+++ b/src/static/templ/manage/pro/updatetestdata.html
@@ -296,11 +296,11 @@
         </thead>
 
         <tbody>
-            {% for testdata_id, testdata in tests['testdatas'].items() %}
+            {% for testdata_id, testdata in config.testdatas.items() %}
                 <tr testdata_id="{{ testdata_id }}">
                     <th scope="row">{{ testdata_id }}</th>
-                    <td><a class="preview-file input">{{ testdata['inputfile'] }}</a></td>
-                    <td><a class="preview-file output">{{ testdata['outputfile'] }}</a></td>
+                    <td><a class="preview-file input">{{ testdata.inputfile }}</a></td>
+                    <td><a class="preview-file output">{{ testdata.outputfile }}</a></td>
                     <td>
                         <div class="btn-toolbar">
                             <div class="dropdown me-2">

--- a/src/static/templ/manage/pro/updatetests.html
+++ b/src/static/templ/manage/pro/updatetests.html
@@ -9,21 +9,21 @@
 		let pro_id = "{{ pro_id }}";
         let re = /^(\d+(-\d+)?)(\s*,\s*\d+(-\d+)?)*$/;
 
-        document.querySelectorAll('.edit-weight').forEach(el => {
+        document.querySelectorAll('.edit-rate').forEach(el => {
 			el.addEventListener('click', function (e) {
-				let group = $(this).parents('.accordion-collapse').attr('group');
-                let weight = $(this).siblings('#weight').val();
+				let subtask = $(this).parents('.accordion-collapse').attr('subtask');
+                let rate = $(this).siblings('#rate').val();
 
-				if (isNaN(weight)) {
-					alert('Weight must be a number');
+				if (isNaN(rate)) {
+					alert('Rate must be a number');
 					return;
 				}
 
                 $.post('/oj/be/manage/pro/updatetests', {
-					'reqtype': 'updateweight',
+					'reqtype': 'updaterate',
 					'pro_id': pro_id,
-					'group': group,
-					'weight': weight,
+					'subtask': subtask,
+					'rate': rate,
 				}, function (res) {
                     let msg = '';
 					let dialog_type = null;
@@ -31,7 +31,7 @@
                     res = JSON.parse(res);
                     if (res.status == 'S') {
 						dialog_type = index.DIALOG_TYPE.success;
-                        msg = `Update weight of task#${group} successfully.`;
+                        msg = `Update rate of subtask#${subtask} successfully.`;
                     } else {
                         msg = res.data;
                     }
@@ -42,12 +42,12 @@
 			});
 		});
 
-        $("button.add-group").on('click', function(e) {
-            let weight = parseInt(prompt('New test group weight: '));
+        $("button.add-subtask").on('click', function(e) {
+            let rate = parseInt(prompt('New subtask rate: '));
             $.post('/oj/be/manage/pro/updatetests', {
-                'reqtype': 'addtaskgroup',
+                'reqtype': 'addsubtask',
                 'pro_id': pro_id,
-                'weight': weight,
+                'rate': rate,
             }, function (res) {
                 let msg = '';
                 let dialog_type = null;
@@ -55,7 +55,7 @@
                 res = JSON.parse(res);
                 if (res.status == 'S') {
                     dialog_type = index.DIALOG_TYPE.success;
-                    msg = `Add task group successfully.`;
+                    msg = `Add subtask successfully.`;
                 } else {
                     msg = res.data;
                 }
@@ -65,13 +65,13 @@
             });
         })
 
-        document.querySelectorAll('button.delete-group').forEach(el => {
+        document.querySelectorAll('button.delete-subtask').forEach(el => {
             el.addEventListener('click', function(e) {
-                let group = $(this).parents('.accordion-collapse').attr('group');
+                let subtask = $(this).parents('.accordion-collapse').attr('subtask');
 				$.post('/oj/be/manage/pro/updatetests', {
-					'reqtype': 'deletetaskgroup',
+					'reqtype': 'deletesubtask',
 					'pro_id': pro_id,
-                    'group': group
+                    'subtask': subtask
 				}, function (res) {
                     let msg = '';
 					let dialog_type = null;
@@ -79,7 +79,7 @@
                     res = JSON.parse(res);
                     if (res.status == 'S') {
 						dialog_type = index.DIALOG_TYPE.success;
-                        msg = `Delete task group #${group} successfully.`;
+                        msg = `Delete subtask #${subtask} successfully.`;
                     } else {
                         msg = res.data;
                     }
@@ -92,7 +92,7 @@
 
         document.querySelectorAll('button.set-testdatas').forEach(el => {
             el.addEventListener('click', function(e) {
-                let group = $(this).parents('.accordion-collapse').attr('group');
+                let subtask = $(this).parents('.accordion-collapse').attr('subtask');
                 let testdatas = $(this).siblings('#testdatas').val();
                 if (!re.test(testdatas)) {
                     index.show_notify_dialog("Testdatas wrong. Please follow the instruction", index.DIALOG_TYPE.warning);
@@ -102,7 +102,7 @@
 				$.post('/oj/be/manage/pro/updatetests', {
 					'reqtype': 'settestdata',
 					'pro_id': pro_id,
-                    'group': group,
+                    'subtask': subtask,
                     'testdatas': testdatas,
 				}, function (res) {
                     let msg = '';
@@ -111,7 +111,7 @@
                     res = JSON.parse(res);
                     if (res.status == 'S') {
 						dialog_type = index.DIALOG_TYPE.success;
-                        msg = `Task group #${group} set testdatas successfully.`;
+                        msg = `Subtask #${subtask} set testdatas successfully.`;
                     } else {
                         msg = res.data;
                     }
@@ -128,35 +128,35 @@
 {% block content %}
 {% from utils.numeric import merge_list_to_str %}
 <div class="col-lg-10 ms-lg-2 mt-lg-2">
-	<button class="btn btn-primary add-group">Add Task Group</button>
+	<button class="btn btn-primary add-subtask">Add Subtask</button>
 
-	<div class="accordion" id="tests">
-    {% for test_group_idx, test_conf in tests['test_group'].items() %}
+	<div class="accordion" id="subtasks">
+    {% for subtask_id, subtask_config in config.subtask_configs.items() %}
 		<div class="accordion-item">
 			<h2 class="accordion-header">
 				    <button
-						class="accordion-button"
+						class="accordion-button collapsed"
 						type="button"
 						data-bs-toggle="collapse"
-						data-bs-target="#collapse{{ test_group_idx }}"
+						data-bs-target="#collapse{{ subtask_id }}"
 						aria-expanded="true"
 						aria-controls="collapseOne"
 					>
-						Task Group {{ test_group_idx + 1 }} Weight: {{ test_conf['weight'] }}
+						Subtask {{ subtask_id + 1 }} Rate: {{ subtask_config.rate }}
 					</button>
 			</h2>
-			<div id="collapse{{ test_group_idx }}" class="accordion-collapse collapse" data-bs-parent="#tests" group="{{ test_group_idx }}">
+			<div id="collapse{{ subtask_id }}" class="accordion-collapse collapse" data-bs-parent="#subtasks" subtask="{{ subtask_id }}">
 				<div class="accordion-body">
-                    <button class="btn btn-danger delete-group">Delete Current Task Group</button>
+                    <button class="btn btn-danger delete-subtask">Delete Current Subtask</button>
 
                     <div class="input-group mb-3">
-                        <input id="weight" class="form-control mb-1" type="number" value="{{ test_conf['weight'] }}" placeholder="Weight">
-                        <button class="btn btn-primary edit-weight">Update weight</button>
+                        <input id="weight" class="form-control mb-1" type="number" value="{{ subtask_config.rate }}" placeholder="Weight">
+                        <button class="btn btn-primary edit-weight">Update Rate</button>
                     </div>
 
                     <label for="testdatas" class="form-label">Testdata id. Starts from 0, for examples: <code>0</code>, <code>1-4</code>, <code>2,4,9-11,13-18</code></label>
                     <div class="input-group mb-3">
-                        <input id="testdatas" class="form-control mb-1" type="text" value="{{ merge_list_to_str(test_conf['testdatas']) }}" placeholder="Testdata">
+                        <input id="testdatas" class="form-control mb-1" type="text" value="{{ merge_list_to_str([testdata.testdata_id for testdata in subtask_config.testdatas]) }}" placeholder="Testdata">
                         <button class="btn btn-primary set-testdatas">Update Testdatas</button>
                     </div>
 				</div>

--- a/src/static/templ/pro-rank.html
+++ b/src/static/templ/pro-rank.html
@@ -28,9 +28,9 @@
                     <th>#</th>
                     <th>Account</th>
                     <th>Score</th>
-                    <th>Runtime(ms)</th>
+                    <th>Time(ms)</th>
                     <th>Memory(KB)</th>
-                    <th>Time</th>
+                    <th>Timestamp</th>
                 </tr>
             </thead>
             <tbody>
@@ -51,7 +51,7 @@
                     <td><a href="/oj/chal/{{chal['chal_id']}}/">{{ chal['chal_id']}}</a></td>
                     <td><a href="/oj/acct/{{chal['acct_id']}}/">{{ chal['acct_name']}}</a></td>
                     <td>{{ chal['rate'] }}</td>
-                    <td>{{ chal['runtime'] }}</td>
+                    <td>{{ chal['time'] }}</td>
                     <td>{{ round(chal['memory'] / 1024) }}</td>
                     <td>{{ chal['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</td>
                     </tr>

--- a/src/static/templ/pro.html
+++ b/src/static/templ/pro.html
@@ -11,11 +11,11 @@
     var pdf_url = '';
     var html_url = '';
     {% if contest %}
-        pdf_url = '/oj/contests/{{ contest.contest_id }}/pro/{{ pro['pro_id'] }}/cont.pdf';
-        html_url = '/oj/contests/{{ contest.contest_id }}/pro/{{ pro['pro_id'] }}/cont.html'
+        pdf_url = '/oj/contests/{{ contest.contest_id }}/pro/{{ pro.pro_id }}/cont.pdf';
+        html_url = '/oj/contests/{{ contest.contest_id }}/pro/{{ pro.pro_id }}/cont.html'
     {% else %}
-        pdf_url = '/oj/pro/{{ pro['pro_id'] }}/cont.pdf';
-        html_url = '/oj/pro/{{ pro['pro_id'] }}/cont.html';
+        pdf_url = '/oj/pro/{{ pro.pro_id }}/cont.pdf';
+        html_url = '/oj/pro/{{ pro.pro_id }}/cont.html';
     {% end %}
 
     function init() {
@@ -33,7 +33,7 @@
                 // valid
                 $('#tags-invalid').hide();
                 $.post('/oj/be/set-tags', {
-                    'pro_id': {{ pro['pro_id'] }},
+                    'pro_id': {{ pro.pro_id }},
                     'tags': tags,
                 }, function() {
                     $('#tags-done').show();
@@ -151,12 +151,12 @@
 </script>
 <div class="row">
     <div id="side" class="col-lg-2 col-12 mt-lg-2">
-        <h3>{{ pro['pro_id']}} / {{ pro['name'] }}</h3>
-        {% if can_submit and pro['allow_submit'] %}
+        <h3>{{ pro.pro_id}} / {{ pro.name }}</h3>
+        {% if can_submit and pro.allow_submit %}
             {% if contest and not contest.is_end() %}
-                <a class="btn btn-primary btn-lg my-lg-1" href="/oj/contests/{{ contest.contest_id }}/submit/{{ pro['pro_id'] }}/">Submit</a><br />
+                <a class="btn btn-primary btn-lg my-lg-1" href="/oj/contests/{{ contest.contest_id }}/submit/{{ pro.pro_id }}/">Submit</a><br />
             {% else %}
-                <a class="btn btn-primary btn-lg my-lg-1" href="/oj/submit/{{ pro['pro_id'] }}/">Submit</a><br />
+                <a class="btn btn-primary btn-lg my-lg-1" href="/oj/submit/{{ pro.pro_id }}/">Submit</a><br />
             {% end %}
         {% else %}
             <a class="btn btn-warning btn-lg my-lg-1">Cannot Submit</a><br />
@@ -164,11 +164,11 @@
 
         <div class="my-lg-1">
             {% if contest %}
-                <a class="btn btn-success" href="/oj/contests/{{ contest.contest_id }}/chal/?proid={{ pro['pro_id'] }}&acctid={{ user.acct_id }}">My Status</a>
-                <a class="btn btn-secondary" href="/oj/contests/{{ contest.contest_id }}/chal/?proid={{ pro['pro_id'] }}">Status</a>
+                <a class="btn btn-success" href="/oj/contests/{{ contest.contest_id }}/chal/?proid={{ pro.pro_id }}&acctid={{ user.acct_id }}">My Status</a>
+                <a class="btn btn-secondary" href="/oj/contests/{{ contest.contest_id }}/chal/?proid={{ pro.pro_id }}">Status</a>
             {% else %}
-                <a class="btn btn-success" href="/oj/rank/{{ pro['pro_id'] }}/">&nbsp;Rank&nbsp;</a>
-                <a class="btn btn-secondary" href="/oj/chal/?proid={{ pro['pro_id'] }}">Status</a>
+                <a class="btn btn-success" href="/oj/rank/{{ pro.pro_id }}/">&nbsp;Rank&nbsp;</a>
+                <a class="btn btn-secondary" href="/oj/chal/?proid={{ pro.pro_id }}">Status</a>
             {% end %}
 
         </div>
@@ -178,9 +178,9 @@
             <a class="btn btn-warning my-lg-1" id="switchviewer" style="display: none; width: 156px; text-align: center;">Switch Viewer</a>
         </div>
         {% if user.is_kernel() and not contest %}
-            <input id="tags" value="{{ pro.get('tags','') or '' }}" style="width: 190px" placeholder="add tags here">
+            <input id="tags" value="{{ pro.tags }}" style="width: 190px" placeholder="add tags here">
         {% else %}
-            <input id="tags" value="{{ pro.get('tags','') or '' }}" style="width: 190px" placeholder="no tags" disabled>
+            <input id="tags" value="{{ pro.tags }}" style="width: 190px" placeholder="no tags" disabled>
         {% end %}
         <div>
 
@@ -221,11 +221,11 @@
                 </tr>
             </thead>
             <tbody>
-                {% for language, limit in pro['testm_conf']['limit'].items() %}
+                {% for language, limit in pro.config.limits.items() %}
                 <tr>
                     <td>{{ language }}</td>
-                    <td>{{ limit['timelimit'] }} </td>
-                    <td>{{ limit['memlimit'] // 1024 }} </td>
+                    <td>{{ limit.time }} </td>
+                    <td>{{ limit.memory // 1024 }} </td>
                 </tr>
                 {% end %}
             </tbody>
@@ -234,21 +234,21 @@
         <table class="table">
             <thead>
                 <tr>
-                    <th>Test</th>
-                    <th>Weight</th>
+                    <th>Subtask</th>
+                    <th>Rate</th>
                 </tr>
             </thead>
             <tbody>
-                {% for test_group_idx, test in pro['testm_conf']['test_group'].items() %}
+                {% for subtask_id, subtask in pro.config.subtask_configs.items() %}
                     <tr>
-                        <td>{{ '%04d' % (test_group_idx + 1) }}</td>
-                        <td>{{ test['weight'] }}</td>
+                        <td>{{ '%04d' % (subtask_id + 1) }}</td>
+                        <td>{{ subtask.rate }}</td>
                     </tr>
                 {% end %}
             </tbody>
         </table>
         {% if user.is_kernel() %}
-            <a class="btn btn-warning" href="/oj/manage/pro/update/?proid={{pro['pro_id']}}">Manage</a>
+            <a class="btn btn-warning" href="/oj/manage/pro/update/?proid={{pro.pro_id}}">Manage</a>
         {% end %}
     </div>
 

--- a/src/static/templ/proset.html
+++ b/src/static/templ/proset.html
@@ -372,17 +372,18 @@
             <tbody>
             {% for pro in prolist %}
                 <tr>
-                    <td class="id">{{ pro['pro_id'] }}</td>
-                    {% if pro['state'] is None %}
+                    {% set pro_id = pro.pro_id %}
+                    <td class="id">{{ pro_id }}</td>
+                    {% if score_map[pro_id]['state'] is None %}
                         <td>Todo</td>
                     {% else %}
-                        <td><a href="/oj/chal/?proid={{ pro['pro_id'] }}&acctid={{ user.acct_id }}" class="state-{{ pro['state'] }}">{{ChalConst.STATE_LONG_STR[pro['state']]}}</a></td>
+                        <td><a href="/oj/chal/?proid={{ pro_id }}&acctid={{ user.acct_id }}" class="state-{{ score_map[pro_id]['state'] }}">{{ChalConst.STATE_LONG_STR[score_map[pro_id]['state']]}}</a></td>
                     {% end %}
                     <td class="name">
-                        <a href="/oj/pro/{{ pro['pro_id'] }}/">{{ pro['name'] }}</a>
+                        <a href="/oj/pro/{{ pro_id }}/">{{ pro.name }}</a>
                     </td>
 
-                    {% set rate = pro['rate_data'] %}
+                    {% set rate = score_map[pro_id]['rate_data'] %}
                     <td>
                         {% if rate['user_ac_chal_cnt'] and rate['user_all_chal_cnt'] %}
                             {{ '%.2f' % (rate['user_ac_chal_cnt'] / rate['user_all_chal_cnt'] * 100) }}%
@@ -390,7 +391,7 @@
                             {{ '0.00%' }}
                         {% end %}
 
-                        (<a href="/oj/rank/{{ pro['pro_id'] }}/">{{ rate['user_ac_chal_cnt'] }}</a>
+                        (<a href="/oj/rank/{{ pro_id }}/">{{ rate['user_ac_chal_cnt'] }}</a>
                         / {{ rate['user_all_chal_cnt'] }})
                     </td>
 
@@ -400,12 +401,12 @@
                         {% else %}
                             {{ '0.00%' }}
                         {% end %}
-                        (<a href="/oj/chal/?proid={{ pro['pro_id'] }}&state=1">{{ rate['ac_chal_cnt'] }}</a>
+                        (<a href="/oj/chal/?proid={{ pro_id }}&state={{ ChalConst.STATE_AC }}">{{ rate['ac_chal_cnt'] }}</a>
                         /
-                        <a href="/oj/chal/?proid={{ pro['pro_id'] }}">{{ rate['all_chal_cnt'] }}</a>)
+                        <a href="/oj/chal/?proid={{ pro_id }}">{{ rate['all_chal_cnt'] }}</a>)
                     </td>
 
-                    <td class="name">{{ pro.get('tags', '') or '' }}</td>
+                    <td class="name">{{ pro.tags }}</td>
                 </tr>
             {% end %}
             </tbody>

--- a/src/static/templ/submit.html
+++ b/src/static/templ/submit.html
@@ -4,7 +4,7 @@
 <script type="text/javascript">
     function init() {
 	    var j_submit = $('#submit');
-        let pro_id = "{{ pro['pro_id'] }}";
+        let pro_id = "{{ pro.pro_id }}";
         let contest_id = "{{ contest_id }}";
 
 	    j_submit.find('input.file').on('change', function(e) {
@@ -19,7 +19,7 @@
 
         j_submit.find('button.submit').on('click', function(e) {
             let code = j_submit.find('textarea.code').val();
-            let comp_type = j_submit.find('#compilerList').val();
+            let compiler_type = j_submit.find('#compilerList').val();
 
             let url = '';
             if (contest_id !== "0") {
@@ -32,7 +32,7 @@
                 'reqtype': 'submit',
                 'pro_id' : pro_id,
                 'code': code,
-                'comp_type': comp_type,
+                'compiler_type': compiler_type,
             }, function(res) {
                 res = JSON.parse(res);
                 if (res.status == 'S') {
@@ -54,7 +54,7 @@
 <div class="row">
     <div class="col-lg-2"></div>
     <div id="submit" class="col-lg-8">
-        <h3>{{ pro['pro_id']}} / {{ pro['name'] }}</h3>
+        <h3>{{ pro.pro_id}} / {{ pro.name }}</h3>
         <form>
             <div class="mb-1">
                 <label for="" class="form-label">Compiler</label>

--- a/src/tests/e2e/bulletin.py
+++ b/src/tests/e2e/bulletin.py
@@ -36,6 +36,29 @@ class BulletinTest(AsyncTest):
             })
             self.assertAPIReturnSuccess(res.text)
 
+            html = self.get_html('manage/bulletin', admin_session)
+            trs = html.select('tbody > tr')
+            self.assertEqual(len(trs), 2)
+            self.assertEqual(trs[0].select('td')[0].text.strip(), 'bulletin 1')
+            self.assertIsNone(trs[0].select('td')[0].select_one('span'))
+            self.assertEqual(trs[0].select('td')[1].text.strip(), 'white')
+            self.assertEqual(trs[0].select('td')[2].text.strip(), 'admin')
+
+            self.assertIn('bulletin 2 (pinned)', trs[1].select('td')[0].text.strip())
+            self.assertIsNotNone(trs[1].select('td')[0].select_one('span'))
+            self.assertEqual(trs[1].select('td')[1].text.strip(), 'red')
+            self.assertEqual(trs[1].select('td')[2].text.strip(), 'admin')
+
+            html = self.get_html('manage/bulletin/update?bulletinid=1', admin_session)
+            self.assertNotIn('checked', html.select_one('input#pinned').attrs)
+            self.assertEqual(html.select_one('input#title').attrs['value'].strip(), 'bulletin 1')
+            self.assertEqual(html.select_one('input#color').attrs['value'].strip(), 'white')
+
+            html = self.get_html('manage/bulletin/update?bulletinid=2', admin_session)
+            self.assertIn('checked', html.select_one('input#pinned').attrs)
+            self.assertEqual(html.select_one('input#title').attrs['value'].strip(), 'bulletin 2 (pinned)')
+            self.assertEqual(html.select_one('input#color').attrs['value'].strip(), 'red')
+
             res = admin_session.post('manage/bulletin/add', data={
                 'reqtype': 'add',
                 'title': '',

--- a/src/tests/e2e/chal.py
+++ b/src/tests/e2e/chal.py
@@ -24,7 +24,7 @@ class ChalTest(AsyncTest):
             })
             res = json.loads(res.text)
             self.assertNotEqual(res['status'], 'Eacces')
-            self.assertEqual(res['data']['comp_type'], 'python')
+            self.assertEqual(res['data']['compiler_type'], 'python')
             self.assertEqual(res['data']['code'].strip(), 'EROOR: The code is lost on server.')
 
             res = admin_session.post('submit', data={
@@ -92,8 +92,7 @@ class ChalListTest(AsyncTest):
                                           on_message_callback=_message)
 
             await ws2.write_message(json.dumps({
-                'first_chal_id': 1,
-                'last_chal_id': 2,
+                'chalids': [1, 2],
                 'acct_id': 1,
             }))
 

--- a/src/tests/e2e/contest.py
+++ b/src/tests/e2e/contest.py
@@ -39,11 +39,11 @@ class ContestTest(AsyncTest):
                 'reqtype': 'update',
                 'name': 'contest 1',
 
-                'contest_mode': ContestMode.IOI.value,
+                'contest_mode': ContestMode.IOI,
                 'contest_start': self.get_isoformat(contest_start),
                 'contest_end': self.get_isoformat(contest_end),
 
-                'reg_mode': RegMode.INVITED.value,
+                'reg_mode': RegMode.INVITED,
                 'reg_end': self.get_isoformat(reg_end),
 
                 'allow_compilers[]': ['g++', 'clang++'],
@@ -208,7 +208,7 @@ class ContestTest(AsyncTest):
 
         with AccountContext('admin@test', 'testtest') as admin_session:
             config = copy.deepcopy(default_config)
-            config['reg_mode'] = RegMode.FREE_REG.value
+            config['reg_mode'] = RegMode.FREE_REG
             res = admin_session.post('contests/1/manage/general', data=config)
             self.assertAPIReturnSuccess(res.text)
 
@@ -251,7 +251,7 @@ class ContestTest(AsyncTest):
             self.assertAPIReturnSuccess(res.text)
 
             config = copy.deepcopy(default_config)
-            config['reg_mode'] = RegMode.REG_APPROVAL.value
+            config['reg_mode'] = RegMode.REG_APPROVAL
             res = admin_session.post('contests/1/manage/general', data=config)
             self.assertAPIReturnSuccess(res.text)
 
@@ -415,7 +415,7 @@ class ContestTest(AsyncTest):
                 'reqtype': 'submit',
                 'pro_id': 1,
                 'code': 'cc1',
-                'comp_type': 'g++',
+                'compiler_type': 'g++',
             })
             self.assertAPIReturnValue(res.text, ('Enoext', 'Problem not in contest'))
 
@@ -423,7 +423,7 @@ class ContestTest(AsyncTest):
                 'reqtype': 'submit',
                 'pro_id': 7,
                 'code': 'cc2',
-                'comp_type': 'python3',
+                'compiler_type': 'python3',
             })
             self.assertAPIReturnValue(res.text, ('Ecomp', 'The compiler is not allowed'))
 
@@ -431,7 +431,7 @@ class ContestTest(AsyncTest):
                 'reqtype': 'submit',
                 'pro_id': 7,
                 'code': open('tests/static_file/code/toj674.ac.cpp').read(),
-                'comp_type': 'g++',
+                'compiler_type': 'g++',
             })
             self.assertAPIReturnValue(res.text, ('S', 17))
 
@@ -450,7 +450,7 @@ class ContestTest(AsyncTest):
                 'reqtype': 'submit',
                 'pro_id': 7,
                 'code': open('tests/static_file/code/toj674.ac.cpp').read(),
-                'comp_type': 'g++',
+                'compiler_type': 'g++',
             })
             self.assertAPIReturnValue(res.text, ('Esame', 'Do not submit same code'))
 
@@ -458,7 +458,7 @@ class ContestTest(AsyncTest):
                 'reqtype': 'submit',
                 'pro_id': 7,
                 'code': 'cc3',
-                'comp_type': 'g++',
+                'compiler_type': 'g++',
             })
             res = json.loads(res.text)
             self.assertEqual(res['status'], 'Einternal')

--- a/src/tests/e2e/main.py
+++ b/src/tests/e2e/main.py
@@ -168,7 +168,7 @@ class E2ETest(AsyncTest):
                 })
                 res = json.loads(res.text)
                 self.assertNotEqual(res['status'], 'Eacces')
-                self.assertEqual(res['data']['comp_type'], 'python')
+                self.assertEqual(res['data']['compiler_type'], 'python')
                 self.assertEqual(res['data']['code'].strip(),
                                  tornado.escape.xhtml_escape(open('tests/static_file/code/toj3.ac.py').read().strip()))
 

--- a/src/tests/e2e/main.py
+++ b/src/tests/e2e/main.py
@@ -120,6 +120,18 @@ class E2ETest(AsyncTest):
                 self.assertIsNotNone(html.select_one('li.manage'))
                 self.assertEqual(html.select_one('script#indexjs').attrs.get('acct_id'), '1')
 
+                html = self.get_html('manage/acct', admin_session)
+                trs = html.select('tbody > tr')
+                self.assertEqual(len(trs), 1)
+                self.assertEqual(trs[0].select('td')[1].text.strip(), 'admin')
+                self.assertEqual(trs[0].select('td')[2].text.strip(), 'admin@test')
+                self.assertEqual(trs[0].select('td')[4].text.strip(), 'Kernel')
+
+                html = self.get_html('manage/acct/update?acctid=1', admin_session)
+                self.assertEqual(html.select_one('h3').text.strip(), '1 / admin')
+                self.assertEqual(html.select_one('option:checked').attrs['value'], '0')
+                self.assertEqual(html.select_one('option:checked').text.strip(), 'Kernel')
+
                 html = self.get_html('manage/judge', admin_session)
                 self.assertEqual(html.select('tr')[1].select('td')[2].text, 'Online', 'Test need judge connected')
 

--- a/src/tests/e2e/manage/pro/specialscore.py
+++ b/src/tests/e2e/manage/pro/specialscore.py
@@ -43,8 +43,8 @@ class ManageProSpecialScoreTest(AsyncTest):
                 'pro_id': expected_pro_id,
                 'limits': json.dumps({
                     'default': {
-                        'timelimit': 1000,
-                        'memlimit': 65536,
+                        'time': 1000,
+                        'memory': 65536,
                     }
                 })
             })
@@ -87,9 +87,9 @@ class ManageProSpecialScoreTest(AsyncTest):
             await self.setup_basic_special_score_problem(5, 'tests/static_file/special_score')
 
             res = admin_session.post('manage/pro/updatetests', data={
-                'reqtype': 'addtaskgroup',
+                'reqtype': 'addsubtask',
                 'pro_id': 5,
-                'weight': 100, # NOTE: weight is not important, because we will be overwritten by the checker
+                'rate': 100, # NOTE: rate is not important, because we will be overwritten by the checker
             })
             self.assertAPIReturnSuccess(res.text)
 
@@ -97,7 +97,7 @@ class ManageProSpecialScoreTest(AsyncTest):
                 'reqtype': 'settestdata',
                 'pro_id': 5,
                 'testdatas': '0',
-                'group': 0,
+                'subtask': 0,
             })
             self.assertAPIReturnSuccess(res.text)
 
@@ -134,12 +134,12 @@ class ManageProSpecialScoreTest(AsyncTest):
         with AccountContext("admin@test", "testtest") as admin_session:
             await self.setup_basic_special_score_problem(6, 'tests/static_file/special_score_cms')
 
-            group_weights = [50, 25, 25]
-            for group_idx, weight in enumerate(group_weights):
+            subtask_rates = [50, 25, 25]
+            for subtask_id, rate in enumerate(subtask_rates):
                 res = admin_session.post('manage/pro/updatetests', data={
-                    'reqtype': 'addtaskgroup',
+                    'reqtype': 'addsubtask',
                     'pro_id': 6,
-                    'weight': weight,
+                    'rate': rate,
                 })
                 self.assertAPIReturnSuccess(res.text)
 
@@ -147,7 +147,7 @@ class ManageProSpecialScoreTest(AsyncTest):
                     'reqtype': 'settestdata',
                     'pro_id': 6,
                     'testdatas': '0',
-                    'group': group_idx,
+                    'subtask': subtask_id,
                 })
                 self.assertAPIReturnSuccess(res.text)
 

--- a/src/tests/e2e/manage/pro/update.py
+++ b/src/tests/e2e/manage/pro/update.py
@@ -81,12 +81,12 @@ class ManageProUpdateTest(AsyncTest):
                 'pro_id': 1,
                 'limits': json.dumps({
                     'default': {
-                        'timelimit': 1000,
-                        'memlimit': 65536,
+                        'time': 1000,
+                        'memory': 65536,
                     },
                     'python3': {
-                        'timelimit': 1500,
-                        'memlimit': 65536
+                        'time': 1500,
+                        'memory': 65536
                     },
                     'gcc': {},
                     'g++': {
@@ -114,9 +114,9 @@ class ManageProUpdateTest(AsyncTest):
 
             await self.wait_for_judge_finish(callback)
             html = self.get_html(f'chal/{chal_id}', admin_session)
-            states_trs = html.select('table#test > tbody > tr')
-            self.assertGreaterEqual(int(states_trs[0].select_one('td.runtime').text), 1000)
-            self.assertGreaterEqual(int(states_trs[1].select_one('td.runtime').text), 1000)
+            states_trs = html.select('table#subtasks > tbody > tr')
+            self.assertGreaterEqual(int(states_trs[0].select_one('td.time').text), 1000)
+            self.assertGreaterEqual(int(states_trs[1].select_one('td.time').text), 1000)
 
             # TODO: we should check limits and file
             pack_token = self.get_upload_token(admin_session)

--- a/src/tests/e2e/manage/pro/updatetests.py
+++ b/src/tests/e2e/manage/pro/updatetests.py
@@ -65,12 +65,12 @@ class ManageProUpdateTestsTest(AsyncTest):
             res = admin_session.get('manage/pro/updatetestdata?proid=1&download=1&testdata_id=0&type=what')
             self.assertAPIReturnValue(res.text, ('Eparam', 'Invalid testdata file type'))
 
-            # NOTE: updateweight
+            # NOTE: updaterate
             res = admin_session.post('manage/pro/updatetests?proid=1', data={
-                'reqtype': 'updateweight',
+                'reqtype': 'updaterate',
                 'pro_id': 1,
-                'weight': 60,
-                'group': 0,
+                'rate': 60,
+                'subtask': 0,
             })
             self.assertAPIReturnSuccess(res.text)
             html = self.get_html('pro/1', admin_session)
@@ -79,14 +79,14 @@ class ManageProUpdateTestsTest(AsyncTest):
             self.assertEqual(trs[0].select('td')[1].text.strip(), '60')
 
             html = self.get_html('manage/pro/updatetests?proid=1', admin_session)
-            groups = html.select_one('div#tests').select('div.accordion-item')
-            self.assertEqual(groups[0].select_one('button.accordion-button').text.strip(), f'Task Group { 0 + 1 } Weight: { 60 }')
+            subtasks = html.select_one('div#subtasks').select('div.accordion-item')
+            self.assertEqual(subtasks[0].select_one('button.accordion-button').text.strip(), f'Subtask { 0 + 1 } Rate: { 60 }')
 
-            # NOTE: addtaskgroup
+            # NOTE: addsubtask
             res = admin_session.post('manage/pro/updatetests?proid=1', data={
-                'reqtype': 'addtaskgroup',
+                'reqtype': 'addsubtask',
                 'pro_id': 1,
-                'weight': 20,
+                'rate': 20,
             })
             self.assertAPIReturnSuccess(res.text)
             html = self.get_html('pro/1', admin_session)
@@ -95,8 +95,8 @@ class ManageProUpdateTestsTest(AsyncTest):
             self.assertEqual(trs[2].select('td')[1].text.strip(), '20')
 
             html = self.get_html('manage/pro/updatetests?proid=1', admin_session)
-            groups = html.select_one('div#tests').select('div.accordion-item')
-            self.assertEqual(groups[2].select_one('button.accordion-button').text.strip(), f'Task Group { 2 + 1 } Weight: { 20 }')
+            subtasks = html.select_one('div#subtasks').select('div.accordion-item')
+            self.assertEqual(subtasks[2].select_one('button.accordion-button').text.strip(), f'Subtask { 2 + 1 } Rate: { 20 }')
 
             # NOTE: addsinglefile
             inputfile_token = await self._upload_file('tests/static_file/toj3/3.in', admin_session)
@@ -142,12 +142,12 @@ class ManageProUpdateTestsTest(AsyncTest):
                 'reqtype': 'settestdata',
                 'pro_id': 1,
                 'testdatas': '0-2',
-                'group': 2,
+                'subtask': 2,
             })
             self.assertAPIReturnSuccess(res.text)
             html = self.get_html('manage/pro/updatetests?proid=1', admin_session)
-            groups = html.select_one('div#tests').select('div.accordion-item')
-            self.assertEqual(groups[2].select_one('#testdatas').attrs['value'].strip(), "0-2")
+            subtasks = html.select_one('div#subtasks').select('div.accordion-item')
+            self.assertEqual(subtasks[2].select_one('#testdatas').attrs['value'].strip(), "0-2")
 
             def callback():
                 res = admin_session.post('submit', data={
@@ -216,12 +216,12 @@ class ManageProUpdateTestsTest(AsyncTest):
                 'reqtype': 'settestdata',
                 'pro_id': 1,
                 'testdatas': '0-1, 3',
-                'group': 2,
+                'subtask': 2,
             })
             self.assertAPIReturnSuccess(res.text)
             html = self.get_html('manage/pro/updatetests?proid=1', admin_session)
-            groups = html.select_one('div#tests').select('div.accordion-item')
-            self.assertEqual(groups[2].select_one('#testdatas').attrs['value'].strip(), "0-1,3")
+            subtasks = html.select_one('div#subtasks').select('div.accordion-item')
+            self.assertEqual(subtasks[2].select_one('#testdatas').attrs['value'].strip(), "0-1,3")
             def callback():
                 res = admin_session.post('submit', data={
                     'reqtype': 'rechal',
@@ -259,11 +259,11 @@ class ManageProUpdateTestsTest(AsyncTest):
                 admin_session
             )
 
-            # NOTE: deletetaskgroup
+            # NOTE: deletesubtask
             res = admin_session.post('manage/pro/updatetests?proid=1', data={
-                'reqtype': 'deletetaskgroup',
+                'reqtype': 'deletesubtask',
                 'pro_id': 1,
-                'group': 2,
+                'subtask': 2,
             })
             self.assertAPIReturnSuccess(res.text)
             def callback():

--- a/src/tests/e2e/submit.py
+++ b/src/tests/e2e/submit.py
@@ -10,7 +10,7 @@ class SubmitTest(AsyncTest):
                 'reqtype': 'submit',
                 'pro_id': 1,
                 'code': '',
-                'comp_type': 'g++',
+                'compiler_type': 'g++',
             })
             self.assertAPIReturnValue(res.text, ('Eempty', 'Submitted code should not be empty'))
 
@@ -18,7 +18,7 @@ class SubmitTest(AsyncTest):
                 'reqtype': 'submit',
                 'pro_id': 1,
                 'code': open('tests/static_file/code/large.cpp').read(),
-                'comp_type': 'g++',
+                'compiler_type': 'g++',
             })
             self.assertAPIReturnValue(res.text, ('Ecodemax', 'Submitted code too long'))
 
@@ -26,7 +26,7 @@ class SubmitTest(AsyncTest):
                 'reqtype': 'submit',
                 'pro_id': 1,
                 'code': 'cc',
-                'comp_type': 'tobiichi',
+                'compiler_type': 'tobiichi',
             })
             self.assertAPIReturnValue(res.text, ('Ecomp', 'The compiler is not allowed'))
 
@@ -34,7 +34,7 @@ class SubmitTest(AsyncTest):
                 'reqtype': 'submit',
                 'pro_id': 1,
                 'code': 'cc',
-                'comp_type': 'python3',
+                'compiler_type': 'python3',
             })
             self.assertAPIReturnValue(res.text, ('S', 10))
             html = self.get_html('submit/1', user_session)
@@ -46,7 +46,7 @@ class SubmitTest(AsyncTest):
                 'reqtype': 'submit',
                 'pro_id': 1,
                 'code': 'cc',
-                'comp_type': 'g++',
+                'compiler_type': 'g++',
             })
             res = json.loads(res.text)
             self.assertEqual(res['status'], 'Einternal')

--- a/src/tests/e2e/util.py
+++ b/src/tests/e2e/util.py
@@ -130,14 +130,14 @@ class AsyncTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(pack_token, "")
         return pack_token
 
-    def submit_problem(self, pro_id: int, code: str, comp_type: str, session) -> int:
+    def submit_problem(self, pro_id: int, code: str, compiler_type: str, session) -> int:
         res = session.post(
             "submit",
             data={
                 "reqtype": "submit",
                 "pro_id": pro_id,
                 "code": code,
-                "comp_type": comp_type,
+                "compiler_type": compiler_type,
             },
         )
         res = json.loads(res.text)

--- a/src/url.py
+++ b/src/url.py
@@ -15,7 +15,6 @@ from handlers.index import (
     AbouotHandler,
     DevInfoHandler,
     IndexHandler,
-    OnlineCounterHandler,
 )
 from handlers.log import LogHandler
 from handlers.manage.url import get_manage_url
@@ -68,7 +67,6 @@ def get_url(db, rs, pool):
         (r'/users', UserRankHandler, args),
         (r'/code', CodeHandler, args),
         (r'/informsub', BulletinSub, sub_args),
-        (r'/online_count', OnlineCounterHandler, args),
         (r'/dev-info', DevInfoHandler, args),
         (r'/report', ReportHandler, args),
     ] + get_manage_url(db, rs, pool) + get_contests_url(db, rs, pool)

--- a/src/utils/htmlgen.py
+++ b/src/utils/htmlgen.py
@@ -18,3 +18,15 @@ def set_page_title(title: str, site_title: str = None):
 
 def markdown_escape(code: str) -> str:
     return code.replace('\\', '\\\\').replace('`', '\\`')
+
+def pro_idx_to_pro_alphabet(num: int) -> str:
+    s = "p"
+
+    if num >= 26:
+        i = num // 26 - 1
+        num %= 26
+        s += chr(65 + i)
+
+    s += chr(65 + num)
+
+    return s


### PR DESCRIPTION
Some column names were confusing, so they were renamed for better clarity.
Converted several dictionaries to dataclasses to enable IDE/editor member auto-completion, improve performance, and reduce memory usage.
Also added return type annotations to functions in ProService and ChalService.

Rename table:
|Old Name|New Name|
|---------------|----------------|
problem.limit | problem.limits
problem.check_type | problem.checker_type
limit.timelimit | limit.time
limit.memlimit | limit.memory
test_config | subtask_config
test_config.weight | test_config.rate
test_config.test_idx | test_config.subtask_id
test | subtask_result
test.test_idx | test.subtask_id
test.runtime | test.time
challenge_state | total_result
challenge_state.runtime | challenge_state.time

Also fix contest proset problem number incorrect, scoreboard did not correctly display the day before the contest started.
Escape log message for security.