### PR TITLE
refactor: use UTC+0 for all time calculations; convert to config.TIMEZONE only for display

### DIFF
--- a/migration/20250928102400_remove_timezone.py
+++ b/migration/20250928102400_remove_timezone.py
@@ -1,0 +1,5 @@
+import config
+async def dochange(db, rs):
+    await db.execute("SET timezone TO 'UTC';")
+    await db.execute(f"ALTER DATABASE {config.DBNAME_OJ} SET timezone TO 'UTC';")
+    await rs.delete("contest")

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -9,3 +9,4 @@ ADMIN_NAME=admin
 ADMIN_MAIL=admin@admin
 ADMIN_PASSWORD=admin1234
 SITE_TITLE="New TNFSH Online Judge"
+TIMEDELTA=8

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,6 +50,10 @@ if [ -z "${SITE_TITLE}" ]; then
     SITE_TITLE="New TNFSH Online Judge"
 fi
 
+if [ -z $TIMEDELTA ]; then
+    TIMEDELTA=8
+fi
+
 if [ ! -d $INSTALL_DIR ]; then
     echo "$INSTALL_DIR does not exist."
     exit
@@ -135,6 +139,8 @@ cd ${INSTALL_DIR}/ntoj/
 COOKIE_SEC=$(head -c 32 /dev/urandom | xxd -ps -c 128)
 UNLOCK_PWD=$($HOME/.local/bin/poetry run python3 ${CURRENT_PWD}/get_unlock_pwd.py <<<${UNLOCK_PASSWORD})
 cat <<EOF | tee ${INSTALL_DIR}/ntoj/config.py >/dev/null
+import datetime
+TIMEZONE   = datetime.timezone(datetime.timedelta(hours=${TIMEDELTA}))
 PORT       = '${PORT}'
 REDIS_DB   = '${REDIS_DB}'
 DBNAME_OJ  = '${DB_NAME}'

--- a/src/handlers/base.py
+++ b/src/handlers/base.py
@@ -5,7 +5,6 @@ import json
 from typing import Any
 
 import asyncpg
-import tornado.gen
 import tornado.template
 import tornado.web
 import tornado.websocket

--- a/src/handlers/board.py
+++ b/src/handlers/board.py
@@ -100,6 +100,6 @@ class BoardHandler(RequestHandler):
             acct_submit=acct_submit,
             name=meta['name'],
             board_list=board_list,
-            end=str(meta['end']).split('+')[0].replace('-', '/'),
+            end=meta['end'],
             timestamp=int(time.time()),
         )

--- a/src/handlers/contests/manage/general.py
+++ b/src/handlers/contests/manage/general.py
@@ -2,9 +2,9 @@ import datetime
 
 from handlers.base import RequestHandler, reqenv, require_permission
 from handlers.contests.base import contest_require_permission
-from services.chal import ChalConst, Compiler
+from services.chal import Compiler
 from services.user import UserConst
-from services.contests import ContestService, ContestMode, RegMode, UserStatus
+from services.contests import ContestConst, ContestService, ContestMode, RegMode, UserStatus
 
 
 class ContestManageDashHandler(RequestHandler):
@@ -145,6 +145,8 @@ class ContestManageAddHandler(RequestHandler):
 
         if reqtype == "add":
             name = self.get_argument('name')
+            if err := self.len_check(name, ContestConst.NAME_MIN, ContestConst.NAME_MAX, 'Name'):
+                return self.error(err)
 
             _, contest_id = await ContestService.inst.add_default_contest(self.acct, name)
             self.error(('S', contest_id))
@@ -159,7 +161,7 @@ def trantime(time):
     else:
         try:
             time = datetime.datetime.strptime(time, '%Y-%m-%dT%H:%M:%S.%fZ')
-            time = time.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=+8)))
+            time = time.replace(tzinfo=datetime.timezone.utc)
 
         except ValueError:
             return ('Eparam', 'Invalid time'), None

--- a/src/handlers/contests/manage/qa.py
+++ b/src/handlers/contests/manage/qa.py
@@ -1,6 +1,7 @@
 import json
 import asyncio
 
+import config
 from services.contests import ContestService
 from services.user import UserService
 from handlers.base import RequestHandler, WebSocketSubHandler, reqenv
@@ -128,7 +129,7 @@ class ContestManageAnnounceHandler(RequestHandler):
                 'type': 'popup-announce',
                 'subject': announce['subject'],
                 'content': announce['content'],
-                'timestamp': announce['timestamp'].strftime('%Y-%m-%d %H:%M:%S'),
+                'timestamp': announce['timestamp'].astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S'),
             }))
             self.error(('S', ''))
 

--- a/src/handlers/contests/reg.py
+++ b/src/handlers/contests/reg.py
@@ -38,7 +38,7 @@ class ContestRegHandler(RequestHandler):
                 if acct_id in self.contest.user_list and self.contest.user_list[acct_id]['status'] == status:
                     return self.error(('Eexist', 'Already registered'))
 
-            if datetime.datetime.now().replace(tzinfo=datetime.timezone(datetime.timedelta(hours=+8))) > self.contest.reg_end:
+            if datetime.datetime.now(datetime.UTC) > self.contest.reg_end:
                 return self.error(('Etime', 'Registration time has passed. Please remember to register earlier next time'))
 
             if self.contest.reg_mode is RegMode.INVITED:

--- a/src/handlers/contests/scoreboard.py
+++ b/src/handlers/contests/scoreboard.py
@@ -10,9 +10,6 @@ from handlers.base import RequestHandler, WebSocketSubHandler, reqenv
 from services.contests import ContestService, ProblemScoreType, UserStatus
 from services.user import UserService
 
-UTC8 = datetime.timezone(datetime.timedelta(hours=8))
-
-
 class _JsonDatetimeEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, datetime.datetime):
@@ -62,7 +59,7 @@ class ContestScoreboardHandler(RequestHandler):
 
         if self.contest.freeze_scoreboard_period != 0 and self.contest.is_running() and not self.contest.is_admin(self.acct):
             if not has_end_time:
-                end_time = datetime.datetime.now().replace(tzinfo=datetime.timezone(datetime.timedelta(hours=+8)))
+                end_time = datetime.datetime.now(datetime.UTC)
 
             total_seconds = int((end_time - self.contest.contest_start).total_seconds())
             minutes = total_seconds // 60
@@ -102,8 +99,7 @@ class ContestScoreboardHandler(RequestHandler):
             else:
                 s[pro_id] = unpackb(scores, strict_map_key=False)
                 for pro_score in s[pro_id].values():
-                    pro_score['timestamp'] = datetime.datetime.fromtimestamp(pro_score['timestamp']).replace(
-                        tzinfo=UTC8)
+                    pro_score['timestamp'] = datetime.datetime.fromtimestamp(pro_score['timestamp'])
                     pro_score['score'] = Decimal(pro_score['score'])
 
             if is_ended:

--- a/src/handlers/rank.py
+++ b/src/handlers/rank.py
@@ -1,5 +1,3 @@
-import datetime
-
 from handlers.base import RequestHandler, reqenv
 from services.user import Account
 from services.chal import ChalConst
@@ -13,7 +11,6 @@ class ProRankHandler(RequestHandler):
         pageoff = int(self.get_argument('pageoff', default=0))
         pagenum = int(self.get_argument('pagenum', default=20))
 
