### PR TITLE
Add Admin Feature to Restrict Account Login by Specific IP

### DIFF
--- a/migration/20251210153000_add_acct_specific_ip.py
+++ b/migration/20251210153000_add_acct_specific_ip.py
@@ -1,0 +1,5 @@
+import json
+
+async def dochange(db, rs):
+    # Add specific_ip column to account table
+    await db.execute('ALTER TABLE public.account ADD COLUMN specific_ip character varying(64) DEFAULT \'\';')

--- a/src/handlers/acct.py
+++ b/src/handlers/acct.py
@@ -353,7 +353,7 @@ class SignHandler(RequestHandler):
         mail = self.get_argument("mail")
         pw = self.get_argument("pw")
 
-        err, acct_id = await UserService.inst.sign_in(mail, pw)
+        err, acct_id = await UserService.inst.sign_in(mail, pw, self.request.remote_ip)
         if err:
             await LogService.inst.add_log(
                 f"{mail} try to sign in but failed: {err}",

--- a/src/handlers/manage/acct.py
+++ b/src/handlers/manage/acct.py
@@ -2,6 +2,8 @@ from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_perm
 from services.log import LogService
 from services.user import UserConst, UserService
 
+from ipaddress import IPv4Address
+
 
 acct_dispatcher = ActionDispatcher()
 
@@ -56,6 +58,12 @@ class ManageAcctHandler(RequestHandler):
             f"{self.acct.name}(#{self.acct.acct_id}) had been send a request to update the account {acct.name}(#{acct.acct_id})",
             "manage.acct.update",
         )
+
+        # Check IP validity
+        try:
+            IPv4Address(acct_specific_ip)
+        except Exception:
+            return self.error(("Einval", "The specific IP address is invalid"))
 
         acct.acct_type = acct_type
         acct.specific_ip = acct_specific_ip

--- a/src/handlers/manage/acct.py
+++ b/src/handlers/manage/acct.py
@@ -62,7 +62,7 @@ class ManageAcctHandler(RequestHandler):
         # Check IP validity
         try:
             IPv4Address(acct_specific_ip)
-        except Exception:
+        except ipaddress.AddressValueError:
             return self.error(("Einval", "The specific IP address is invalid"))
 
         acct.acct_type = acct_type

--- a/src/handlers/manage/acct.py
+++ b/src/handlers/manage/acct.py
@@ -42,6 +42,7 @@ class ManageAcctHandler(RequestHandler):
     async def update_acct(self):
         acct_id = int(self.get_argument("acct_id"))
         acct_type = int(self.get_argument("acct_type"))
+        acct_specific_ip = self.get_argument('specific_ip', default='').strip()
         err, acct = await UserService.inst.info_acct(acct_id)
 
         if err:
@@ -57,6 +58,7 @@ class ManageAcctHandler(RequestHandler):
         )
 
         acct.acct_type = acct_type
+        acct.specific_ip = acct_specific_ip
         err, _ = await UserService.inst.update_acct(acct)
         if err:
             return self.error(err)

--- a/src/services/user.py
+++ b/src/services/user.py
@@ -41,6 +41,7 @@ class Account:
     lastip: str
     last_compiler: Compiler
     proclass_collection: list[int]
+    specific_ip: str
 
     def is_kernel(self):
         return self.acct_type == UserConst.ACCTTYPE_KERNEL
@@ -50,7 +51,7 @@ class Account:
 
 
 GUEST_ACCOUNT = Account(
-    acct_id=0, acct_type=UserConst.ACCTTYPE_GUEST, name='', mail='', photo='', cover='', lastip='', last_compiler=Compiler.GPP, motto='', proclass_collection=[]
+    acct_id=0, acct_type=UserConst.ACCTTYPE_GUEST, name='', mail='', photo='', cover='', lastip='', last_compiler=Compiler.GPP, motto='', proclass_collection=[], specific_ip=''
 )
 
 
@@ -239,6 +240,7 @@ class UserService:
                 last_compiler=result['last_compiler'],
                 lastip=result['lastip'],
                 proclass_collection=result['proclass_collection'],
+                specific_ip='',
             )
             b_acct = pickle.dumps(acct)
 
@@ -356,6 +358,7 @@ class UserService:
                     last_compiler='',
                     lastip=lastip,
                     proclass_collection=[],
+                    specific_ip='',
                 )
 
                 if private:

--- a/src/services/user.py
+++ b/src/services/user.py
@@ -74,11 +74,11 @@ class UserService:
         self.rs = rs
         UserService.inst = self
 
