### PR TITLE
fix: remove e2e sentences

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ ARG BASE_URL
 
 RUN UNLOCK_PASSWORD_PROCESSED=$(echo "${UNLOCK_PASSWORD}" | python3 scripts/get_unlock_pwd.py) \
 && COOKIE_SEC=$(python3 -c "import sys; print(open('/dev/urandom','rb').read(32).hex())") \
-&& rm -rf tests && rm rune2etest.py rune2etest.sh \
+&& rm -rf tests \
 && rm runintegratedtest.sh runintegratedtest.py \
 && rm rununittest.sh rununittest.py upgrade.py \
 && mv /ntoj/static /ntoj/static-tmp \

--- a/src/runintegratedtest.sh
+++ b/src/runintegratedtest.sh
@@ -88,13 +88,11 @@ omit =
     *.generated.py
     runintegratedtest.py
     rununittest.py
-    rune2etest.py
     tests/*
     server.py
     upgrade.py
     config_dev.py
 EOF
-
 
 # run migration
 if [ -f docker-dev ]; then

--- a/src/rununittest.sh
+++ b/src/rununittest.sh
@@ -14,7 +14,6 @@ omit =
     *.generated.py
     runintegratedtest.py
     rununittest.py
-    rune2etest.py
     tests/*
     server.py
     upgrade.py

--- a/src/static/templ/chal.html
+++ b/src/static/templ/chal.html
@@ -11,8 +11,6 @@
 }
 </style>
 
-<!-- TODO: Testdata Result Message e2etest -->
-
 <script type="text/javascript">
     var ws;
     var state_map = {


### PR DESCRIPTION
## Description
Because rune2etest.py & rune2etest.sh have been removed, building the docker container of release version will fail.
So I removed everything related to `e2e`.