-        tz = datetime.timezone(datetime.timedelta(hours=+8))
         pro_id = int(pro_id)
         allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
         if self.acct.is_kernel():
@@ -90,7 +87,7 @@ class ProRankHandler(RequestHandler):
                     'time': int(time),
                     'memory': int(memory),
                     'rate': rate,
-                    'timestamp': timestamp.astimezone(tz),
+                    'timestamp': timestamp,
                 }
             )
 

--- a/src/runintegratedtest.sh
+++ b/src/runintegratedtest.sh
@@ -4,6 +4,8 @@ current_pwd=$(pwd)
 
 mkdir -p /tmp/ntoj_test_web/oj/problem
 cat <<EOF >config.py
+import datetime
+TIMEZONE   = datetime.timezone(datetime.timedelta(hours=+8))
 DBNAME_OJ = 'ntoj_unittest_db_name'
 DBUSER_OJ = 'ntoj_unittest_db_user'
 DBPW_OJ = 'ntoj_unittest_db_password'

--- a/src/services/board.py
+++ b/src/services/board.py
@@ -1,5 +1,3 @@
-import datetime
-
 class BoardConst:
     STATUS_ONLINE = 0
     STATUS_HIDDEN = 1
@@ -43,8 +41,8 @@ class BoardService:
             'status': status,
             'pro_list': pro_list,
             'acct_list': acct_list,
-            'start': start.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=8))),
-            'end': end.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=8))),
+            'start': start,
+            'end': end,
         }
 
         return None, meta

--- a/src/services/bulletin.py
+++ b/src/services/bulletin.py
@@ -12,7 +12,6 @@ class BulletinService:
         self.db = db
         self.rs = rs
         BulletinService.inst = self
-        self.tz = datetime.timezone(datetime.timedelta(hours=+8))
 
     async def list_bulletin(self):
         async with self.db.acquire() as con:
@@ -30,7 +29,7 @@ class BulletinService:
                 {
                     "bulletin_id": b_id,
                     "title": title,
-                    "timestamp": timestamp.astimezone(self.tz),
+                    "timestamp": timestamp,
                     "color": color,
                     "pinned": pinned,
                     "acct_id": acct_id,
@@ -59,7 +58,7 @@ class BulletinService:
         result = {
             'title': result['title'],
             'content': result['content'],
-            'timestamp': result['timestamp'].astimezone(self.tz),
+            'timestamp': result['timestamp'],
             'name': result['name'],
             'color': result['color'],
             'pinned': result['pinned'],

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -29,6 +29,9 @@ class UserStatus(enum.IntEnum):
     APPROVED = 2
     ADMIN = 3
 
+class ContestConst:
+    NAME_MIN = 1
+    NAME_MAX = 50
 
 @dataclass(slots=True, kw_only=True)
 class Contest:
@@ -58,16 +61,13 @@ class Contest:
     freeze_scoreboard_period: int = 0
 
     def is_start(self) -> bool:
-        return datetime.datetime.now().replace(
-            tzinfo=datetime.timezone(datetime.timedelta(hours=+8))) >= self.contest_start
+        return datetime.datetime.now(datetime.UTC) >= self.contest_start
 
     def is_end(self) -> bool:
-        return datetime.datetime.now().replace(
-            tzinfo=datetime.timezone(datetime.timedelta(hours=+8))) >= self.contest_end
+        return datetime.datetime.now(datetime.UTC) >= self.contest_end
 
     def is_running(self) -> bool:
-        return self.contest_start <= datetime.datetime.now().replace(
-            tzinfo=datetime.timezone(datetime.timedelta(hours=+8))) < self.contest_end
+        return self.contest_start <= datetime.datetime.now(datetime.UTC) < self.contest_end
 
     def is_pro(self, pro_id: int) -> bool:
         return pro_id in self.pro_list
@@ -153,9 +153,9 @@ class ContestService:
                 contest = Contest(**result)
                 contest.reg_mode = RegMode(contest.reg_mode)
                 contest.contest_mode = ContestMode(contest.contest_mode)
-                contest.contest_start = contest.contest_start.astimezone(datetime.timezone(datetime.timedelta(hours=+8)))
-                contest.contest_end = contest.contest_end.astimezone(datetime.timezone(datetime.timedelta(hours=+8)))
-                contest.reg_end = contest.reg_end.astimezone(datetime.timezone(datetime.timedelta(hours=+8)))
+                contest.contest_start = contest.contest_start
+                contest.contest_end = contest.contest_end
+                contest.reg_end = contest.reg_end
 
                 result = await con.fetch('SELECT pro_id, score_type FROM contest_problem_joints WHERE contest_id = $1 ORDER BY "order";', contest_id)
                 for pro_id, score_type in result:
@@ -192,8 +192,8 @@ class ContestService:
                     "contest_id": contest_id,
                     "name": name,
                     "contest_mode": contest_mode,
-                    "contest_start": contest_start.astimezone(datetime.timezone(datetime.timedelta(hours=+8))),
-                    "contest_end": contest_end.astimezone(datetime.timezone(datetime.timedelta(hours=+8))),
+                    "contest_start": contest_start,
+                    "contest_end": contest_end,
                     "is_public_scoreboard": is_public_scoreboard
                 } for contest_id, name, contest_mode, contest_start, contest_end, is_public_scoreboard in result
             ]

--- a/src/services/log.py
+++ b/src/services/log.py
@@ -1,12 +1,10 @@
 import datetime
 import json
 
-tz = datetime.timezone(datetime.timedelta(hours=+8))
-
 class _Encoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, datetime.datetime):
-            return o.astimezone(tz).isoformat(timespec="seconds")
+            return o.isoformat(timespec="seconds")
 
         return super().default(o)
 
@@ -37,7 +35,7 @@ class LogService:
 
     async def view_log(self, log_id: int):
         async with self.db.acquire() as con:
-            res = await con.fetch('SELECT log_id, message, "timestamp", params FROM log WHERE log_id = $1', int(log_id))
+            res = await con.fetch('SELECT log_id, "type", message, "timestamp", params FROM log WHERE log_id = $1', int(log_id))
             if len(res) == 0:
                 return ('Enoext', 'Log not found'), None
             res = res[0]
@@ -48,8 +46,9 @@ class LogService:
 
             return None, {
                 'log_id': res['log_id'],
+                'log_type': res['type'],
                 'message': res['message'],
-                'timestamp': res['timestamp'].astimezone(tz).isoformat(timespec="seconds"),
+                'timestamp': res['timestamp'],
                 'params': params
             }
 
@@ -92,7 +91,7 @@ class LogService:
                     {
                         'log_id': log_id,
                         'message': message,
-                        'timestamp': timestamp.astimezone(tz).isoformat(timespec="seconds"),
+                        'timestamp': timestamp,
                     }
                 )
 