-    async def sign_in(self, mail, pw):
+    async def sign_in(self, mail, pw, ip = ''):
         async with self.db.acquire() as con:
             result = await con.fetch(
                 '''
-                    SELECT "acct_id","password" FROM "account"
+                    SELECT "acct_id","password","specific_ip" FROM "account"
                     WHERE "mail" = $1;
                 ''',
                 mail,
@@ -88,6 +88,10 @@ class UserService:
 
         acct_id = result[0]['acct_id']
         hpw = result[0]['password']
+        specific_ip = result[0]['specific_ip']
+
+        if specific_ip and ip and specific_ip != ip:
+            return ('Esignip', 'Login failed'), None
 
         hpw = base64.b64decode(hpw.encode('utf-8'))
         if bcrypt.hashpw(pw.encode('utf-8'), hpw) == hpw:

--- a/src/services/user.py
+++ b/src/services/user.py
@@ -219,7 +219,7 @@ class UserService:
             async with self.db.acquire() as con:
                 result = await con.fetch(
                     '''
-                        SELECT "name", "acct_type", "mail", "photo", "cover", "lastip", "last_compiler", "motto", "proclass_collection"
+                        SELECT "name", "acct_type", "mail", "photo", "cover", "lastip", "last_compiler", "motto", "proclass_collection", "specific_ip"
                         FROM "account" WHERE "acct_id" = $1;
                     ''',
                     acct_id,
@@ -240,7 +240,7 @@ class UserService:
                 last_compiler=result['last_compiler'],
                 lastip=result['lastip'],
                 proclass_collection=result['proclass_collection'],
-                specific_ip='',
+                specific_ip=result['specific_ip'] if result['specific_ip'] else '',
             )
             b_acct = pickle.dumps(acct)
 
@@ -272,7 +272,8 @@ class UserService:
                         "acct_type" = $1, "name" = $2,
                         "photo" = $3, "cover" = $4,
                         "last_compiler" = $5,
-                        "motto" = $6, "proclass_collection" = $7
+                        "motto" = $6, "proclass_collection" = $7,
+                        "specific_ip" = $9
                     WHERE
                         "acct_id" = $8 RETURNING "acct_id";
                 ''',
@@ -284,6 +285,7 @@ class UserService:
                 acct.motto,
                 acct.proclass_collection,
                 acct.acct_id,
+                acct.specific_ip,
             )
             if len(result) != 1:
                 return ('Enoext', 'Account not found'), None
@@ -338,7 +340,7 @@ class UserService:
             async with self.db.acquire() as con:
                 result = await con.fetch(
                     '''
-                        SELECT "acct_id", "acct_type", "name", "mail", "lastip"
+                        SELECT "acct_id", "acct_type", "name", "mail", "lastip", "specific_ip"
                         FROM "account" WHERE "acct_type" >= $1
                         ORDER BY "acct_id" ASC;
                     ''',
@@ -346,7 +348,7 @@ class UserService:
                 )
 
             acctlist = []
-            for acct_id, acct_type, name, mail, lastip in result:
+            for acct_id, acct_type, name, mail, lastip, specific_ip in result:
                 acct = Account(
                     acct_id=acct_id,
                     acct_type=acct_type,
@@ -358,7 +360,7 @@ class UserService:
                     last_compiler='',
                     lastip=lastip,
                     proclass_collection=[],
-                    specific_ip='',
+                    specific_ip=specific_ip if specific_ip else '',
                 )
 
                 if private:

--- a/src/static/templ/manage/acct/acct-list.html
+++ b/src/static/templ/manage/acct/acct-list.html
@@ -15,6 +15,7 @@
                 <th>Name</th>
                 <th>Mail</th>
                 <th>Last IP</th>
+                <th>Specific IP</th>
                 <th>Level</th>
                 <th></th>
             </tr>
@@ -26,6 +27,7 @@
                 <td><a href="{{ url(f'/acct/{ acct.acct_id }/') }}">{{ acct.name }}</a></td>
                 <td>{{ acct.mail }}</td>
                 <td>{{ acct.lastip }}</td>
+                <td>{{ acct.specific_ip}}</td>
                 <td>
                     {% if acct.is_kernel() %}
                         Kernel

--- a/src/static/templ/manage/acct/update.html
+++ b/src/static/templ/manage/acct/update.html
@@ -5,14 +5,22 @@
 <script type="text/javascript" id="contjs">
     function init() {
 		var j_form = $('#form');
+        const ip_re = /^(((?!25?[6-9])[12]\d|[1-9])?\d\.?\b){4}$/;
 
 		j_form.find('button.submit').on('click', function(e) {
             var type = j_form.find('#type').val();
+            const ip = j_form.find('#ip').val().trim();
+
+            if(ip.length > 0 && !ip_re.test(ip)) {
+                index.show_notify_dialog('Specific IP format error, please input correct IP address.', index.DIALOG_TYPE.error);
+                return;
+            }
 
             $.post(`{{ url('/be/manage/acct/update') }}`, {
                 'reqtype': 'update',
                 'acct_id': {{ acct.acct_id }},
                 'acct_type': type,
+                'specific_ip': ip,
             }, function(res) {
                 res = JSON.parse(res);
                 if (res.status == 'S') {
@@ -41,6 +49,11 @@
                 <option value="{{ UserConst.ACCTTYPE_KERNEL }}" {% if acct.is_kernel() %} selected {% end %}>Kernel</option>
 				<option value="{{ UserConst.ACCTTYPE_USER }}" {% if not acct.is_kernel() %} selected {% end %}>User</option>
 			</select>
+		</div>
+
+		<div class="mb-3">
+			<label>Specific IP</label>
+            <input class="form-control" id="ip" type="text">
 		</div>
 
 		<button type="button" class="btn btn-primary submit">Update</button>

--- a/src/static/templ/manage/acct/update.html
+++ b/src/static/templ/manage/acct/update.html
@@ -53,7 +53,7 @@
 
 		<div class="mb-3">
 			<label>Specific IP</label>
-            <input class="form-control" id="ip" type="text">
+            <input class="form-control" id="ip" type="text" value="{{ acct.specific_ip }}">
 		</div>
 
 		<button type="button" class="btn btn-primary submit">Update</button>

--- a/src/tests/unit/services/test_user.py
+++ b/src/tests/unit/services/test_user.py
@@ -118,6 +118,7 @@ class TestUserService(unittest.IsolatedAsyncioTestCase):
             lastip="",
             last_compiler=Compiler.GCC,
             proclass_collection=[],
+            specific_ip="",
         )
         self.fake_rs.get.return_value = MagicMock()
         with patch("pickle.loads", return_value=dummy_acct):
@@ -198,6 +199,7 @@ class TestUserService(unittest.IsolatedAsyncioTestCase):
             lastip="",
             last_compiler=Compiler.GCC,
             proclass_collection=[],
+            specific_ip="",
         )
         self.fake_conn.fetch.return_value = [{"acct_id": 1}]
         self.fake_rs.delete.return_value = None
@@ -219,6 +221,7 @@ class TestUserService(unittest.IsolatedAsyncioTestCase):
             lastip="",
             last_compiler=Compiler.GCC,
             proclass_collection=[],
+            specific_ip="",
         )
         err, _ = await self.service.update_acct(acct)
         self.assertEqual(err[0], "Eparam")
@@ -235,6 +238,7 @@ class TestUserService(unittest.IsolatedAsyncioTestCase):
             lastip="",
             last_compiler=Compiler.GCC,
             proclass_collection=[],
+            specific_ip="",
         )
         err, _ = await self.service.update_acct(acct)
         self.assertEqual(err[0], "Enamemin")
@@ -251,6 +255,7 @@ class TestUserService(unittest.IsolatedAsyncioTestCase):
             lastip="",
             last_compiler=Compiler.GCC,
             proclass_collection=[],
+            specific_ip="",
         )
         err, _ = await self.service.update_acct(acct)
         self.assertEqual(err[0], "Emottomax")
@@ -283,6 +288,7 @@ class TestUserService(unittest.IsolatedAsyncioTestCase):
                 lastip="127.0.0.1",
                 last_compiler=Compiler.GCC,
                 proclass_collection=[],
+                specific_ip="",
             )
         ]
         self.fake_rs.hget.return_value = MagicMock()


### PR DESCRIPTION
## Description
This PR introduces a new feature allowing administrators to restrict user account logins to a specific IP address.

**Added:**
- Database migration: Adds a specific_ip column to the account table.
- Backend: Updates Account model and UserService to handle specific_ip. During sign-in, if specific_ip is set, login is only allowed from that IP.
- Admin panel: Allows admins to set or update specific_ip for each account.
- Frontend: Displays specific_ip in account list and update forms, with input validation for IPv4 format.
- Tests: Updates unit tests to cover specific_ip logic.

## How it was tested
0. I set up the server in my VM(ubuntu 24.04). The host is Windows 11. Then, I add two account for testing.
1. Check both accounts can successfully login from VM & host.
2. I restrict both account to login from different ip. Check the accounts can only login from the specific ip.
3. Clear the specific ip setting. Check the result is same as step 1.