--- a/src/static/templ/board-list.html
+++ b/src/static/templ/board-list.html
@@ -1,3 +1,4 @@
+{% import datetime %}
 {% from services.board import BoardConst %}
 <script type="text/javascript" id="contjs">
     function init() {

--- a/src/static/templ/board-list.html
+++ b/src/static/templ/board-list.html
@@ -24,7 +24,7 @@
 			<th scope="row">{{ board['board_id'] }}</th>
             <td><a href="/oj/board/{{ board['board_id'] }}/">{{ board['name'] }}</a></td>
             <td>
-				{% set delta = board['end'] - datetime.datetime.now().replace(tzinfo=datetime.timezone(datetime.timedelta(hours=8))) %}
+				{% set delta = board['end'] - datetime.datetime.now(datetime.UTC) %}
 				{% set deltasecond = delta.days * 24 * 60 * 60 + delta.seconds %}
 				{% if deltasecond <= 0 %}
 				    Over

--- a/src/static/templ/board.html
+++ b/src/static/templ/board.html
@@ -1,3 +1,4 @@
+{% import datetime %}
 {% import math %}
 {% from services.chal import ChalConst %}
 {% from services.board import BoardConst %}
@@ -160,7 +161,7 @@
       board.scrollLeft = board_old_scroll_left
     }
   }, 50);
-  var end = new Date('{{end}}').getTime();
+  var end = new Date('{{end.astimezone(datetime.UTC)}}').getTime();
   var j_contest = $('#contest');
 
   function GetCount() {

--- a/src/static/templ/board.html
+++ b/src/static/templ/board.html
@@ -1,4 +1,3 @@
-{% import datetime %}
 {% import math %}
 {% from services.chal import ChalConst %}
 {% from services.board import BoardConst %}

--- a/src/static/templ/board.html
+++ b/src/static/templ/board.html
@@ -161,7 +161,7 @@
       board.scrollLeft = board_old_scroll_left
     }
   }, 50);
-  var end = new Date('{{end.astimezone(datetime.UTC)}}').getTime();
+  var end = new Date('{{ end }}').getTime();
   var j_contest = $('#contest');
 
   function GetCount() {

--- a/src/static/templ/bulletin.html
+++ b/src/static/templ/bulletin.html
@@ -1,13 +1,14 @@
+{% import config %}
 <script>
     function init() {
         let desc_tex = `{{ markdown_escape(bulletin['content']) }}`;
 
         let descEle = document.getElementById('content');
         descEle.innerHTML = DOMPurify.sanitize(marked.parse(index.unescape_html(desc_tex)));
-        MathJax.Hub.Queue(["Typeset",MathJax.Hub, descEle]);
+        MathJax.Hub.Queue(["Typeset", MathJax.Hub, descEle]);
     }
 </script>
 
 <h2>{{bulletin['title']}}</h2>
 <div id="content"></div>
-<h5>Author: {{bulletin['name']}}, {{ bulletin['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h5>
+<h5>Author: {{bulletin['name']}}, {{ bulletin['timestamp'].astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S') }}</h5>

--- a/src/static/templ/chal.html
+++ b/src/static/templ/chal.html
@@ -1,6 +1,5 @@
 {% import config %}
 {% from services.chal import ChalConst, MessageType %}
-{% import datetime %}
 <script src="/oj/third/prism.js"></script>
 <link rel="stylesheet" href="/oj/third/prism.css">
 <style>
@@ -12,7 +11,6 @@
 }
 </style>
 
-<!-- TODO: move timezone to config -->
 <!-- TODO: Testdata Result Message e2etest -->
 
 <script type="text/javascript">

--- a/src/static/templ/chal.html
+++ b/src/static/templ/chal.html
@@ -1,3 +1,4 @@
+{% import config %}
 {% from services.chal import ChalConst, MessageType %}
 {% import datetime %}
 <script src="/oj/third/prism.js"></script>
@@ -11,7 +12,6 @@
 }
 </style>
 
-{% set TZ = datetime.timezone(datetime.timedelta(hours=+8)) %}
 <!-- TODO: move timezone to config -->
 <!-- TODO: Testdata Result Message e2etest -->
 
@@ -244,7 +244,7 @@
                 </tr>
                 <tr>
                     <td>Timestamp</td>
-                    <td class="time">{{ chal.timestamp.astimezone(TZ).strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                    <td class="time">{{ chal.timestamp.astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S') }}</td>
                 </tr>
             </tbody>
         </table>

--- a/src/static/templ/challist.html
+++ b/src/static/templ/challist.html
@@ -1,6 +1,5 @@
-{% import datetime %}
+{% import config %}
 {% from services.chal import ChalConst, COMPILER_INFOS, Compiler %}
-{% set TZ = datetime.timezone(datetime.timedelta(hours=+8)) %}
 
 <link rel="stylesheet" type="text/css" href="/oj/challist.css">
 
@@ -232,7 +231,7 @@
                     <td id="memory">{{ chal.total_result.memory }}</td>
                     <td id="score">{{ chal.total_result.rate }}</td>
                     <td>{{ chal.compiler_type }}</td>
-                    <td class="time">{{ chal.timestamp.astimezone(TZ).strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                    <td class="time">{{ chal.timestamp.astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S') }}</td>
                 </tr>
             {% end %}
             </tbody>

--- a/src/static/templ/contests/contests-list.html
+++ b/src/static/templ/contests/contests-list.html
@@ -3,9 +3,10 @@
 </script>
 <div class="col-lg-12 ms-lg-2">
 
+    {% import config %}
     {% from services.contests import ContestMode %}
     {% import datetime %}
-    {% set now = datetime.datetime.now().replace(tzinfo=datetime.timezone(datetime.timedelta(hours=+8))) %}
+    {% set now = datetime.datetime.now(datetime.UTC) %}
 
     <h3>Active Contests</h3>
     <table class="table table-hover table-sm table-responsive-sm col mx-lg-3">
@@ -23,7 +24,7 @@
                 {% if contest['contest_start'] <= now < contest['contest_end'] %}
                 <tr>
                     <th scope="row"><a href="/oj/contests/{{ contest['contest_id'] }}/info/">{{ contest['name'] }}</a></th>
-                    <td>{{ contest['contest_start'].strftime("%Y-%m-%d %H:%M") }}</td>
+                    <td>{{ contest['contest_start'].astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M") }}</td>
                     <td>{{ contest['contest_end'] - contest['contest_start'] }}</td>
                     <td>{{ ContestMode(int(contest['contest_mode'])).name }}</td>
                     <td>{{ "Yes" if contest['is_public_scoreboard'] else "No" }}</td>
@@ -49,7 +50,7 @@
                 {% if contest['contest_id'] == 1 %}
                 <tr>
                     <th scope="row"><a href="/oj/contests/{{ contest['contest_id'] }}/info/">{{ contest['name'] }}</a></th>
-                    <td>{{ contest['contest_start'].strftime("%Y-%m-%d %H:%M") }}</td>
+                    <td>{{ contest['contest_start'].astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M") }}</td>
                     <td>{{ contest['contest_end'] - contest['contest_start'] }}</td>
                     <td>{{ ContestMode(int(contest['contest_mode'])).name }}</td>
                     <td>{{ "Yes" if contest['is_public_scoreboard'] else "No" }}</td>
@@ -80,7 +81,7 @@
                 {% if contest['contest_start'] > now %}
                 <tr>
                     <th scope="row"><a href="/oj/contests/{{ contest['contest_id'] }}/info/">{{ contest['name'] }}</a></th>
-                    <td>{{ contest['contest_start'].strftime("%Y-%m-%d %H:%M") }}</td>
+                    <td>{{ contest['contest_start'].astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M") }}</td>
                     <td>{{ contest['contest_end'] - contest['contest_start'] }}</td>
                     <td>{{ ContestMode(int(contest['contest_mode'])).name }}</td>
                     <td>{{ "Yes" if contest['is_public_scoreboard'] else "No" }}</td>
@@ -109,7 +110,7 @@
                 {% if now >= contest['contest_end'] %}
                 <tr>
                     <th scope="row"><a href="/oj/contests/{{ contest['contest_id'] }}/info/">{{ contest['name'] }}</a></th>
-                    <td>{{ contest['contest_start'].strftime("%Y-%m-%d %H:%M") }}</td>
+                    <td>{{ contest['contest_start'].astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M") }}</td>
                     <td>{{ contest['contest_end'] - contest['contest_start'] }}</td>
                     <td>{{ ContestMode(int(contest['contest_mode'])).name }}</td>
                     <td>{{ "Yes" if contest['is_public_scoreboard'] else "No" }}</td>

--- a/src/static/templ/contests/info.html
+++ b/src/static/templ/contests/info.html
@@ -1,3 +1,4 @@
+{% import config %}
 {% from services.contests import ContestMode, RegMode, UserStatus %}
 <script>
     function init() {
@@ -22,8 +23,8 @@
             <div class="card mb-1">
                 <div class="card-header">Start / End</div>
                 <div class="card-body">
-                    <h5>{{ contest.contest_start.strftime("%Y-%m-%d %H:%M:%S") }}</h5>
-                    <h5>{{ contest.contest_end.strftime("%Y-%m-%d %H:%M:%S") }}</h5>
+                    <h5>{{ contest.contest_start.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</h5>
+                    <h5>{{ contest.contest_end.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</h5>
                 </div>
             </div>
 
@@ -46,7 +47,7 @@
                     {% if contest.reg_mode is RegMode.INVITED %}
                         <h5>Invited</h5>
                     {% else %}
-                        <h5>{{ contest.reg_end.strftime("%Y-%m-%d %H:%M:%S") }}</h5>
+                        <h5>{{ contest.reg_end.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</h5>
                         {% if contest.reg_mode is RegMode.FREE_REG %}
                             <h5>Free Registration, no approval needed</h5>
                         {% elif contest.reg_mode is RegMode.REG_APPROVAL %}
@@ -63,7 +64,7 @@
                     {% if contest.is_admin(user) %}
                         <h5>Admin, no registration needed</h5>
                     {% else %}
-                        {% set now = datetime.datetime.now().replace(tzinfo=datetime.timezone(datetime.timedelta(hours=+8))) %}
+                        {% set now = datetime.datetime.now(datetime.UTC) %}
                         {% set can_reg = True %}
                         {% if now >= contest.reg_end %}
                             {% set can_reg = False %}

--- a/src/static/templ/contests/manage/announce.html
+++ b/src/static/templ/contests/manage/announce.html
@@ -1,5 +1,6 @@
 {% extends 'manage.html' %}
 {% block head %}
+{% import config %}
 <script type="text/javascript">
     function init() {
         $("#add").on('click', function(e) {
@@ -136,7 +137,7 @@
                             <div class="card-body">
                                 <h4 class="card-title">{{ announce['subject'] }}</h4>
                                 <p class="card-text">{{ announce['content'] }}</p>
-                                <h6>{{ announce['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                                <h6>{{ announce['timestamp'].astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S') }}</h6>
                             </div>
                         </div>
                         <button class="btn btn-primary edit">Edit</button>

--- a/src/static/templ/contests/manage/general.html
+++ b/src/static/templ/contests/manage/general.html
@@ -122,7 +122,7 @@
 
 {% block content %}
 
-{% import datetime %}
+{% import config %}
 {% from services.contests import ContestMode %}
 {% from services.contests import RegMode %}
 {% from services.chal import Compiler, COMPILER_INFOS %}
@@ -149,7 +149,7 @@
         <div class="mb-1">
             <label for="datepickerContestStart" class="form-label">Contest Start Time</label>
             <div class="input-group" id="datepickerContestStart">
-                <input id="datepickerContestStartInput" class="form-control" value="{{ contest.contest_start.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=+8))) }}">
+                <input id="datepickerContestStartInput" class="form-control" value="{{ contest.contest_start.astimezone(config.TIMEZONE) }}">
                 <span class="input-group-text" data-td-target="#datepickerContestStart" data-td-toggle="datepickerContestStart">
                     <svg class="svg-inline--fa fa-calendar" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="calendar" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M96 32V64H48C21.5 64 0 85.5 0 112v48H448V112c0-26.5-21.5-48-48-48H352V32c0-17.7-14.3-32-32-32s-32 14.3-32 32V64H160V32c0-17.7-14.3-32-32-32S96 14.3 96 32zM448 192H0V464c0 26.5 21.5 48 48 48H400c26.5 0 48-21.5 48-48V192z"></path></svg><!-- <span class="fa-solid fa-calendar"></span> Font Awesome fontawesome.com -->
                 </span>
@@ -159,7 +159,7 @@
         <div class="mb-1">
             <label for="datepickerContestEnd" class="form-label">Contest End Time</label>
             <div class="input-group" id="datepickerContestEnd">
-                <input id="datepickerContestEndInput" class="form-control" value="{{ contest.contest_end.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=+8))) }}">
+                <input id="datepickerContestEndInput" class="form-control" value="{{ contest.contest_end.astimezone(config.TIMEZONE) }}">
                 <span class="input-group-text" data-td-target="#datepickerContestEnd" data-td-toggle="datepickerContestEnd">
                     <svg class="svg-inline--fa fa-calendar" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="calendar" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M96 32V64H48C21.5 64 0 85.5 0 112v48H448V112c0-26.5-21.5-48-48-48H352V32c0-17.7-14.3-32-32-32s-32 14.3-32 32V64H160V32c0-17.7-14.3-32-32-32S96 14.3 96 32zM448 192H0V464c0 26.5 21.5 48 48 48H400c26.5 0 48-21.5 48-48V192z"></path></svg>
                 </span>
@@ -184,7 +184,7 @@
         <div class="mb-1">
             <label for="datepickerRegEnd" class="form-label">Registration End Time</label>
             <div class="input-group" id="datepickerRegEnd">
-                <input id="datepickerRegEndInput" class="form-control" value="{{ contest.reg_end.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=+8))) }}">
+                <input id="datepickerRegEndInput" class="form-control" value="{{ contest.reg_end.astimezone(config.TIMEZONE) }}">
                 <span class="input-group-text" data-td-target="#datepickerRegEnd" data-td-toggle="datepickerRegEnd">
                     <svg class="svg-inline--fa fa-calendar" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="calendar" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M96 32V64H48C21.5 64 0 85.5 0 112v48H448V112c0-26.5-21.5-48-48-48H352V32c0-17.7-14.3-32-32-32s-32 14.3-32 32V64H160V32c0-17.7-14.3-32-32-32S96 14.3 96 32zM448 192H0V464c0 26.5 21.5 48 48 48H400c26.5 0 48-21.5 48-48V192z"></path></svg>
                 </span>

--- a/src/static/templ/contests/manage/question.html
+++ b/src/static/templ/contests/manage/question.html
@@ -1,5 +1,6 @@
 {% extends 'manage.html' %}
 {% block head %}
+{% import config %}
 <script type="text/javascript">
     function init() {
         $("td.reply").each((_, element) => {

--- a/src/static/templ/contests/manage/question.html
+++ b/src/static/templ/contests/manage/question.html
@@ -74,7 +74,7 @@
                                     <span class="float-end"><a href="/oj/acct/{{ question['ask_acct'].acct_id }}/">{{ question['ask_acct'].name }}</a></span>
                                 </h4>
                                 <p class="card-text">{{ question['ask_content'] }}</p>
-                                <h6>Ask Time: {{ question['ask_timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                                <h6>Ask Time: {{ question['ask_timestamp'].astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S') }}</h6>
                             </div>
                         </div>
                     </td>
@@ -107,7 +107,7 @@
                         {% if replied %}
                         <div class="view">
                             <p><strong>Reply: {{ question['reply_content'] }}</strong></p>
-                            <h6>Reply Time: {{ question['reply_timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                            <h6>Reply Time: {{ question['reply_timestamp'].astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S') }}</h6>
                             <button class="btn btn-primary edit">Edit Reply</button>
                         </div>
                         {% end %}

--- a/src/static/templ/contests/qa.html
+++ b/src/static/templ/contests/qa.html
@@ -1,3 +1,4 @@
+{% import config %}
 {% from services.contests import UserStatus %}
 <script>
     function init() {
@@ -46,7 +47,7 @@
                         <div class="card-body">
                             <h4 class="card-title">{{ announce['subject'] }}</h4>
                             <p class="card-text">{{ announce['content'] }}</p>
-                            <h6>{{ announce['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                            <h6>{{ announce['timestamp'].astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S') }}</h6>
                         </div>
                     </div>
                 {% end %}
@@ -95,7 +96,7 @@
                                     <div class="card-body">
                                         <h4 class="card-title">{{ question['ask_subject'] }}</h4>
                                         <p class="card-text">{{ question['ask_content'] }}</p>
-                                        <h6>{{ question['ask_timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                                        <h6>{{ question['ask_timestamp'].astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S') }}</h6>
                                     </div>
                                 </div>
                             </td>
@@ -105,7 +106,7 @@
                                     <div class="card-body">
                                         {% if question['reply_timestamp'] %}
                                         <p class="card-text">{{ question['reply_content'] }}</p>
-                                        <h6>{{ question['reply_timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</h6>
+                                        <h6>{{ question['reply_timestamp'].astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S') }}</h6>
                                         {% end %}
                                     </div>
                                 </div>

--- a/src/static/templ/contests/reg.html
+++ b/src/static/templ/contests/reg.html
@@ -1,3 +1,4 @@
+{% import config %}
 {% from services.contests import RegMode, UserStatus %}
 {% import datetime %}
 
@@ -61,9 +62,9 @@
     <div class="col mt-4">
         <div class="mb-1 text-center">
             <label class="form-label">Status: {{ status }}</label>
-            <label class="form-label">Registration End: {{ contest.reg_end.strftime("%Y-%m-%d %H:%M:%S") }}</label>
+            <label class="form-label">Registration End: {{ contest.reg_end.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</label>
 
-            {% set now = datetime.datetime.now().replace(tzinfo=datetime.timezone(datetime.timedelta(hours=+8))) %}
+            {% set now = datetime.datetime.now(datetime.UTC) %}
             {% set is_reged = user.acct_id in contest.user_list and contest.user_list[user.acct_id]['status'] in [UserStatus.REQUESTED, UserStatus.APPROVED] %}
 
             {% if now >= contest.reg_end %}

--- a/src/static/templ/contests/scoreboard.html
+++ b/src/static/templ/contests/scoreboard.html
@@ -1,4 +1,6 @@
+{% import datetime %}
 {% from services.contests import ContestMode %}
+{% from utils.htmlgen import pro_idx_to_pro_alphabet %}
 
 <style>
 .rank-gold > td {
@@ -51,8 +53,8 @@ font-weight: bolder;
 <script>
     var contest_id = '{{ contest.contest_id }}';
     var post_url = `/oj/be/contests/${contest_id}/scoreboard`;
-    var contest_start = new Date("{{ contest.contest_start }}");
-    var contest_end = new Date("{{ contest.contest_end }}");
+    var contest_start = new Date("{{ contest.contest_start.replace(datetime.UTC) }}");
+    var contest_end = new Date("{{ contest.contest_end.replace(datetime.UTC) }}");
     var contest_length = parseInt((contest_end - contest_start) / 1000);
     var score_color_class_map
         = ["state-0", "state-1", "state-2", "state-3", "state-4", "state-5", "state-6", "state-7", "state-8", "state-9", "state-10"];
@@ -312,7 +314,7 @@ font-weight: bolder;
                         <th scope="col">Username</th>
                         {% for idx, pro_id in enumerate(contest.pro_list) %}
                         <th scope="col">
-                            <a class="" href="/oj/contests/{{ contest.contest_id }}/pro/{{ pro_id }}/">p{{chr(65+idx)}}</a>
+                            <a class="" href="/oj/contests/{{ contest.contest_id }}/pro/{{ pro_id }}/">{{ pro_idx_to_pro_alphabet(idx) }}</a>
                         </th>
                         {% end %}
                         <th scope="col">Total</th>

--- a/src/static/templ/contests/scoreboard.html
+++ b/src/static/templ/contests/scoreboard.html
@@ -53,8 +53,8 @@ font-weight: bolder;
 <script>
     var contest_id = '{{ contest.contest_id }}';
     var post_url = `/oj/be/contests/${contest_id}/scoreboard`;
-    var contest_start = new Date("{{ contest.contest_start.replace(datetime.UTC) }}");
-    var contest_end = new Date("{{ contest.contest_end.replace(datetime.UTC) }}");
+    var contest_start = new Date("{{ contest.contest_start.replace(tzinfo=datetime.UTC) }}");
+    var contest_end = new Date("{{ contest.contest_end.replace(tzinfo=datetime.UTC) }}");
     var contest_length = parseInt((contest_end - contest_start) / 1000);
     var score_color_class_map
         = ["state-0", "state-1", "state-2", "state-3", "state-4", "state-5", "state-6", "state-7", "state-8", "state-9", "state-10"];

--- a/src/static/templ/info.html
+++ b/src/static/templ/info.html
@@ -1,3 +1,4 @@
+{% import config %}
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
 
 <style>
@@ -81,7 +82,7 @@
           </a>
         </td>
         <td>
-          <font size=4>{{ bulletin['timestamp'].strftime('%Y-%m-%d') }}</font>
+          <font size=4>{{ bulletin['timestamp'].astimezone(config.TIMEZONE).strftime('%Y-%m-%d') }}</font>
         </td>
         <td>
           <font size=4>

--- a/src/static/templ/log.html
+++ b/src/static/templ/log.html
@@ -1,6 +1,5 @@
 {% import config %}
 {% import json %}
-<!-- TODO: log type -->
 
 <label for="" class="form-control">ID</label>
 <p>{{ log['log_id'] }}</p>

--- a/src/static/templ/log.html
+++ b/src/static/templ/log.html
@@ -1,10 +1,15 @@
+{% import config %}
 {% import json %}
+<!-- TODO: log type -->
 
 <label for="" class="form-control">ID</label>
 <p>{{ log['log_id'] }}</p>
 
+<label for="" class="form-control">Log Type</label>
+<p>{{ log['log_type'] }}</p>
+
 <label for="" class="form-control">Timestamp</label>
-<p>{{ log['timestamp'] }}</p>
+<p>{{ log['timestamp'].astimezone(config.TIMEZONE) }}</p>
 
 <label for="" class="form-control">Message</label>
 <p>{{ log['message'] }}</p>

--- a/src/static/templ/loglist.html
+++ b/src/static/templ/loglist.html
@@ -1,4 +1,4 @@
-{% import math %}
+{% import config %}
 
 <script type="text/javascript">
     var j_form = $("#form");
@@ -38,7 +38,7 @@
                 <tr>
                     <td class="id"><a href="/oj/log/{{ log['log_id'] }}/">{{ log['log_id'] }}</a></td>
                     <td>{{ log['message'] }}</td>
-                    <td>{{ log['timestamp'] }}</td>
+                    <td>{{ log['timestamp'].astimezone(config.TIMEZONE) }}</td>
                 </tr>
             {% end %}
             </tbody>

--- a/src/static/templ/manage/board/update.html
+++ b/src/static/templ/manage/board/update.html
@@ -112,6 +112,7 @@
 </script>
 {% end %}
 {% block content %}
+{% import config %}
 {% from services.board import BoardConst %}
 {% from utils.numeric import merge_list_to_str %}
 
@@ -132,7 +133,7 @@
         <div class="mb-1">
             <label for="#datepickerStartInput" class="form-label">Start Time</label>
             <div id="datepickerStart" class="input-group">
-                <input id="datepickerStartInput" type="text" class="form-control" value="{{ board['start'].strftime('%Y/%m/%d %H:%M') }}">
+                <input id="datepickerStartInput" type="text" class="form-control" value="{{ board['start'].astimezone(config.TIMEZONE).strftime('%Y/%m/%d %H:%M') }}">
                 <span class="input-group-text" data-td-target="#datepickerStart" data-td-toggle="datepickerStart">
                     <svg class="svg-inline--fa fa-calendar" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="calendar" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M96 32V64H48C21.5 64 0 85.5 0 112v48H448V112c0-26.5-21.5-48-48-48H352V32c0-17.7-14.3-32-32-32s-32 14.3-32 32V64H160V32c0-17.7-14.3-32-32-32S96 14.3 96 32zM448 192H0V464c0 26.5 21.5 48 48 48H400c26.5 0 48-21.5 48-48V192z"></path></svg><!-- <span class="fa-solid fa-calendar"></span> Font Awesome fontawesome.com -->
                 </span>
@@ -140,7 +141,7 @@
 
             <label for="#datepickerEnd" class="form-label">End Time</label>
             <div id="datepickerEnd" class="input-group">
-                <input id="datepickerEndInput" type="text" class="form-control" value="{{ board['end'].strftime('%Y/%m/%d %H:%M') }}">
+                <input id="datepickerEndInput" type="text" class="form-control" value="{{ board['end'].astimezone(config.TIMEZONE).strftime('%Y/%m/%d %H:%M') }}">
                 <span class="input-group-text" data-td-target="#datepickerEnd" data-td-toggle="datepickerEnd">
                     <svg class="svg-inline--fa fa-calendar" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="calendar" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M96 32V64H48C21.5 64 0 85.5 0 112v48H448V112c0-26.5-21.5-48-48-48H352V32c0-17.7-14.3-32-32-32s-32 14.3-32 32V64H160V32c0-17.7-14.3-32-32-32S96 14.3 96 32zM448 192H0V464c0 26.5 21.5 48 48 48H400c26.5 0 48-21.5 48-48V192z"></path></svg><!-- <span class="fa-solid fa-calendar"></span> Font Awesome fontawesome.com -->
                 </span>

--- a/src/static/templ/manage/bulletin/bulletin-list.html
+++ b/src/static/templ/manage/bulletin/bulletin-list.html
@@ -5,6 +5,7 @@
 </script>
 {% end %}
 {% block content %}
+{% import config %}
 <div class="col-lg-10 ms-lg-2 mt-lg-2">
     <table class="table">
         <thead>
@@ -36,7 +37,7 @@
                 <td><font size=3>
                     <a href="/oj/acct/{{ bulletin['acct_id'] }}/">{{ bulletin['name'] }}</a>
                 </font></td>
-                <td><font size=3>{{ bulletin['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</font></td>
+                <td><font size=3>{{ bulletin['timestamp'].astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S') }}</font></td>
                 <td>
                     <a class="btn btn-secondary" href="/oj/manage/bulletin/update/?bulletinid={{ bulletin['bulletin_id'] }}">&#x2699</a>
                 </td>

--- a/src/static/templ/pro-rank.html
+++ b/src/static/templ/pro-rank.html
@@ -1,3 +1,4 @@
+{% import config %}
 <style type="text/css">
 .rank-gold > td {
   background-color: #cab03b;
@@ -53,7 +54,7 @@
                     <td>{{ chal['rate'] }}</td>
                     <td>{{ chal['time'] }}</td>
                     <td>{{ chal['memory'] }}</td>
-                    <td>{{ chal['timestamp'].strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                    <td>{{ chal['timestamp'].astimezone(config.TIMEZONE).strftime('%Y-%m-%d %H:%M:%S') }}</td>
                     </tr>
                 {% end %}
             </tbody>

--- a/src/static/templ/pro.html
+++ b/src/static/templ/pro.html
@@ -152,7 +152,7 @@
     }
 </script>
 <div class="row">
-    <div id="side" class="col-lg-3 col-12 mt-lg-2">
+    <div id="side" class="col-lg-2 col-12 mt-lg-2">
         <h3>{{ pro.pro_id}} / {{ pro.name }}</h3>
         {% if can_submit and pro.allow_submit %}
             {% if contest and not contest.is_end() %}
@@ -297,7 +297,7 @@
     </div>
 
     <!-- TODO: Remove fixed height -->
-    <div id="cont" class="col-lg-9 col-12" style="height: 904px;">
+    <div id="cont" class="col-lg-10 col-12" style="height: 904px;">
         <strong>Loading...</strong>
     </div>
 </div>

--- a/src/tests/integrated/board.py
+++ b/src/tests/integrated/board.py
@@ -3,6 +3,8 @@ import datetime
 from services.board import BoardService, BoardConst
 from .util import AsyncTest, AccountContext
 
+def to_utc(d:datetime.datetime) -> datetime.datetime:
+    return d.replace(tzinfo=datetime.UTC)
 
 class BoardTest(AsyncTest):
     async def main(self):
@@ -25,16 +27,16 @@ class BoardTest(AsyncTest):
             self.assertEqual(len(boardlist), 1)
             self.assertEqual(boardlist[0]['name'], 'board1')
             self.assertEqual(boardlist[0]['status'], BoardConst.STATUS_ONLINE)
-            self.assertEqual(boardlist[0]['start'], (now - datetime.timedelta(days=7)).replace(tzinfo=datetime.UTC))
-            self.assertEqual(boardlist[0]['end'], (now + datetime.timedelta(days=7)).replace(tzinfo=datetime.UTC))
+            self.assertEqual(boardlist[0]['start'], to_utc(now - datetime.timedelta(days=7)))
+            self.assertEqual(boardlist[0]['end'], to_utc(now + datetime.timedelta(days=7)))
 
             err, board = await BoardService.inst.get_board(1)
             self.assertIsNone(err)
             assert board
             self.assertEqual(board['name'], 'board1')
             self.assertEqual(board['status'], BoardConst.STATUS_ONLINE)
-            self.assertEqual(board['start'], (now - datetime.timedelta(days=7)).replace(tzinfo=datetime.UTC))
-            self.assertEqual(board['end'], (now + datetime.timedelta(days=7)).replace(tzinfo=datetime.UTC))
+            self.assertEqual(board['start'], to_utc(now - datetime.timedelta(days=7)))
+            self.assertEqual(board['end'], to_utc(now + datetime.timedelta(days=7)))
             self.assertEqual(board['pro_list'], [1, 2])
             self.assertEqual(board['acct_list'], [1])
 
@@ -55,8 +57,8 @@ class BoardTest(AsyncTest):
             assert board
             self.assertEqual(board['name'], 'board1')
             self.assertEqual(board['status'], BoardConst.STATUS_HIDDEN)
-            self.assertEqual(board['start'], (now - datetime.timedelta(days=14)).replace(tzinfo=datetime.UTC))
-            self.assertEqual(board['end'], (now - datetime.timedelta(days=7)).replace(tzinfo=datetime.UTC))
+            self.assertEqual(board['start'], to_utc(now - datetime.timedelta(days=14)))
+            self.assertEqual(board['end'], to_utc(now - datetime.timedelta(days=7)))
             self.assertEqual(board['pro_list'], [1, 2])
             self.assertEqual(board['acct_list'], [1])
 

--- a/src/tests/integrated/board.py
+++ b/src/tests/integrated/board.py
@@ -3,7 +3,7 @@ import datetime
 from services.board import BoardService, BoardConst
 from .util import AsyncTest, AccountContext
 
-def to_utc(d:datetime.datetime) -> datetime.datetime:
+def to_utc(d: datetime.datetime) -> datetime.datetime:
     return d.replace(tzinfo=datetime.UTC)
 
 class BoardTest(AsyncTest):

--- a/src/tests/integrated/board.py
+++ b/src/tests/integrated/board.py
@@ -25,16 +25,16 @@ class BoardTest(AsyncTest):
             self.assertEqual(len(boardlist), 1)
             self.assertEqual(boardlist[0]['name'], 'board1')
             self.assertEqual(boardlist[0]['status'], BoardConst.STATUS_ONLINE)
-            # self.assertEqual(boardlist[0]['start'], (now - datetime.timedelta(days=7)).replace(tzinfo=datetime.timezone.utc))
-            # self.assertEqual(boardlist[0]['end'], (now + datetime.timedelta(days=7)).replace(tzinfo=datetime.timezone.utc))
+            self.assertEqual(boardlist[0]['start'], (now - datetime.timedelta(days=7)).replace(tzinfo=datetime.UTC))
+            self.assertEqual(boardlist[0]['end'], (now + datetime.timedelta(days=7)).replace(tzinfo=datetime.UTC))
 
             err, board = await BoardService.inst.get_board(1)
             self.assertIsNone(err)
             assert board
             self.assertEqual(board['name'], 'board1')
             self.assertEqual(board['status'], BoardConst.STATUS_ONLINE)
-            # self.assertEqual(board['start'], (now - datetime.timedelta(days=7)).replace(tzinfo=datetime.timezone.utc))
-            # self.assertEqual(board['end'], (now + datetime.timedelta(days=7)).replace(tzinfo=datetime.timezone.utc))
+            self.assertEqual(board['start'], (now - datetime.timedelta(days=7)).replace(tzinfo=datetime.UTC))
+            self.assertEqual(board['end'], (now + datetime.timedelta(days=7)).replace(tzinfo=datetime.UTC))
             self.assertEqual(board['pro_list'], [1, 2])
             self.assertEqual(board['acct_list'], [1])
 
@@ -55,8 +55,8 @@ class BoardTest(AsyncTest):
             assert board
             self.assertEqual(board['name'], 'board1')
             self.assertEqual(board['status'], BoardConst.STATUS_HIDDEN)
-            # self.assertEqual(board['start'], (now - datetime.timedelta(days=14)).replace(tzinfo=datetime.timezone.utc))
-            # self.assertEqual(board['end'], (now - datetime.timedelta(days=7)).replace(tzinfo=datetime.timezone.utc))
+            self.assertEqual(board['start'], (now - datetime.timedelta(days=14)).replace(tzinfo=datetime.UTC))
+            self.assertEqual(board['end'], (now - datetime.timedelta(days=7)).replace(tzinfo=datetime.UTC))
             self.assertEqual(board['pro_list'], [1, 2])
             self.assertEqual(board['acct_list'], [1])
 

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -9,10 +9,12 @@ from services.pro import ProService, ProConst
 from services.chal import Compiler
 from .util import AsyncTest, AccountContext
 
+def to_utc(d: datetime.datetime) -> datetime.datetime:
+    return d.replace(tzinfo=datetime.UTC)
 
 class ContestTest(AsyncTest):
     async def main(self):
-        # TOOD: add special score test
+        # TODO: add special score test
         self.signup('contest1', 'contest1@test', 'test')  # acct_id = 4
         self.signup('contest2', 'contest2@test', 'test')
         self.signup('contest3', 'contest3@test', 'test')
@@ -83,9 +85,9 @@ class ContestTest(AsyncTest):
             self.assertTrue(contest.hide_admin)
             self.assertEqual(contest.submission_cd_time, 60)
             self.assertEqual(contest.freeze_scoreboard_period, 0)
-            self.assertEqual(contest.contest_start, contest_start.replace(tzinfo=datetime.UTC))
-            self.assertEqual(contest.contest_end, contest_end.replace(tzinfo=datetime.UTC))
-            self.assertEqual(contest.reg_end, reg_end.replace(tzinfo=datetime.UTC))
+            self.assertEqual(contest.contest_start, to_utc(contest_start))
+            self.assertEqual(contest.contest_end, to_utc(contest_end))
+            self.assertEqual(contest.reg_end, to_utc(reg_end))
 
             # test desc
             res = admin_session.post('contests/1/manage/desc', data={
@@ -308,7 +310,7 @@ class ContestTest(AsyncTest):
             self.assertAPIReturnSuccess(res.text)
             err, contest = await ContestService.inst.get_contest(1)
             self.assertIsNone(err)
-            self.assertEqual(contest.contest_start, contest_start.replace(tzinfo=datetime.UTC))
+            self.assertEqual(contest.contest_start, to_utc(contest_start))
             self.assertTrue(contest.is_start())
 
         with AccountContext('contest1@test', 'test') as user_session:
@@ -619,7 +621,7 @@ class ContestTest(AsyncTest):
             self.assertAPIReturnSuccess(res.text)
             err, contest = await ContestService.inst.get_contest(1)
             self.assertIsNone(err)
-            self.assertEqual(contest.contest_end, contest_end.replace(tzinfo=datetime.UTC))
+            self.assertEqual(contest.contest_end, to_utc(contest_end))
             self.assertTrue(contest.is_end())
 
             res = admin_session.post('contests/1/manage/pro', data={

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -26,6 +26,18 @@ class ContestTest(AsyncTest):
 
             res = admin_session.post('contests/manage/add', data={
                 'reqtype': 'add',
+                'name': ''
+            })
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Name too short'))
+
+            res = admin_session.post('contests/manage/add', data={
+                'reqtype': 'add',
+                'name': 'name' * 1000
+            })
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Name too long'))
+
+            res = admin_session.post('contests/manage/add', data={
+                'reqtype': 'add',
                 'name': 'contest 1'
             })
             self.assertEqual(json.loads(res.text)['data'], 1)
@@ -60,8 +72,8 @@ class ContestTest(AsyncTest):
             res = admin_session.post('contests/1/manage/general', data=default_config)
             self.assertAPIReturnSuccess(res.text)
 
-            # TODO: start, end reg_end assertEqual, ref board.py
             err, contest = await ContestService.inst.get_contest(1)
+            assert contest
             self.assertIsNone(err)
             self.assertEqual(contest.contest_mode, ContestMode.IOI)
             self.assertEqual(contest.reg_mode, RegMode.INVITED)
@@ -71,6 +83,9 @@ class ContestTest(AsyncTest):
             self.assertTrue(contest.hide_admin)
             self.assertEqual(contest.submission_cd_time, 60)
             self.assertEqual(contest.freeze_scoreboard_period, 0)
+            self.assertEqual(contest.contest_start, contest_start.replace(tzinfo=datetime.UTC))
+            self.assertEqual(contest.contest_end, contest_end.replace(tzinfo=datetime.UTC))
+            self.assertEqual(contest.reg_end, reg_end.replace(tzinfo=datetime.UTC))
 
             # test desc
             res = admin_session.post('contests/1/manage/desc', data={
@@ -291,7 +306,10 @@ class ContestTest(AsyncTest):
             config['contest_start'] = self.get_isoformat(contest_start)
             res = admin_session.post('contests/1/manage/general', data=config)
             self.assertAPIReturnSuccess(res.text)
-            # TODO: assert contest started
+            err, contest = await ContestService.inst.get_contest(1)
+            self.assertIsNone(err)
+            self.assertEqual(contest.contest_start, contest_start.replace(tzinfo=datetime.UTC))
+            self.assertTrue(contest.is_start())
 
         with AccountContext('contest1@test', 'test') as user_session:
             res = user_session.get('contests/1/pro/5/cont.pdf')
@@ -599,7 +617,10 @@ class ContestTest(AsyncTest):
             config['contest_end'] = self.get_isoformat(contest_end)
             res = admin_session.post('contests/1/manage/general', data=config)
             self.assertAPIReturnSuccess(res.text)
-            # TODO: assert contest ended
+            err, contest = await ContestService.inst.get_contest(1)
+            self.assertIsNone(err)
+            self.assertEqual(contest.contest_end, contest_end.replace(tzinfo=datetime.UTC))
+            self.assertTrue(contest.is_end())
 
             res = admin_session.post('contests/1/manage/pro', data={
                 'reqtype': 'public',

--- a/src/tests/unit/services/test_board.py
+++ b/src/tests/unit/services/test_board.py
@@ -42,12 +42,13 @@ class TestBoardService(unittest.IsolatedAsyncioTestCase):
         err, meta = await self.service.get_board(1)
         self.fake_conn.fetchrow.assert_awaited_once()
         self.assertIsNone(err)
+        self.assertIsNotNone(meta)
         self.assertEqual(meta["name"], "BoardA")
         self.assertEqual(meta["status"], BoardConst.STATUS_ONLINE)
         self.assertEqual(meta["pro_list"], [1, 2])
         self.assertEqual(meta["acct_list"], [3, 4])
-        self.assertEqual(meta["start"].tzinfo.utcoffset(meta["start"]), datetime.timedelta(hours=8))
-        self.assertEqual(meta["end"].tzinfo.utcoffset(meta["end"]), datetime.timedelta(hours=8))
+        self.assertEqual(meta["start"], start)
+        self.assertEqual(meta["end"], end)
 
     async def test_get_board_not_found(self):
         self.fake_conn.fetchrow.return_value = None

--- a/src/tests/unit/services/test_bulletin.py
+++ b/src/tests/unit/services/test_bulletin.py
@@ -17,7 +17,6 @@ class TestBulletinService(unittest.IsolatedAsyncioTestCase):
         self.service = BulletinService(self.fake_db, rs=None)
 
     async def test_list_bulletin(self):
-        tz = datetime.timezone(datetime.timedelta(hours=8))
         self.fake_conn.fetch.return_value = [
             (1, "Title1", datetime.datetime(2024, 1, 1, 10, 0), "Red", True, "Alice", 101),
             (2, "Title2", datetime.datetime(2024, 1, 2, 11, 0), "Blue", False, "Bob", 102),
@@ -28,10 +27,8 @@ class TestBulletinService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(res), 2)
         self.assertEqual(res[0]["bulletin_id"], 1)
         self.assertEqual(res[1]["title"], "Title2")
-        self.assertEqual(res[0]["timestamp"].tzinfo.utcoffset(res[0]["timestamp"]), tz.utcoffset(res[0]["timestamp"]))
 
     async def test_get_bulletin_found(self):
-        tz = datetime.timezone(datetime.timedelta(hours=8))
         dt = datetime.datetime(2024, 1, 1, 12, 0)
         self.fake_conn.fetch.return_value = [{
             "title": "TitleA",
@@ -51,7 +48,6 @@ class TestBulletinService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(meta["color"], "Green")
         self.assertTrue(meta["pinned"])
         self.assertEqual(meta["acct_id"], 101)
-        self.assertEqual(meta["timestamp"].tzinfo.utcoffset(meta["timestamp"]), tz.utcoffset(meta["timestamp"]))
 
     async def test_get_bulletin_not_found(self):
         self.fake_conn.fetch.return_value = []

--- a/src/tests/unit/services/test_log.py
+++ b/src/tests/unit/services/test_log.py
@@ -2,7 +2,7 @@ import unittest
 import datetime
 import json
 from unittest.mock import AsyncMock, MagicMock
-from services.log import LogService, tz, _Encoder
+from services.log import LogService, _Encoder
 
 
 class TestLogService(unittest.IsolatedAsyncioTestCase):
@@ -62,9 +62,7 @@ class TestLogService(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(err)
         self.assertEqual(log["log_id"], 789)
         self.assertEqual(log["message"], "Log message")
-        self.assertEqual(
-            log["timestamp"], timestamp.astimezone(tz).isoformat(timespec="seconds")
-        )
+        self.assertEqual(log["timestamp"], timestamp)
         self.assertEqual(json.loads(log["params"])["key"], "value")
 
     async def test_view_log_not_found(self):
@@ -128,7 +126,7 @@ class TestLogService(unittest.IsolatedAsyncioTestCase):
     def test_encoder_datetime(self):
         dt = datetime.datetime(2024, 6, 1, 12, 0, tzinfo=datetime.timezone.utc)
         encoded = json.dumps({"dt": dt}, cls=_Encoder)
-        self.assertIn("+08:00", encoded)
+        self.assertIn("+00:00", encoded)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We introduce a new config option named TIMEZONE, which specifies the timezone to convert to when rendering pages. Administrators must manually add this option to the configuration file before running the backend; otherwise the backend will not work.
Use UTC+0 for internal time computations and storage. Only convert timestamps to config.TIMEZONE when rendering/displaying to users. This reduces timezone-related bugs and inconsistencies.
