### PR TITLE
refactor: Unify WebSocket endpoints into single handler

### DIFF
--- a/src/handlers/acct.py
+++ b/src/handlers/acct.py
@@ -182,7 +182,7 @@ class AcctConfigHandler(RequestHandler):
 
         # publish all session keys to logout channel so websocket connections close
         for session_key in await self.rs.hgetall(f"account_session@{target_acct_id}"):
-            await self.rs.publish(UnifiedWebSocketHandler._LOGOUT_EVENT_CHANNEL, session_key)
+            await self.rs.publish(UnifiedWebSocketHandler._LOGOUT_EVENT_CHANNEL, session_key.decode())
         await self.rs.delete(f"account_session@{target_acct_id}")
         self.clear_cookie("id")
         return self.error(("S", ""))

--- a/src/handlers/acct.py
+++ b/src/handlers/acct.py
@@ -6,7 +6,7 @@ import hashlib
 from msgpack import packb, unpackb
 
 import config
-from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_permission
+from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_permission, UnifiedWebSocketHandler
 from services.log import LogService
 from services.pro import ProService, ProClassService, ProClassConst, ProConst
 from services.rate import RateService
@@ -164,6 +164,8 @@ class AcctConfigHandler(RequestHandler):
             if hashlib.md5(session_key).hexdigest() == hashed_session_key:
                 found = True
                 await self.rs.hdel(f"account_session@{target_acct_id}", session_key)
+                # notify websocket handlers to close connections matching this session
+                await self.rs.publish(UnifiedWebSocketHandler._LOGOUT_EVENT_CHANNEL, session_key)
                 break
 
         if found:
@@ -178,6 +180,9 @@ class AcctConfigHandler(RequestHandler):
         if target_acct_id != str(self.acct.acct_id):
             return self.error(PERMISSION_DENIED_ERROR)
 
+        # publish all session keys to logout channel so websocket connections close
+        for session_key in await self.rs.hgetall(f"account_session@{target_acct_id}"):
+            await self.rs.publish(UnifiedWebSocketHandler._LOGOUT_EVENT_CHANNEL, session_key)
         await self.rs.delete(f"account_session@{target_acct_id}")
         self.clear_cookie("id")
         return self.error(("S", ""))
@@ -432,5 +437,6 @@ class SignHandler(RequestHandler):
 
         if (session_key := self.get_cookie("id")) is not None:
             await self.rs.hdel(f"account_session@{self.acct.acct_id}", session_key)
+            await self.rs.publish(UnifiedWebSocketHandler._LOGOUT_EVENT_CHANNEL, session_key)
         self.clear_cookie("id", path=base_url)
         self.error(("S", ""))

--- a/src/handlers/base.py
+++ b/src/handlers/base.py
@@ -169,9 +169,14 @@ class UnifiedWebSocketHandler(tornado.websocket.WebSocketHandler):
     # Subscription tracking: connection -> set of subscribed types
     subscriptions: dict = {}
 
+    # Locks to protect subscription and connection collections
+    _subscriptions_lock = asyncio.Lock()
+    _connections_lock = asyncio.Lock()
+
     # Message type callbacks: channel -> callback class instance
     # Callback class should have: register(), message(data), unregister() methods
     _channel_callbacks: dict = {}
+    _channel_callbacks_lock = asyncio.Lock()
 
     def __init__(self, *args, **kwargs):
         self.db: asyncpg.Pool = kwargs.pop("db")
@@ -200,10 +205,12 @@ class UnifiedWebSocketHandler(tornado.websocket.WebSocketHandler):
                 rs = aioredis.Redis(connection_pool=cls._redis_pool)
                 cls._shared_pubsub = rs.pubsub()
 
-                # Subscribe to all registered channels
-                if cls._channel_callbacks:
-                    await cls._shared_pubsub.subscribe(*cls._channel_callbacks.keys())
-                    await cls._shared_pubsub.subscribe(cls._LOGOUT_EVENT_CHANNEL)
+                # Subscribe to all registered channels using a snapshot
+                async with cls._channel_callbacks_lock:
+                    channels = list(cls._channel_callbacks.keys())
+                if channels:
+                    await cls._shared_pubsub.subscribe(*channels)
+                await cls._shared_pubsub.subscribe(cls._LOGOUT_EVENT_CHANNEL)
 
                 # Start listener task
                 cls._pubsub_task = asyncio.create_task(cls._listen_redis_messages())
@@ -213,8 +220,11 @@ class UnifiedWebSocketHandler(tornado.websocket.WebSocketHandler):
     @classmethod
     async def _resubscribe_all_channels(cls):
         """Resubscribe to all registered channels after reconnection"""
-        if cls._shared_pubsub and cls._channel_callbacks:
-            await cls._shared_pubsub.subscribe(*cls._channel_callbacks.keys())
+        if cls._shared_pubsub:
+            async with cls._channel_callbacks_lock:
+                channels = list(cls._channel_callbacks.keys())
+            if channels:
+                await cls._shared_pubsub.subscribe(*channels)
             # Ensure logout channel is subscribed too
             await cls._shared_pubsub.subscribe(cls._LOGOUT_EVENT_CHANNEL)
 
@@ -251,7 +261,53 @@ class UnifiedWebSocketHandler(tornado.websocket.WebSocketHandler):
 
             UnifiedWebSocketHandler.register_channel_callback("my_channel", MyChannelCallback())
         """
-        cls._channel_callbacks[channel] = callback_class
+        # Register synchronously (typically called at import time). However, if the
+        # shared pubsub is already running, schedule a background coroutine to
+        # subscribe this channel in the shared pubsub. We still protect the
+        # callback dict with a lock for safety when concurrent modifications may
+        # occur (rare at runtime).
+        # Helper: async registration method (safe for runtime registration)
+        async def _register_async():
+            async with cls._channel_callbacks_lock:
+                cls._channel_callbacks[channel] = callback_class
+            if cls._shared_pubsub is not None:
+                # shared pubsub exists and is likely subscribed; subscribe new channel
+                await cls._shared_pubsub.subscribe(channel)
+        # Perform sync registration first (fast and works during import)
+        # and rely on async task to perform subscribe when loop is available
+        async def _sync_register():
+            async with cls._channel_callbacks_lock:
+                cls._channel_callbacks[channel] = callback_class
+
+        loop = None
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # No loop available; just set value without lock (import time)
+            cls._channel_callbacks[channel] = callback_class
+            return
+
+        if loop.is_running():
+            # schedule asynchronous subscription/register to avoid blocking
+            asyncio.create_task(_register_async())
+        else:
+            # not running: we can create loop and run now
+            loop.run_until_complete(_register_async())
+        # Now schedule asynchronous subscribe task if loop is running
+        # Done: registration scheduling performed above
+
+    @classmethod
+    async def register_channel_callback_async(cls, channel: str, callback_class):
+        """Async-friendly registration API: sets callback and subscribes
+
+        This can be awaited at runtime to ensure subscribe happens before
+        continuing. Works both when `UnifiedWebSocketHandler` _shared_pubsub
+        is not initialized yet or is already active.
+        """
+        async with cls._channel_callbacks_lock:
+            cls._channel_callbacks[channel] = callback_class
+        if cls._shared_pubsub is not None:
+            await cls._shared_pubsub.subscribe(channel)
 
     @classmethod
     async def _listen_redis_messages(cls):
@@ -291,8 +347,12 @@ class UnifiedWebSocketHandler(tornado.websocket.WebSocketHandler):
                         session_key = data
                         close_failed = []
                         # Build set of candidate connections: subscriptions + active
-                        candidates = set(list(cls.subscriptions.keys()))
-                        candidates.update(cls.active_connections)
+                        async with cls._subscriptions_lock:
+                            subs_keys = list(cls.subscriptions.keys())
+                        async with cls._connections_lock:
+                            active_keys = list(cls.active_connections)
+                        candidates = set(subs_keys)
+                        candidates.update(active_keys)
 
                         for conn in list(candidates):
                             try:
@@ -314,27 +374,35 @@ class UnifiedWebSocketHandler(tornado.websocket.WebSocketHandler):
                         continue
 
                     failed_conns = []
-                    for conn, types in list(cls.subscriptions.items()):
-                        if channel in types:
-                            try:
-                                if channel in cls._channel_callbacks:
-                                    callback = cls._channel_callbacks[channel]
-                                    formatted_data = await callback.message(conn, data)
-                                    if formatted_data is None:
-                                        continue  # Callback decided to skip this connection
+                    # Take a snapshot of current subscriptions to avoid races
+                    async with cls._subscriptions_lock:
+                        snapshot = list(cls.subscriptions.items())
+                    for conn, types in snapshot:
+                        if not types:
+                            continue
+                        if channel not in types:
+                            continue
 
-                                    await conn.write_message(
-                                        json.dumps(
-                                            {"type": channel, "data": formatted_data}
-                                        )
-                                    )
-                                else:
-                                    # No callback, send raw data
-                                    await conn.write_message(
-                                        json.dumps({"type": channel, "data": data})
-                                    )
-                            except Exception as e:
-                                failed_conns.append(conn)
+                        try:
+                            # obtain callback instance under lock to avoid race
+                            async with cls._channel_callbacks_lock:
+                                callback = cls._channel_callbacks.get(channel)
+                            if callback is None:
+                                # no callback found, send raw data
+                                await conn.write_message(
+                                    json.dumps({"type": channel, "data": data})
+                                )
+                                continue
+
+                            formatted_data = await callback.message(conn, data)
+                            if formatted_data is None:
+                                continue  # Callback decided to skip this connection
+
+                            await conn.write_message(
+                                json.dumps({"type": channel, "data": formatted_data})
+                            )
+                        except Exception as e:
+                            failed_conns.append(conn)
 
                     for conn in failed_conns:
                         try:
@@ -347,14 +415,15 @@ class UnifiedWebSocketHandler(tornado.websocket.WebSocketHandler):
 
                 # Exponential backoff
                 await asyncio.sleep(retry_delay)
-                retry_delay = min(retry_delay * 2, self._MAX_RETRY_DELAY)
+                retry_delay = min(retry_delay * 2, cls._MAX_RETRY_DELAY)
 
     async def open(self):
         """Called when WebSocket connection is opened"""
         # Ensure shared pubsub is initialized
         await self.get_shared_pubsub()
 
-        self.acct_id = self.get_secure_cookie("id")
+        acct_id_cookie = self.get_secure_cookie("id")
+        self.acct_id = int(acct_id_cookie) if acct_id_cookie is not None else 0
         self.session_id = self.get_cookie("id")
 
         self.start_ping()
@@ -410,29 +479,40 @@ class UnifiedWebSocketHandler(tornado.websocket.WebSocketHandler):
                 self.last_pong = tornado.ioloop.IOLoop.current().time()
                 return
 
+
             elif msg_type == "register":
                 channel = msg_data
+                # Make subscription/active connection modifications safe
+                async with self.__class__._subscriptions_lock:
+                    self.__class__.subscriptions.setdefault(self, set()).add(channel)
+                async with self.__class__._connections_lock:
+                    self.__class__.active_connections.add(self)
 
-                self.subscriptions.setdefault(self, set()).add(channel)
-
-                self.active_connections.add(self)
-
-                if channel in self._channel_callbacks:
-                    await self._channel_callbacks[channel].register(self)
+                # Protect callback access with a lock
+                async with self.__class__._channel_callbacks_lock:
+                    callback = self.__class__._channel_callbacks.get(channel)
+                if callback is not None:
+                    await callback.register(self)
 
             elif msg_type == "unregister":
                 channel = msg_data
-                if self in self.subscriptions:
-                    self.subscriptions[self].discard(channel)
+                async with self.__class__._subscriptions_lock:
+                    if self in self.__class__.subscriptions:
+                        self.__class__.subscriptions[self].discard(channel)
 
-                    if channel in self._channel_callbacks:
-                        await self._channel_callbacks[channel].unregister(self)
+                    async with self.__class__._channel_callbacks_lock:
+                        callback = self.__class__._channel_callbacks.get(channel)
+                    if callback is not None:
+                        await callback.unregister(self)
 
             else:
                 # Handle custom message types
                 # Check all registered callbacks for custom message handlers
                 handled = False
-                for channel, callback in self._channel_callbacks.items():
+                # iterate channel callbacks with a snapshot under lock
+                async with self.__class__._channel_callbacks_lock:
+                    callback_items = list(self._channel_callbacks.items())
+                for channel, callback in callback_items:
                     if hasattr(callback, "handle_custom_message"):
                         # Let callback decide if it handles this message type
                         result = await callback.handle_custom_message(
@@ -459,10 +539,11 @@ class UnifiedWebSocketHandler(tornado.websocket.WebSocketHandler):
             if self.ping_callback:
                 self.ping_callback.stop()
 
-            if self in self.subscriptions:
-                del self.subscriptions[self]
-
-            self.active_connections.discard(self)
+            async with self.__class__._subscriptions_lock:
+                if self in self.__class__.subscriptions:
+                    del self.__class__.subscriptions[self]
+            async with self.__class__._connections_lock:
+                self.__class__.active_connections.discard(self)
 
         except Exception as e:
             pass

--- a/src/handlers/base.py
+++ b/src/handlers/base.py
@@ -137,29 +137,338 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
 
         super().__init__(*args, **kwargs)
 
+class UnifiedWebSocketHandler(tornado.websocket.WebSocketHandler):
+    """Unified WebSocket handler with shared Redis pubsub connection
 
-class WebSocketSubHandler(tornado.websocket.WebSocketHandler):
+    This handler replaces multiple individual WebSocket handlers with a single
+    unified handler that uses type-based message routing. All connections share
+    a single Redis pubsub connection to reduce resource usage.
+
+    Features:
+    - Shared Redis pubsub connection (1 connection for all WebSocket connections)
+    - Type-based message routing with register/unregister mechanism
+    - Ping-pong health check (30s interval, 60s timeout)
+    - Proper connection pool management
+    - Error isolation (one connection failure doesn't affect others)
+    """
+
+    # Shared Redis pubsub connection (class-level)
+    _PING_INTERVAL = 30  # seconds
+    _PING_TIMEOUT = 60  # seconds
+    _PING_DATA = {"type": "ping", "data": ""}
+    _LOGOUT_EVENT_CHANNEL = "logout_acct_sub"
+    _MAX_RETRY_DELAY = 60
+    _shared_pubsub: aioredis.client.PubSub = None
+    _pubsub_lock = asyncio.Lock()
+    _pubsub_task: asyncio.Task = None
+    _redis_pool = None
+
+    # Connection pool tracking
+    active_connections: set = set()  # All active WebSocket connections
+
+    # Subscription tracking: connection -> set of subscribed types
+    subscriptions: dict = {}
+
+    # Message type callbacks: channel -> callback class instance
+    # Callback class should have: register(), message(data), unregister() methods
+    _channel_callbacks: dict = {}
+
     def __init__(self, *args, **kwargs):
+        self.db: asyncpg.Pool = kwargs.pop("db")
         pool = kwargs.pop("pool")
+        if UnifiedWebSocketHandler._redis_pool is None:
+            UnifiedWebSocketHandler._redis_pool = pool
+
         self.rs: aioredis.Redis = aioredis.Redis(connection_pool=pool)
-        self.p = self.rs.pubsub()
-        self.task: asyncio.Task = None
+        self.acct_id: int = 0
+        self.session_id = None
+
+        self.last_pong = 0.0
+        self.last_ping = 0.0
+        self.ping_callback = None
 
         super().__init__(*args, **kwargs)
-        self.settings["websocket_ping_interval"] = 10
 
     def check_origin(self, _: str) -> bool:
         return True
 
-    async def cleanup(self):
-        await self.p.unsubscribe()
-        if self.task:
-            self.task.cancel()
+    @classmethod
+    async def get_shared_pubsub(cls):
+        """Get or create the shared Redis pubsub connection"""
+        async with cls._pubsub_lock:
+            if cls._shared_pubsub is None:
+                rs = aioredis.Redis(connection_pool=cls._redis_pool)
+                cls._shared_pubsub = rs.pubsub()
 
-        await self.p.aclose()
-        await self.rs.aclose()
+                # Subscribe to all registered channels
+                if cls._channel_callbacks:
+                    await cls._shared_pubsub.subscribe(*cls._channel_callbacks.keys())
+                    await cls._shared_pubsub.subscribe(cls._LOGOUT_EVENT_CHANNEL)
+
+                # Start listener task
+                cls._pubsub_task = asyncio.create_task(cls._listen_redis_messages())
+
+        return cls._shared_pubsub
+
+    @classmethod
+    async def _resubscribe_all_channels(cls):
+        """Resubscribe to all registered channels after reconnection"""
+        if cls._shared_pubsub and cls._channel_callbacks:
+            await cls._shared_pubsub.subscribe(*cls._channel_callbacks.keys())
+            # Ensure logout channel is subscribed too
+            await cls._shared_pubsub.subscribe(cls._LOGOUT_EVENT_CHANNEL)
+
+    @classmethod
+    def register_channel_callback(cls, channel: str, callback_class):
+        """Register a callback class for a specific channel
+
+        Args:
+            channel: The Redis channel name
+            callback_class: A class that implements the callback interface:
+                - channel_name (class attribute): The Redis channel name
+                - register(conn): Called when client registers to this channel
+                - message(conn, data): Called when message received, returns formatted data or None
+                - unregister(conn): Called when client unregisters from this channel
+
+        Example:
+            class MyChannelCallback:
+                def __init__(self):
+                    self.conn_state = {}
+
+                async def register(self, conn):
+                    self.conn_state[conn] = {}
+                    # Initialize connection-specific state
+
+                async def message(self, conn, data):
+                    # Process message with connection state
+                    if should_skip(conn, data):
+                        return None
+                    return format_data(data)
+
+                async def unregister(self, conn):
+                    # Cleanup connection state
+                    self.conn_state.pop(conn, None)
+
+            UnifiedWebSocketHandler.register_channel_callback("my_channel", MyChannelCallback())
+        """
+        cls._channel_callbacks[channel] = callback_class
+
+    @classmethod
+    async def _listen_redis_messages(cls):
+        """Listen to Redis messages and distribute to subscribed connections
+
+        This runs as a single background task that receives all Redis pubsub
+        messages and distributes them to the appropriate WebSocket connections
+        based on their subscriptions.
+        """
+        retry_delay = 1
+
+        while True:
+            try:
+                if cls._shared_pubsub is None:
+                    await cls.get_shared_pubsub()
+                    await cls._resubscribe_all_channels()
+                    retry_delay = 1
+
+                async for msg in cls._shared_pubsub.listen():
+                    if msg["type"] != "message":
+                        continue
+
+                    channel = (
+                        msg["channel"].decode()
+                        if isinstance(msg["channel"], bytes)
+                        else msg["channel"]
+                    )
+                    data = (
+                        msg["data"].decode()
+                        if isinstance(msg["data"], bytes)
+                        else msg["data"]
+                    )
+
+                    if channel == cls._LOGOUT_EVENT_CHANNEL:
+                        # data is expected to be a session key (cookie id).
+                        # Find all connections that match this session_id and close them.
+                        session_key = data
+                        close_failed = []
+                        # Build set of candidate connections: subscriptions + active
+                        candidates = set(list(cls.subscriptions.keys()))
+                        candidates.update(cls.active_connections)
+
+                        for conn in list(candidates):
+                            try:
+                                if getattr(conn, "session_id", None) == session_key:
+                                    try:
+                                        conn.close(code=4000, reason="Logout")
+                                    except Exception:
+                                        # fallback to cleanup if close fails
+                                        close_failed.append(conn)
+                            except Exception as e:
+                                pass
+
+                        for conn in close_failed:
+                            try:
+                                await conn.cleanup()
+                            except Exception as e:
+                                pass
+
+                        continue
+
+                    failed_conns = []
+                    for conn, types in list(cls.subscriptions.items()):
+                        if channel in types:
+                            try:
+                                if channel in cls._channel_callbacks:
+                                    callback = cls._channel_callbacks[channel]
+                                    formatted_data = await callback.message(conn, data)
+                                    if formatted_data is None:
+                                        continue  # Callback decided to skip this connection
+
+                                    await conn.write_message(
+                                        json.dumps(
+                                            {"type": channel, "data": formatted_data}
+                                        )
+                                    )
+                                else:
+                                    # No callback, send raw data
+                                    await conn.write_message(
+                                        json.dumps({"type": channel, "data": data})
+                                    )
+                            except Exception as e:
+                                failed_conns.append(conn)
+
+                    for conn in failed_conns:
+                        try:
+                            await conn.cleanup()
+                        except Exception as e:
+                            pass
+
+            except Exception as e:
+                cls._shared_pubsub = None
+
+                # Exponential backoff
+                await asyncio.sleep(retry_delay)
+                retry_delay = min(retry_delay * 2, self._MAX_RETRY_DELAY)
+
+    async def open(self):
+        """Called when WebSocket connection is opened"""
+        # Ensure shared pubsub is initialized
+        await self.get_shared_pubsub()
+
+        self.acct_id = self.get_secure_cookie("id")
+        self.session_id = self.get_cookie("id")
+
+        self.start_ping()
+
+    def start_ping(self):
+        """Start ping-pong health check mechanism"""
+        now = tornado.ioloop.IOLoop.current().time()
+        self.last_pong = now
+        self.last_ping = now
+        self.ping_callback = tornado.ioloop.PeriodicCallback(
+            self.periodic_ping,
+            self._PING_INTERVAL * 1000,  # 30 seconds
+        )
+        self.ping_callback.start()
+
+    def periodic_ping(self):
+        """Send periodic ping and check for timeout"""
+        now = tornado.ioloop.IOLoop.current().time()
+
+        if self.last_pong > 0 and (now - self.last_pong) > self._PING_TIMEOUT:
+            try:
+                self.close(code=1000, reason="Ping timeout")
+            except Exception as e:
+                pass
+            return
+
+        try:
+            self.write_message(json.dumps(self._PING_DATA))
+            self.last_ping = now
+        except Exception as e:
+            try:
+                self.close()
+            except:
+                pass
+
+    async def on_message(self, message):
+        """Handle incoming WebSocket messages
+
+        Message format: {"type": "...", "data": "..."}
+
+        Supported message types:
+        - pong: Response to ping (health check)
+        - register: Subscribe to a message type
+        - unregister: Unsubscribe from a message type
+        """
+
+        try:
+            msg = json.loads(message)
+            msg_type = msg.get("type")
+            msg_data = msg.get("data")
+
+            if msg_type == "pong":
+                self.last_pong = tornado.ioloop.IOLoop.current().time()
+                return
+
+            elif msg_type == "register":
+                channel = msg_data
+
+                self.subscriptions.setdefault(self, set()).add(channel)
+
+                self.active_connections.add(self)
+
+                if channel in self._channel_callbacks:
+                    await self._channel_callbacks[channel].register(self)
+
+            elif msg_type == "unregister":
+                channel = msg_data
+                if self in self.subscriptions:
+                    self.subscriptions[self].discard(channel)
+
+                    if channel in self._channel_callbacks:
+                        await self._channel_callbacks[channel].unregister(self)
+
+            else:
+                # Handle custom message types
+                # Check all registered callbacks for custom message handlers
+                handled = False
+                for channel, callback in self._channel_callbacks.items():
+                    if hasattr(callback, "handle_custom_message"):
+                        # Let callback decide if it handles this message type
+                        result = await callback.handle_custom_message(
+                            self, msg_type, msg_data
+                        )
+                        if (
+                            result is not False
+                        ):  # callback can return False to indicate "not handled"
+                            handled = True
+                            break
+
+                if not handled:
+                    pass
+
+        except json.JSONDecodeError as e:
+            pass
+        except Exception as e:
+            pass
+
+    async def cleanup(self):
+        """Clean up connection resources"""
+
+        try:
+            if self.ping_callback:
+                self.ping_callback.stop()
+
+            if self in self.subscriptions:
+                del self.subscriptions[self]
+
+            self.active_connections.discard(self)
+
+        except Exception as e:
+            pass
 
     def on_close(self) -> None:
+        """Called when WebSocket connection is closed"""
         asyncio.create_task(self.cleanup())
 
 

--- a/src/handlers/bulletin.py
+++ b/src/handlers/bulletin.py
@@ -1,8 +1,26 @@
-import asyncio
-
-from handlers.base import RequestHandler, WebSocketSubHandler, reqenv
+from handlers.base import RequestHandler, UnifiedWebSocketHandler, reqenv
 from services.bulletin import BulletinService
 from services.judge import JudgeServerClusterService
+
+
+class BulletinCallback:
+    """Callback for bulletin updates - simple message forwarding"""
+
+    async def register(self, conn):
+        """Registering does not require special handling"""
+        pass
+
+    async def message(self, conn, data):
+        """Directly forward the bulletin ID"""
+        return data
+
+    async def unregister(self, conn):
+        """Unsubscribing does not require special handling"""
+        pass
+
+
+_bulletin_callback = BulletinCallback()
+UnifiedWebSocketHandler.register_channel_callback("bulletinsub", _bulletin_callback)
 
 
 class BulletinHandler(RequestHandler):
@@ -23,22 +41,3 @@ class BulletinHandler(RequestHandler):
 
         await self.render('bulletin', bulletin=bulletin)
 
-
-class BulletinSub(WebSocketSubHandler):
-    async def listen_newbulletin(self):
-        async for msg in self.p.listen():
-            if msg['type'] != 'message':
-                continue
-
-            await self.on_message(str(int(msg['data'])))
-
-    async def open(self):
-        await self.p.subscribe('bulletinsub')
-
-        self.task = asyncio.tasks.Task(self.listen_newbulletin())
-
-    async def on_message(self, msg):
-        await self.write_message(msg)
-
-    def on_close(self) -> None:
-        super().on_close()

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -1,12 +1,11 @@
-import asyncio
 import decimal
 import json
-from dataclasses import is_dataclass, asdict
+from dataclasses import asdict, is_dataclass
 
 from handlers.base import (
     ActionDispatcher,
     RequestHandler,
-    WebSocketSubHandler,
+    UnifiedWebSocketHandler,
     reqenv,
     require_permission,
 )
@@ -17,14 +16,352 @@ from services.chal import (
     ChalConst,
     COMPILER_INFOS,
     MessageType,
+    Challenge,
 )
 from services.pro import ProService, ProConst
 from services.user import UserService, UserConst
-from services.contests import UserStatus
+from services.contests import UserStatus, ContestService
 from utils.numeric import parse_str_to_list
 from services.log import LogService
 
 chal_dispatcher = ActionDispatcher()
+
+
+class ChalListCallback:
+    """Callback for new challenge list notifications - simple message forwarding"""
+
+    async def register(self, conn):
+        """Registering does not require special handling"""
+        pass
+
+    async def message(self, conn, data):
+        """Directly forward the notification"""
+        return data
+
+    async def unregister(self, conn):
+        """Unsubscribing does not require special handling"""
+        pass
+
+
+# Register callback
+_challist_callback = ChalListCallback()
+UnifiedWebSocketHandler.register_channel_callback("challist_sub", _challist_callback)
+
+class _Encoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, decimal.Decimal):
+            return str(o)
+        elif is_dataclass(o):
+            return asdict(o)
+        return super().default(o)
+
+class ChalListStateCallback:
+    """Callback for challenge list state updates
+
+    Manages per-connection state for filtering challenge updates by chalids
+    and user permissions.
+    """
+
+    def __init__(self):
+        self.conn_state = {}
+
+    async def register(self, conn):
+        """Called when a connection subscribes to challiststatesub"""
+        self.conn_state[conn] = {
+            'chals': {},
+        }
+
+    async def message(self, conn, data):
+        """Called when a message is received on challiststatesub channel
+
+        Args:
+            conn: WebSocket connection
+            data: Challenge ID from Redis
+
+        Returns:
+            Formatted challenge data JSON string, or None to skip
+
+        Normal
+        full data
+
+        Contest
+        Not Started
+            If viewer is admin: full data
+            Else: deny
+
+        Running
+            If viewer is admin: full data
+            If owner equals viewer: full data
+            Else: deny
+
+        Ended
+            If viewer is admin: full data
+            If owner equals viewer: full data
+            If owner not equal to viewer and owner is not admin: remove response message, CE/IE details
+            Else: deny
+        """
+        chal_id = int(data)
+        if chal_id not in self.conn_state.get(conn, {}).get('chals', {}):
+            return None  # Skip this connection
+
+        chal: Challenge = self.conn_state[conn]['chals'][chal_id]
+        err, viewer = await UserService.inst.info_acct(conn.acct_id)
+        if err:
+            return None
+
+        allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
+        if viewer.is_kernel():
+            allow_statuses = ProConst.PRO_STATUS_FULL
+        if chal.contest_id != 0:
+            allow_statuses = ProConst.PRO_STATUS_CONTEST_USER
+        err, _ = await ProService.inst.get_pro(chal.pro_id, allow_statuses)
+        if err:
+            return None
+
+        async def gen():
+            _, total_result = await ChalService.inst.get_total_result(chal_id)
+            return json.dumps({"chal_id": chal_id, **asdict(total_result)}, cls=_Encoder)
+
+        if chal.contest_id != 0:
+            err, contest = await ContestService.inst.get_contest(chal.contest_id)
+            if err:
+                return None
+
+            if contest.is_admin(acct_id=viewer.acct_id):
+                return await gen()
+
+            if contest.is_running():
+                if viewer.acct_id == chal.acct_id:
+                    return await gen()
+
+            elif contest.is_end():
+                if viewer.acct_id == chal.acct_id:
+                    return data
+                if not contest.is_admin(acct_id=chal.acct_id) and contest.is_public_scoreboard:
+                    return await gen()
+                return None
+
+            return None
+
+        return await gen()
+
+
+    async def unregister(self, conn):
+        """Called when a connection unsubscribes from challiststatesub"""
+        self.conn_state.pop(conn, None)
+
+    async def init(self, conn, chalids: list[int]):
+        """Initialize connection state with chalids and user permissions
+
+        This should be called from the challiststatesub_init message handler.
+        """
+        if conn not in self.conn_state:
+            self.conn_state[conn] = {
+                'chals': {},
+            }
+
+        state = self.conn_state[conn]
+        for chal_id in chalids:
+            err, chal = await ChalService.inst.get_chal(chal_id, with_result=False)
+            if err:
+                state['chals'][chal_id] = None
+                continue
+
+            state['chals'][chal_id] = chal
+
+    async def handle_custom_message(self, conn, msg_type, msg_data):
+        """Handle custom message types for this channel
+
+        Args:
+            conn: WebSocket connection
+            msg_type: Message type
+            msg_data: Message data
+
+        Returns:
+            True if handled, False if not handled by this callback
+        """
+
+        if msg_type == "challiststatesub_init":
+            try:
+                init_data = json.loads(msg_data)
+                chalids = init_data.get("chalids", [])
+                print(chalids)
+
+                await self.init(conn, chalids)
+                return True  # Handled
+            except Exception as e:
+                return True  # Handled (but failed)
+
+        return False  # Not handled by this callback
+
+
+_challist_state_callback = ChalListStateCallback()
+UnifiedWebSocketHandler.register_channel_callback("challiststatesub", _challist_state_callback)
+
+
+class ChalStateCallback:
+    """Callback for single challenge state updates
+
+    Manages per-connection state for filtering single challenge updates.
+    """
+
+    def __init__(self):
+        self.conn_state = {}
+
+    async def register(self, conn: UnifiedWebSocketHandler):
+        """Called when a connection subscribes to chalstatesub"""
+        self.conn_state[conn] = {
+            'chal': None,
+        }
+
+    async def message(self, conn: UnifiedWebSocketHandler, data):
+        """Called when a message is received on chalstatesub channel
+
+        Args:
+            conn: WebSocket connection instance
+            data: JSON string containing {'chal_id': int, ...}
+
+        Returns:
+            str: Message data if chal_id matches
+            None: Skip this connection if chal_id doesn't match
+
+        Normal
+        Viewer as owner or admin: full data
+        If problem status equal to hideen: deny
+        Viewer not equal to owner and viewer is not admin: remove response message, CE/IE details
+
+        Contest
+        Not Started
+            If viewer is admin: full data
+            Else: deny
+
+        Running
+            If viewer is admin: full data
+            If owner equals viewer: full data
+            Else: deny
+
+        Ended
+            If viewer is admin: full data
+            If owner equals viewer: full data
+            If owner not equal to viewer and owner is not admin: remove response message, CE/IE details
+            Else: deny
+        """
+
+        state = self.conn_state.get(conn)
+        if not state or state['chal'] is None:
+            return None
+        chal: Challenge = state['chal']
+
+        msg_data = json.loads(data)
+        if msg_data.get('chal_id') != chal.chal_id:
+            return None  # Skip this connection
+
+
+        err, viewer = await UserService.inst.info_acct(conn.acct_id)
+        if err:
+            return None
+
+        allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
+        if viewer.is_kernel():
+            allow_statuses = ProConst.PRO_STATUS_FULL
+        if chal.contest_id != 0:
+            allow_statuses = ProConst.PRO_STATUS_CONTEST_USER
+        err, _ = await ProService.inst.get_pro(chal.pro_id, allow_statuses)
+        if err:
+            return None
+
+        def sanitize():
+            nonlocal msg_data
+            try:
+                if 'total_result' in msg_data and isinstance(msg_data['total_result'], dict):
+                    total_result = msg_data['total_result']
+                    total_result['ce_message'] = ''
+                    total_result['ie_message'] = ''
+                    total_result['message_type'] = MessageType.NONE.value
+
+                if 'testdata_results' in msg_data and isinstance(msg_data['testdata_results'], dict):
+                    for td in msg_data['testdata_results'].values():
+                        if isinstance(td, dict):
+                            td['message'] = ''
+                            td['message_type'] = MessageType.NONE.value
+
+                if 'message' in msg_data:
+                    msg_data['message'] = ''
+                    if 'message_type' in msg_data:
+                        msg_data['message_type'] = MessageType.NONE.value
+            except Exception:
+                # In case of any unexpected data structure, fail-safe to not reveal data
+                if 'message' in msg_data:
+                    msg_data['message'] = ''
+                if 'total_result' in msg_data and isinstance(msg_data['total_result'], dict):
+                    msg_data['total_result']['ce_message'] = ''
+                    msg_data['total_result']['ie_message'] = ''
+                    msg_data['total_result']['message_type'] = MessageType.NONE.value
+            return json.dumps(msg_data)
+
+
+        if chal.contest_id != 0:
+            err, contest = await ContestService.inst.get_contest(chal.contest_id)
+            if err:
+                return None
+
+            if contest.is_admin(acct_id=viewer.acct_id):
+                return data
+
+            if contest.is_running():
+                if viewer.acct_id == chal.acct_id:
+                    return data
+                return None
+
+            if contest.is_end():
+                if viewer.acct_id == chal.acct_id:
+                    return data
+                if not contest.is_admin(acct_id=chal.acct_id) and contest.is_public_scoreboard:
+                    return sanitize()
+                return None
+
+            return None
+
+        # NOTE: normal
+        if viewer.is_kernel():
+            return data
+
+        if viewer.acct_id == chal.acct_id:
+            return data
+
+        return sanitize()
+
+    async def unregister(self, conn: UnifiedWebSocketHandler):
+        """Called when a connection unsubscribes or closes"""
+        self.conn_state.pop(conn, None)
+
+    async def handle_custom_message(self, conn: UnifiedWebSocketHandler, msg_type, msg_data):
+        """Handle custom initialization message
+
+        Expects a plain integer string as the chal_id
+        """
+        if msg_type == 'chalstatesub_init':
+            try:
+                chal_id = int(msg_data)
+                state = self.conn_state.get(conn)
+                if state is None:
+                    self.conn_state[conn] = {'chal': None}
+                    state = self.conn_state[conn]
+
+                err, chal = await ChalService.inst.get_chal(chal_id, with_result=False)
+                if err:
+                    return True  # Handled (but we won't set chal)
+
+                state['chal'] = chal
+                return True  # Handled
+            except Exception:
+                return True  # Handled (but failed)
+
+        return False  # Not handled by this callback
+
+
+_chal_state_callback = ChalStateCallback()
+UnifiedWebSocketHandler.register_channel_callback("chalstatesub", _chal_state_callback)
 
 
 class ChalListHandler(RequestHandler):
@@ -152,9 +489,16 @@ class ChalHandler(RequestHandler):
                     self.contest.hide_admin
                     and self.contest.is_admin(acct_id=chal.acct_id)
                     and not self.contest.is_admin(self.acct)
+                ) or (
+                    not self.contest.hide_admin
+                    and not (self.acct.acct_id == chal.acct_id or self.contest.is_admin(self.acct))
                 ):
                     return self.error(("Eacces", "Permission denied"))
 
+            # After contest: if scoreboard not public, only own or admin can view
+            if not self.contest.is_running() and not self.contest.is_public_scoreboard:
+                if not (self.acct and (self.acct.acct_id == chal.acct_id or self.contest.is_admin(self.acct))):
+                    return self.error(("Eacces", "Permission denied"))
             allow_statuses = ProConst.PRO_STATUS_CONTEST_USER
 
         elif self.acct.is_kernel():
@@ -225,89 +569,3 @@ class ChalHandler(RequestHandler):
         )
 
         self.error(("S", ""))
-
-
-class _Encoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, decimal.Decimal):
-            return str(o)
-        elif is_dataclass(o):
-            return asdict(o)
-        return super().default(o)
-
-
-class ChalListNewChalHandler(WebSocketSubHandler):
-    async def listen_challistnewchal(self):
-        async for msg in self.p.listen():
-            if msg["type"] != "message":
-                continue
-
-            await self.write_message(str(int(msg["data"])))
-
-    async def open(self):
-        await self.p.subscribe("challist_sub")
-
-        self.task = asyncio.tasks.Task(self.listen_challistnewchal())
-
-
-class ChalListNewStateHandler(WebSocketSubHandler):
-    async def listen_challiststate(self):
-        async for msg in self.p.listen():
-            if msg["type"] != "message":
-                continue
-
-            chal_id = int(msg["data"])
-            if chal_id in self.chalids:
-                _, chal = await ChalService.inst.get_chal(chal_id)
-                err, _ = await ProService.inst.get_pro(
-                    chal.pro_id, self.allow_pro_statuses
-                )
-                if err:
-                    self.chalids.remove(chal_id)
-
-                _, total_result = await ChalService.inst.get_total_result(chal_id)
-                await self.write_message(
-                    json.dumps(
-                        {"chal_id": chal_id, **asdict(total_result)}, cls=_Encoder
-                    )
-                )
-
-    async def open(self):
-        self.chalids: set[int] = None
-        self.allow_pro_statuses = ProConst.STATUS_ONLINE
-
-        await self.p.subscribe("challiststatesub")
-
-        self.task = asyncio.tasks.Task(self.listen_challiststate())
-
-    async def on_message(self, msg):
-        # TODO: contest challist
-        # TODO: user authentication
-
-        if self.chalids is None:
-            j = json.loads(msg)
-
-            self.chalids = set(j["chalids"])
-
-            err, acct = await UserService.inst.info_acct(acct_id=int(j["acct_id"]))
-            if not err and acct.is_kernel():
-                self.allow_pro_statuses.append(ProConst.STATUS_HIDDEN)
-
-
-class ChalNewStateHandler(WebSocketSubHandler):
-    async def listen_chalstate(self):
-        async for msg in self.p.listen():
-            if msg["type"] != "message":
-                continue
-
-            if json.loads(msg["data"])["chal_id"] == self.chal_id:
-                await self.write_message(msg["data"])
-
-    async def open(self):
-        self.chal_id = -1
-        await self.p.subscribe("chalstatesub")
-        self.task = asyncio.tasks.Task(self.listen_chalstate())
-
-    async def on_message(self, msg):
-        if self.chal_id == -1 and msg.isdigit():
-            self.chal_id = int(msg)

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -136,7 +136,7 @@ class ChalListStateCallback:
 
             elif contest.is_end():
                 if viewer.acct_id == chal.acct_id:
-                    return data
+                    return await gen()
                 if not contest.is_admin(acct_id=chal.acct_id) and contest.is_public_scoreboard:
                     return await gen()
                 return None
@@ -185,7 +185,6 @@ class ChalListStateCallback:
             try:
                 init_data = json.loads(msg_data)
                 chalids = init_data.get("chalids", [])
-                print(chalids)
 
                 await self.init(conn, chalids)
                 return True  # Handled

--- a/src/handlers/contests/manage/qa.py
+++ b/src/handlers/contests/manage/qa.py
@@ -1,16 +1,84 @@
 import json
-import asyncio
 
 import config
 from services.contests import ContestService
 from services.user import UserService
-from handlers.base import RequestHandler, WebSocketSubHandler, reqenv, ActionDispatcher
+from handlers.base import RequestHandler, UnifiedWebSocketHandler, reqenv, ActionDispatcher
 from handlers.contests.base import contest_require_permission
 
 SUBJECT_MIN = 1
 SUBJECT_MAX = 50
 CONTENT_MIN = 1
 CONTENT_MAX = 256
+
+
+class ContestManageQACallback:
+    """Callback for contest management new question notifications
+
+    Manages per-connection state for filtering contest-specific new question notifications.
+    Only used by contest administrators.
+    """
+
+    def __init__(self):
+        # Store connection-specific state: {conn: {'contest_id': int}}
+        self.conn_state = {}
+
+    async def register(self, conn):
+        """Called when a connection subscribes to contestnewquessub"""
+        # Initialize connection state with no contest_id
+        self.conn_state[conn] = {'contest_id': None}
+
+    async def message(self, conn, data):
+        """Called when a message is received on contestnewquessub channel
+
+        Args:
+            conn: WebSocket connection instance
+            data: Contest ID as string
+
+        Returns:
+            str: Contest ID if it matches the subscribed contest
+            None: Skip this connection if contest_id doesn't match
+        """
+        try:
+            state = self.conn_state.get(conn)
+            if not state or state['contest_id'] is None:
+                return None
+
+            # Check if message contest_id matches subscribed contest
+            contest_id = int(data)
+            if contest_id == state['contest_id']:
+                return str(contest_id)  # Forward message to this connection
+
+            return None  # Skip this connection
+        except Exception as e:
+            return None
+
+    async def unregister(self, conn):
+        """Called when a connection unsubscribes or closes"""
+        self.conn_state.pop(conn, None)
+
+    async def handle_custom_message(self, conn, msg_type, msg_data):
+        """Handle custom initialization message
+
+        Expects a plain integer string as the contest_id
+        """
+        if msg_type == 'contestnewquessub_init':
+            try:
+                contest_id = int(msg_data)
+                state = self.conn_state.get(conn)
+                if state:
+                    state['contest_id'] = contest_id
+                return True  # Handled
+            except Exception as e:
+                return True  # Handled (but failed)
+
+        return False  # Not handled by this callback
+
+
+# Create and register callback instance
+_contest_manage_qa_callback = ContestManageQACallback()
+UnifiedWebSocketHandler.register_channel_callback("contestnewquessub", _contest_manage_qa_callback)
+
 
 contest_manage_question_dispatcher = ActionDispatcher()
 
@@ -103,7 +171,6 @@ class ContestManageQuestionHandler(RequestHandler):
         return await contest_manage_question_dispatcher.dispatch(self, reqtype)
 
 
-# Create dispatcher for announce handler
 contest_manage_announce_dispatcher = ActionDispatcher()
 
 
@@ -198,23 +265,3 @@ class ContestManageAnnounceHandler(RequestHandler):
     async def post(self):
         reqtype = self.get_argument("reqtype")
         return await contest_manage_announce_dispatcher.dispatch(self, reqtype)
-
-
-class ContestManageQANewQuesHandler(WebSocketSubHandler):
-    async def listen_newques(self):
-        async for msg in self.p.listen():
-            if msg["type"] != "message":
-                continue
-
-            if int(msg["data"]) == self.contest_id:
-                await self.write_message(str(int(msg["data"])))
-
-    async def open(self):
-        self.contest_id = -1
-        await self.p.subscribe("contestnewquessub")
-
-        self.task = asyncio.tasks.Task(self.listen_newques())
-
-    async def on_message(self, msg):
-        if self.contest_id == -1 and msg.isdigit():
-            self.contest_id = int(msg)

--- a/src/handlers/contests/manage/url.py
+++ b/src/handlers/contests/manage/url.py
@@ -7,15 +7,13 @@ from handlers.contests.manage.general import (
 )
 from handlers.contests.manage.pro import ContestManageProHandler
 from handlers.contests.manage.reg import ContestManageRegHandler
-from handlers.contests.manage.qa import ContestManageQuestionHandler, ContestManageAnnounceHandler, ContestManageQANewQuesHandler
+from handlers.contests.manage.qa import ContestManageQuestionHandler, ContestManageAnnounceHandler
 
 def get_contests_manage_url(db, rs, pool):
     args = {
         'db': db,
         'rs': rs,
     }
-
-    sub_args = {'pool': pool}
 
     return [
         (r'/be/contests/manage/add', ContestManageAddHandler, args),
@@ -28,5 +26,4 @@ def get_contests_manage_url(db, rs, pool):
         (r'/be/contests/\d+/manage/reg', ContestManageRegHandler, args),
         (r'/be/contests/\d+/manage/question', ContestManageQuestionHandler, args),
         (r'/be/contests/\d+/manage/announce', ContestManageAnnounceHandler, args),
-        (r'/be/contests/\d+/manage/qasub', ContestManageQANewQuesHandler, sub_args),
     ]

--- a/src/handlers/contests/qa.py
+++ b/src/handlers/contests/qa.py
@@ -1,10 +1,9 @@
 import time
-import asyncio
 import json
 
 from services.contests import ContestService
 
-from handlers.base import RequestHandler, WebSocketSubHandler, reqenv, ActionDispatcher
+from handlers.base import RequestHandler, UnifiedWebSocketHandler, reqenv, ActionDispatcher
 from handlers.contests.base import contest_require_permission
 
 SUBJECT_MIN = 1
@@ -12,6 +11,88 @@ SUBJECT_MAX = 50
 CONTENT_MIN = 1
 CONTENT_MAX = 256
 ASK_CD_TIME = 60 * 3
+
+
+class ContestQACallback:
+    """Callback for contest Q&A updates
+
+    Manages per-connection state for filtering contest-specific Q&A messages.
+    Handles both announcements/questions and replies, with proper routing.
+    """
+
+    def __init__(self):
+        # Store connection-specific state: {conn: {'contest_id': int, 'acct_id': int}}
+        self.conn_state = {}
+
+    async def register(self, conn):
+        """Called when a connection subscribes to contestnewqasub"""
+        # Initialize connection state
+        self.conn_state[conn] = {'contest_id': None, 'acct_id': None}
+
+    async def message(self, conn, data):
+        """Called when a message is received on contestnewqasub channel
+
+        Args:
+            conn: WebSocket connection instance
+            data: JSON string containing message data
+
+        Returns:
+            str: Message data if it should be forwarded
+            None: Skip this connection
+        """
+        try:
+            state = self.conn_state.get(conn)
+            if not state or state['contest_id'] is None or state['acct_id'] is None:
+                return None
+
+            # Parse message
+            msg_data = json.loads(data)
+
+            # Check contest_id matches
+            if msg_data.get('contest_id') != state['contest_id']:
+                return None
+
+            # For non-reply messages, send to all subscribers of this contest
+            if msg_data.get('type') != 'reply':
+                return data
+
+            # For reply messages, only send to the person who asked
+            if msg_data.get('ask_acct_id') == state['acct_id']:
+                return data
+
+            return None  # Skip this connection
+        except Exception as e:
+            return None
+
+    async def unregister(self, conn):
+        """Called when a connection unsubscribes or closes"""
+        self.conn_state.pop(conn, None)
+
+    async def handle_custom_message(self, conn, msg_type, msg_data):
+        """Handle custom initialization message
+
+        Expects JSON: {"contest_id": int, "acct_id": int}
+        """
+        if msg_type == 'contestnewqasub_init':
+            try:
+                init_data = json.loads(msg_data)
+                contest_id = int(init_data.get('contest_id'))
+                acct_id = int(init_data.get('acct_id'))
+
+                state = self.conn_state.get(conn)
+                if state:
+                    state['contest_id'] = contest_id
+                    state['acct_id'] = acct_id
+                return True  # Handled
+            except Exception as e:
+                return True  # Handled (but failed)
+
+        return False  # Not handled by this callback
+
+
+_contest_qa_callback = ContestQACallback()
+UnifiedWebSocketHandler.register_channel_callback("contestnewqasub", _contest_qa_callback)
+
 
 contest_qa_dispatcher = ActionDispatcher()
 
@@ -99,30 +180,3 @@ class ContestQAHandler(RequestHandler):
     async def post(self):
         reqtype = self.get_argument("reqtype")
         return await contest_qa_dispatcher.dispatch(self, reqtype)
-
-
-class ContestNewQAHandler(WebSocketSubHandler):
-    async def listen_newqa(self):
-        async for msg in self.p.listen():
-            if msg["type"] != "message":
-                continue
-
-            data = json.loads(msg["data"])
-            if data["contest_id"] == self.contest_id:
-                if data["type"] != "reply":
-                    await self.write_message(msg["data"])
-                elif data["ask_acct_id"] == self.acct_id:
-                    await self.write_message(msg["data"])
-
-    async def open(self):
-        self.contest_id = -1
-        self.acct_id = -1
-        await self.p.subscribe("contestnewqasub")
-
-        self.task = asyncio.tasks.Task(self.listen_newqa())
-
-    async def on_message(self, msg):
-        j = json.loads(msg)
-        if self.contest_id == -1 or self.acct_id == -1:
-            self.contest_id = int(j["contest_id"])
-            self.acct_id = int(j["acct_id"])

--- a/src/handlers/contests/qa.py
+++ b/src/handlers/contests/qa.py
@@ -80,9 +80,10 @@ class ContestQACallback:
                 acct_id = int(init_data.get('acct_id'))
 
                 state = self.conn_state.get(conn)
-                if state:
-                    state['contest_id'] = contest_id
-                    state['acct_id'] = acct_id
+                if not state:
+                    return True
+                state['contest_id'] = contest_id
+                state['acct_id'] = acct_id
                 return True  # Handled
             except Exception as e:
                 return True  # Handled (but failed)

--- a/src/handlers/contests/scoreboard.py
+++ b/src/handlers/contests/scoreboard.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 import json
 from decimal import Decimal
@@ -6,9 +5,76 @@ from decimal import Decimal
 import tornado.web
 from msgpack import packb, unpackb
 
-from handlers.base import RequestHandler, WebSocketSubHandler, reqenv
+import config
+from handlers.base import RequestHandler, UnifiedWebSocketHandler, reqenv
 from services.contests import ContestService, ProblemScoreType, UserStatus
 from services.user import UserService
+
+
+class ContestScoreboardCallback:
+    """Callback for contest scoreboard new challenge updates
+
+    Manages per-connection state for filtering contest-specific updates.
+    """
+    def __init__(self):
+        # Store connection-specific state: {conn: {'contest_id': int}}
+        self.conn_state = {}
+
+    async def register(self, conn):
+        """Called when a connection subscribes to contestnewchalsub"""
+        # Initialize connection state with no contest_id
+        self.conn_state[conn] = {'contest_id': None}
+
+    async def message(self, conn, data):
+        """Called when a message is received on contestnewchalsub channel
+
+        Args:
+            conn: WebSocket connection instance
+            data: Contest ID as string
+
+        Returns:
+            str: Contest ID if it matches the subscribed contest
+            None: Skip this connection if contest_id doesn't match
+        """
+        try:
+            state = self.conn_state.get(conn)
+            if not state or state['contest_id'] is None:
+                return None
+
+            # Check if message contest_id matches subscribed contest
+            contest_id = int(data)
+            if contest_id == state['contest_id']:
+                return str(contest_id)  # Forward message to this connection
+
+            return None  # Skip this connection
+        except Exception as e:
+            return None
+
+    async def unregister(self, conn):
+        """Called when a connection unsubscribes or closes"""
+        self.conn_state.pop(conn, None)
+
+    async def handle_custom_message(self, conn, msg_type, msg_data):
+        """Handle custom initialization message
+
+        Expects a plain integer string as the contest_id
+        """
+        if msg_type == 'contestnewchalsub_init':
+            try:
+                contest_id = int(msg_data)
+                state = self.conn_state.get(conn)
+                if state:
+                    state['contest_id'] = contest_id
+                return True  # Handled
+            except Exception as e:
+                return True  # Handled (but failed)
+
+        return False  # Not handled by this callback
+
+
+_contest_scoreboard_callback = ContestScoreboardCallback()
+UnifiedWebSocketHandler.register_channel_callback("contestnewchalsub", _contest_scoreboard_callback)
+
 
 class _JsonDatetimeEncoder(json.JSONEncoder):
     def default(self, o):
@@ -118,7 +184,7 @@ class ContestScoreboardHandler(RequestHandler):
                 scores[pro_id] = {
                     'pro_id': pro_id,
                     'chal_id': p['chal_id'],
-                    'timestamp': p['timestamp'] - start_time,
+                    'timestamp': p['timestamp'].astimezone(config.TIMEZONE) - start_time,
                     'score': p['score'],
                     'fail_cnt': p['fail_cnt']
                 }
@@ -132,23 +198,3 @@ class ContestScoreboardHandler(RequestHandler):
             })
 
         self.error(('S', all_scores), encoder=_JsonDatetimeEncoder)
-
-
-class ContestScoreboardNewChalHandler(WebSocketSubHandler):
-    async def listen_newchal(self):
-        async for msg in self.p.listen():
-            if msg['type'] != 'message':
-                continue
-
-            if int(msg['data']) == self.contest_id:
-                await self.write_message(str(int(msg['data'])))
-
-    async def open(self):
-        self.contest_id = -1
-        await self.p.subscribe('contestnewchalsub')
-
-        self.task = asyncio.tasks.Task(self.listen_newchal())
-
-    async def on_message(self, msg):
-        if self.contest_id == -1 and msg.isdigit():
-            self.contest_id = int(msg)

--- a/src/handlers/contests/url.py
+++ b/src/handlers/contests/url.py
@@ -3,8 +3,8 @@ from handlers.contests.contests import ContestInfoHandler, ContestListHandler
 from handlers.contests.manage.url import get_contests_manage_url
 from handlers.contests.proset import ContestProsetHandler
 from handlers.contests.reg import ContestRegHandler
-from handlers.contests.scoreboard import ContestScoreboardHandler, ContestScoreboardNewChalHandler
-from handlers.contests.qa import ContestQAHandler, ContestNewQAHandler
+from handlers.contests.scoreboard import ContestScoreboardHandler
+from handlers.contests.qa import ContestQAHandler
 from handlers.pro import ProHandler, ProStaticHandler
 from handlers.submit import SubmitHandler
 
@@ -14,8 +14,6 @@ def get_contests_url(db, rs, pool):
         'db': db,
         'rs': rs,
     }
-
-    sub_args = {'pool': pool}
 
     return [
         (r'/be/contests', ContestListHandler, args),
@@ -30,8 +28,6 @@ def get_contests_url(db, rs, pool):
         (r'/be/contests/\d+/submit', SubmitHandler, args),
         (r'/be/contests/\d+/reg', ContestRegHandler, args),
         (r'/be/contests/\d+/scoreboard', ContestScoreboardHandler, args),
-        (r'/be/contests/\d+/scoreboardsub', ContestScoreboardNewChalHandler, sub_args),
         (r'/be/contests/\d+/qa', ContestQAHandler, args),
-        (r'/be/contests/\d+/qasub', ContestNewQAHandler, sub_args),
         # ('/contests/pro/(.+)', args),  # Experiment Problem UI
     ] + get_contests_manage_url(db, rs, pool)

--- a/src/handlers/contests/url.py
+++ b/src/handlers/contests/url.py
@@ -21,7 +21,7 @@ def get_contests_url(db, rs, pool):
         (r'/be/contests', ContestListHandler, args),
         (r'/be/contests/\d+', ContestInfoHandler, args),
         (r'/be/contests/\d+/info', ContestInfoHandler, args),
-        (r'/be/contests/\d+/pro/(\d+)/(.*)', ProStaticHandler, {'db': db, 'rs': rs, 'path': 'problem'}),
+        (r'/contests/\d+/pro/(\d+)/(.+)', ProStaticHandler, {'db': db, 'rs': rs, 'path': 'problem'}),
         (r'/be/contests/\d+/pro/(\d+)', ProHandler, args),
         (r'/be/contests/\d+/proset', ContestProsetHandler, args),
         (r'/be/contests/\d+/chal', ChalListHandler, args),

--- a/src/handlers/manage/info.py
+++ b/src/handlers/manage/info.py
@@ -31,7 +31,8 @@ class ManageInfoHandler(RequestHandler):
     async def _get_system_info(self):
         info = {}
 
-        info['active_websocket_connections'] = len(UnifiedWebSocketHandler.active_connections)
+        async with UnifiedWebSocketHandler._connections_lock:
+            info['active_websocket_connections'] = len(UnifiedWebSocketHandler.active_connections)
 
         try:
             with open("./version.txt", "r") as f:

--- a/src/handlers/manage/info.py
+++ b/src/handlers/manage/info.py
@@ -8,7 +8,7 @@ import time
 import psutil
 
 import config
-from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_permission
+from handlers.base import ActionDispatcher, RequestHandler, UnifiedWebSocketHandler, reqenv, require_permission
 from services.user import UserConst, UserService
 
 info_dispatcher = ActionDispatcher()
@@ -30,6 +30,8 @@ class ManageInfoHandler(RequestHandler):
 
     async def _get_system_info(self):
         info = {}
+
+        info['active_websocket_connections'] = len(UnifiedWebSocketHandler.active_connections)
 
         try:
             with open("./version.txt", "r") as f:

--- a/src/handlers/manage/judge.py
+++ b/src/handlers/manage/judge.py
@@ -7,13 +7,33 @@ import config
 from handlers.base import (
     ActionDispatcher,
     RequestHandler,
-    WebSocketSubHandler,
+    UnifiedWebSocketHandler,
     reqenv,
     require_permission,
 )
 from services.judge import JudgeServerClusterService
 from services.log import LogService
 from services.user import UserConst
+
+
+class JudgeCntCallback:
+    """Judge server challenge count update callback - simple message forwarding"""
+
+    async def register(self, conn):
+        """Registering does not require special handling"""
+        pass
+
+    async def message(self, conn, data):
+        """Directly forward the message"""
+        return data
+
+    async def unregister(self, conn):
+        """Unsubscribing does not require special handling"""
+        pass
+
+
+_judge_cnt_callback = JudgeCntCallback()
+UnifiedWebSocketHandler.register_channel_callback("judgechalcnt_sub", _judge_cnt_callback)
 
 
 judge_dispatcher = ActionDispatcher()
@@ -80,17 +100,3 @@ class ManageJudgeHandler(RequestHandler):
         )
 
         self.error(("S", ""))
-
-
-class JudgeChalCntSub(WebSocketSubHandler):
-    async def listen_newchal(self):
-        async for msg in self.p.listen():
-            if msg["type"] != "message":
-                continue
-
-            await self.write_message(msg["data"].decode("utf-8"))
-
-    async def open(self):
-        await self.p.subscribe("judgechalcnt_sub")
-
-        self.task = asyncio.tasks.Task(self.listen_newchal())

--- a/src/handlers/manage/url.py
+++ b/src/handlers/manage/url.py
@@ -3,8 +3,8 @@ from handlers.manage.board import ManageBoardHandler
 from handlers.manage.bulletin import ManageBulletinHandler
 from handlers.manage.contest import ManageContestHandler
 from handlers.manage.dash import ManageDashHandler
-from handlers.manage.judge import JudgeChalCntSub, ManageJudgeHandler
 from handlers.manage.info import ManageInfoHandler
+from handlers.manage.judge import ManageJudgeHandler
 from handlers.manage.pack import ManagePackHandler
 from handlers.manage.pro.url import get_manage_pro_url
 from handlers.manage.proclass import ManageProClassHandler
@@ -17,13 +17,12 @@ def get_manage_url(db, rs, pool):
         'rs': rs,
     }
 
-    sub_args = {'pool': pool}
-
     # Get pro management URLs with args applied
     pro_urls = [(pattern, handler, args) for pattern, handler in get_manage_pro_url()]
 
     return [
         ('/be/manage/dash', ManageDashHandler, args),
+        ('/be/manage/info', ManageInfoHandler, args),
         ('/be/manage/acct', ManageAcctHandler, args),
         ('/be/manage/acct/(.+)', ManageAcctHandler, args),
         ('/be/manage/board', ManageBoardHandler, args),
@@ -36,7 +35,5 @@ def get_manage_url(db, rs, pool):
         ('/be/manage/question', ManageQuestionHandler, args),
         ('/be/manage/question/(.+)', ManageQuestionHandler, args),
         ('/be/manage/judge', ManageJudgeHandler, args),
-        ('/be/manage/judgecntws', JudgeChalCntSub, sub_args),
         ('/be/manage/pack', ManagePackHandler, args),
-        ("/be/manage/info", ManageInfoHandler, args),
     ] + pro_urls

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -13,8 +13,31 @@ var index = new function() {
     var that = this;
     var curr_url = null;
 
+    /**
+     * @var {number|null} that.acct_id - current account id, null if not logged in
+     */
     that.acct_id = null;
+    that.base_url = null;
     that.prev_url = null;
+
+    /**
+     * @var {WebSocket|null} that.ws - current WebSocket connection, null if none, if contest_id set, it will connect to contest ws, otherwise normal ws
+     */
+    that.ws = null;
+
+    /**
+     * @var {Map<string, function>} that.ws_callback_map - map of websocket message type to callback function
+     */
+    that.ws_callback_map = new Map();
+
+    /**
+     * @var {Array<string>} that.ws_pending_registers - pending register types waiting for WebSocket to open
+     */
+    that.ws_pending_registers = [];
+    /**
+     * @var {Array<{type: string, data: any}>} that.ws_pending_messages - pending messages waiting for WebSocket to open
+     */
+    that.ws_pending_messages = [];
 
     /*
 	Reload new page
@@ -222,6 +245,8 @@ var index = new function() {
             });
         });
 
+        that.ws = that.ws_init('ws');
+
         if (acct_id != '0') {
             that.acct_id = parseInt(acct_id);
             j_navlist.find('li.leave').show();
@@ -405,15 +430,99 @@ var index = new function() {
         }, 3000));
     };
 
-    that.get_ws = function(ws_url) {
+    that.ws_init = function(ws_url) {
         let ws_link = '';
         if (location.protocol !== 'https:') {
             ws_link = `ws://${location.host}${that.base_url}/be/${ws_url}`;
         } else {
             ws_link = `wss://${location.host}${that.base_url}/be/${ws_url}`;
         }
-	    return new WebSocket(ws_link);
-    };
+        let ws = new WebSocket(ws_link);
+
+        ws.onopen = function() {
+            console.log('WebSocket connected');
+            // Send all pending register messages
+            for (let type of that.ws_pending_registers) {
+                console.log(`Registering pending callback: ${type}`);
+                ws.send(JSON.stringify({'type': 'register', 'data': type}));
+            }
+            that.ws_pending_registers = [];
+            // Send all pending messages
+            for (let msg of that.ws_pending_messages) {
+                try {
+                    ws.send(JSON.stringify(msg));
+                } catch (e) {
+                    console.error('Failed to send pending ws message', e);
+                }
+            }
+            that.ws_pending_messages = [];
+        };
+
+        ws.onmessage = function(event) {
+            let data = JSON.parse(event.data);
+            if (data.type == "ping") {
+                ws.send(JSON.stringify({'type': 'pong', 'data': ''}));
+            } else if (that.ws_callback_map.has(data.type)) {
+                that.ws_callback_map.get(data.type)(data.data);
+            } else {
+                console.warn(`no callback registered for ws message type ${data.type}`);
+            }
+        };
+
+        ws.onerror = function(error) {
+            console.error('WebSocket error:', error);
+        };
+
+        ws.onclose = function() {
+            console.log('WebSocket closed');
+        };
+
+        return ws;
+    }
+
+    /**
+     *
+     * @param {string} type
+     * @param {Function} callback
+     */
+    that.register_ws_callback = function(type, callback) {
+        if (that.ws == null) {
+            console.error('ws is null, cannot register callback');
+            return;
+        }
+        if (that.ws_callback_map.has(type)) {
+            console.warn(`ws callback for type ${type} already registered, overwriting`);
+        }
+        that.ws_callback_map.set(type, callback);
+
+        // If WebSocket is already open, send register immediately
+        if (that.ws.readyState === WebSocket.OPEN) {
+            that.ws.send(JSON.stringify({'type': 'register', 'data': type}));
+        } else {
+            // Otherwise, add to pending list
+            console.log(`WebSocket not ready, queuing register for: ${type}`);
+            that.ws_pending_registers.push(type);
+        }
+    }
+
+    /**
+     *
+     * @param {string} type
+     * @param {object} data
+     */
+    that.ws_send = function(type, data) {
+        if (that.ws == null) {
+            // Socket not initialized yet: queue message
+            that.ws_pending_messages.push({'type': type, 'data': data});
+            return;
+        }
+        if (that.ws.readyState === WebSocket.OPEN) {
+            that.ws.send(JSON.stringify({'type': type, 'data': data}));
+        } else {
+            // WebSocket not open (yet or reconnecting); queue the message
+            that.ws_pending_messages.push({'type': type, 'data': data});
+        }
+    }
 
     that.unescape_html = function(html) {
         const parser = new DOMParser();

--- a/src/static/templ/chal.html
+++ b/src/static/templ/chal.html
@@ -148,7 +148,7 @@
         $('#reject').on('click', function(e) {
             let url = '';
             {% if chal.contest_id == 0 %}
-                url = `{{ url('/be/chal/{ chal.chal_id }') }}`;
+                url = `{{ url(f'/be/chal/{ chal.chal_id }') }}`;
             {% else %}
                 url = `{{ url(f'/be/contests/{ chal.contest_id }/chal/{ chal.chal_id }') }}`;
             {% end %}

--- a/src/static/templ/chal.html
+++ b/src/static/templ/chal.html
@@ -30,14 +30,13 @@
         total_table.querySelector('td.memory').innerHTML = memory;
         total_table.querySelector('td.score').innerHTML = rate;
 
+        total_result_message.innerHTML = '';
         if (message_type !== {{ MessageType.NONE.value }}) {
-            total_result_message.innerHTML = '';
-        } else {
             if (message_type === {{ MessageType.TEXT.value }}) {
                 let text = document.createTextNode(message);
                 let pre = document.createElement('pre');
                 pre.appendChild(text);
-                $(total_result_message_collapse).show();
+                total_result_message.appendChild(pre);
             } else if (message_type === {{ MessageType.HTML.value }}) {
                 let div = document.createElement('div');
                 div.innerHTML = message;

--- a/src/static/templ/chal.html
+++ b/src/static/templ/chal.html
@@ -115,15 +115,14 @@
     function init() {
         const chal_id = "{{ chal.chal_id }}";
         const contest_id = "{{ chal.contest_id }}";
-        ws = index.get_ws("chalnewstatesub");
-        ws.onopen = function(e) {
-            ws.send(chal_id);
-        };
 
-        ws.onmessage = function(e) {
-            var chal_state_data = JSON.parse(e['data']);
+        index.register_ws_callback('chalstatesub', function(data) {
+            var chal_state_data = JSON.parse(data);
             update_state_data(chal_state_data);
-        };
+        });
+
+        // Initialize with chal_id
+        index.ws_send('chalstatesub_init', chal_id);
 
         {% if rechal == True %}
         $('#rechal').on('click', function(e) {
@@ -149,9 +148,9 @@
         $('#reject').on('click', function(e) {
             let url = '';
             {% if chal.contest_id == 0 %}
-                url = `{{ url('/be/chal/${chal_id}') }}`;
+                url = `{{ url('/be/chal/{ chal.chal_id }') }}`;
             {% else %}
-                url = `{{ url(f'/be/contests/{ chal.contest_id }/chal/${chal_id}') }}`;
+                url = `{{ url(f'/be/contests/{ chal.contest_id }/chal/{ chal.chal_id }') }}`;
             {% end %}
             let reason = prompt('Reject Reason: ');
             $.post(url, {
@@ -191,7 +190,7 @@
     }
 
     function destroy() {
-        ws.close();
+        index.ws_send('unregister', 'chalstatesub');
     }
 </script>
 

--- a/src/static/templ/challist.html
+++ b/src/static/templ/challist.html
@@ -80,7 +80,7 @@
                 });
                 // Send contest_id after registration (for backward compatibility with old handler)
                 if (index.ws && index.ws.readyState === WebSocket.OPEN) {
-                    index.ws_send('contest_subscribe', '{{ contest.contest_id }}');
+                    index.ws_send('contestnewchalsub_init', '{{ contest.contest_id }}');
                 }
             {% else %}
                 // Normal challenge list

--- a/src/static/templ/challist.html
+++ b/src/static/templ/challist.html
@@ -4,7 +4,6 @@
 <link rel="stylesheet" type="text/css" href="{{ url('/src/challist.css') }}">
 
 <script type="text/javascript">
-    var newchal_ws, newstate_ws;
     var state_map = {
         {% for state, desc in ChalConst.STATE_LONG_STR.items() %}
             {% raw f"{state}: '{desc}'," %}
@@ -73,19 +72,24 @@
             chalsub_count = 0;
 
             {% if contest %}
-                newchal_ws = index.get_ws('contests/{{ contest.contest_id }}/scoreboardsub');
-                newchal_ws.onopen = function(e) {
-                    newchal_ws.send('{{ contest.contest_id }}')
+                // Contest scoreboard uses different channel
+                index.register_ws_callback('contestnewchalsub', function(data) {
+                    chalsub_count += 1;
+                    j_chalsub.find('a').text(chalsub_count + ' new challenges');
+                    j_chalsub.show();
+                });
+                // Send contest_id after registration (for backward compatibility with old handler)
+                if (index.ws && index.ws.readyState === WebSocket.OPEN) {
+                    index.ws_send('contest_subscribe', '{{ contest.contest_id }}');
                 }
             {% else %}
-                newchal_ws = index.get_ws('challistnewchalsub');
+                // Normal challenge list
+                index.register_ws_callback('challist_sub', function(data) {
+                    chalsub_count += 1;
+                    j_chalsub.find('a').text(chalsub_count + ' new challenges');
+                    j_chalsub.show();
+                });
             {% end %}
-
-            newchal_ws.onmessage = function(e) {
-                chalsub_count += 1;
-                j_chalsub.find('a').text(chalsub_count + ' new challenges');
-                j_chalsub.show();
-            };
         })();
 
         (() => {
@@ -100,23 +104,36 @@
                 state_el.innerText = state_map[state];
             };
 
-            newstate_ws = index.get_ws('challistnewstatesub');
+            // Register callback for challenge state updates
+            index.register_ws_callback('challiststatesub', function(data) {
+                update_state(JSON.parse(data));
+            });
 
-            newstate_ws.onopen = (e) => {
+            // Send initial subscription data after WebSocket is ready
+            let send_subscription = () => {
                 let chalids = [
                     {% for chal in challist %}
                         {{ chal.chal_id }},
                     {% end %}
                 ];
-                newstate_ws.send(JSON.stringify({
-                    acct_id: '{{ user.acct_id }}',
+                index.ws_send('challiststatesub_init', JSON.stringify({
                     chalids: chalids,
                 }));
             };
 
-            newstate_ws.onmessage = (e) => {
-                update_state(JSON.parse(e['data']));
-            };
+            // If WebSocket is already open, send immediately
+            if (index.ws && index.ws.readyState === WebSocket.OPEN) {
+                send_subscription();
+            } else {
+                // Otherwise, wait for onopen
+                if (index.ws) {
+                    let original_onopen = index.ws.onopen;
+                    index.ws.onopen = function(e) {
+                        if (original_onopen) original_onopen(e);
+                        send_subscription();
+                    };
+                }
+            }
         })();
 
         {% if (flt.state == 100 or flt.state == 101) and isadmin %}
@@ -144,8 +161,15 @@
     }
 
     function destroy() {
-        newchal_ws.close();
-        newstate_ws.close();
+        // Unregister callbacks when leaving page
+        if (index.ws && index.ws.readyState === WebSocket.OPEN) {
+            {% if contest %}
+                index.ws_send('unregister', 'contestnewchalsub');
+            {% else %}
+                index.ws_send('unregister', 'challist_sub');
+            {% end %}
+            index.ws_send('unregister', 'challiststatesub');
+        }
     }
 </script>
 

--- a/src/static/templ/contests/scoreboard.html
+++ b/src/static/templ/contests/scoreboard.html
@@ -140,28 +140,22 @@ font-weight: bolder;
             update_scoreboard(timestamp);
         });
 
-        ws = index.get_ws(`contests/${contest_id}/scoreboardsub`);
-        ws.onopen = (e) => {
-            ws.send(contest_id);
+        index.register_ws_callback('contestnewchalsub', function(data) {
+            if (data == contest_id) {
+                refresh_scoreboard(-1);
+            }
+        });
 
+        // Initialize with contest_id and setup connection indicator
+        index.ws_send('contestnewchalsub_init', contest_id);
+
+        // Update connection indicator when WebSocket opens
+        if (index.ws && index.ws.readyState === WebSocket.OPEN) {
             let indicator = $("#connectIndicator");
             indicator.removeClass('bg-danger');
             indicator.addClass('bg-success');
             indicator.text("Online");
-        };
-
-        ws.onmessage = (e) => {
-            if (e.data == contest_id) {
-                refresh_scoreboard(-1);
-            }
-        };
-
-        ws.onclose = (e) => {
-            let indicator = $("#connectIndicator");
-            indicator.addClass('bg-danger');
-            indicator.removeClass('bg-success');
-            indicator.text("Offline");
-        };
+        }
 
         let cur_date = new Date();
         slider.attr('max', contest_length);
@@ -202,6 +196,9 @@ font-weight: bolder;
         timer_id = setInterval(timer, 1);
     }
 
+    function destroy() {
+        index.ws_send('unregister', 'contestnewchalsub');
+    }
 
     /**
      * @argument timestamp { number|string }

--- a/src/static/templ/index.html
+++ b/src/static/templ/index.html
@@ -40,20 +40,18 @@
       index.init();
       var j_index = $('#index-navlist');
 
-      var msg_ws = index.get_ws("informsub");
-
       var inform_count = 0;
       var on = false;
-      msg_ws.onopen = function (e) {
-      };
 
-      msg_ws.onmessage = function (e) {
+      // Register bulletin update callback
+      index.register_ws_callback('bulletinsub', function(data) {
         inform_count += 1;
         j_index.find('a.message').text('公告 *' + inform_count);
         j_index.find('a.message').show();
         on = true;
         setInterval(function () {if (on == true) {j_index.find('a.message').fadeOut(500).fadeIn(500);} }, 1000);
-      };
+      });
+
       j_index.find('a.message').on('click', function (e) {
         j_index.find('a.message').hide();
         inform_count = 0;
@@ -93,35 +91,38 @@
         {% end %}
 
         {% if contest.is_admin(user) %}
-            let ws = index.get_ws("contests/{{ contest.contest_id }}/manage/qasub");
-            let contest_ask_cnt = parseInt("{{ contest_ask_cnt }}");
-            ws.onopen = (e) => {
-                ws.send("{{ contest.contest_id }}");
-            };
-            ws.onmessage = (e) => {
-                contest_ask_cnt += 1;
-                $("#notifyRedDot").text(contest_ask_cnt);
-                $("#notifyRedDot").show();
-            };
+          // Subscribe to admin-only new-question notifications using unified WS API
+          let contest_ask_cnt = parseInt("{{ contest_ask_cnt }}");
+          index.register_ws_callback('contestnewquessub', function(data) {
+            // data is a plain string with contest_id; just increment the counter
+            contest_ask_cnt += 1;
+            $("#notifyRedDot").text(contest_ask_cnt);
+            $("#notifyRedDot").show();
+          });
+          // Initialize channel with contest id
+          index.ws_send('contestnewquessub_init', "{{ contest.contest_id }}");
         {% elif contest.is_start() %}
-            let ws = index.get_ws("contests/{{ contest.contest_id }}/qasub");
             let contest_notification_cnt = parseInt("{{ contest_notification_cnt }}");
-            ws.onopen = (e) => {
-                ws.send(JSON.stringify({
-                    contest_id: "{{ contest.contest_id }}",
-                    acct_id: "{{ user.acct_id }}",
-                }));
-            };
-            ws.onmessage = (e) => {
-                e = JSON.parse(e.data);
+            index.register_ws_callback('contestnewqasub', function(data) {
+              // server publishes JSON string for contestnewqasub; parse it
+              try {
+                let e = JSON.parse(data);
                 if (e.type == 'popup-announce') {
-                    index.show_notify_dialog(e.content, index.DIALOG_TYPE.info, e.subject);
+                  index.show_notify_dialog(e.content, index.DIALOG_TYPE.info, e.subject);
                 } else {
-                    contest_notification_cnt += 1;
-                    $("#notifyRedDot").text(contest_notification_cnt);
-                    $("#notifyRedDot").show();
+                  contest_notification_cnt += 1;
+                  $("#notifyRedDot").text(contest_notification_cnt);
+                  $("#notifyRedDot").show();
                 }
-            };
+              } catch (err) {
+                console.warn('malformed contestnewqasub payload', data);
+              }
+            });
+            // Initialize channel with contest id + acct_id
+            index.ws_send('contestnewqasub_init', JSON.stringify({
+              contest_id: "{{ contest.contest_id }}",
+              acct_id: "{{ user.acct_id }}",
+            }));
         {% end %}
     {% end %}
 
@@ -214,7 +215,7 @@
           <li class="nav-item"><a class="nav-link" style="color: #e74c3c;" href="{{ url('/question/') }}">get reply</a></li>
           {% end %}
 
-          <li><a class="nav-link" style="display: none;" href="" class="message"></a></li>
+          <li><a class="nav-link message" style="display: none;" href=""></a></li>
           <!-- <li><a class="nav-link" href="http://forum.tfcis.org/forum.php?mod=forumdisplay&fid=40" target="_new">Discuss</a></li> -->
           <li><a class="nav-link" href="https://github.com/TFcis/NTOJ/issues" target="_new">Make A Wish</a></li>
           <li class="nav-item about"><a class="nav-link" href="{{ url('/about/') }}">About</a></li>

--- a/src/static/templ/manage/info.html
+++ b/src/static/templ/manage/info.html
@@ -178,6 +178,10 @@ function formatBytes(bytes) {
                     <td>{{ info['config']['timezone'] }}</td>
                 </tr>
                 <tr>
+                    <td>Active WebSocket Connections</td>
+                    <td>{{ info['active_websocket_connections'] }}</td>
+                </tr>
+                <tr>
                     <td>Can See Code User</td>
                     <td>
                         {% if info['config']['can_see_code_user'] %}

--- a/src/static/templ/manage/judge.html
+++ b/src/static/templ/manage/judge.html
@@ -3,16 +3,16 @@
 
 <script type="text/javascript" id="contjs">
     var j_form = $('#form');
-    var ws;
+
     function init() {
-        ws = index.get_ws('manage/judgecntws');
-
-	    ws.onopen = function(e) {};
-
-	    ws.onmessage = function(e) {
-            let res = JSON.parse(e['data']);
+        index.register_ws_callback('judgechalcnt_sub', function(data) {
+            let res = JSON.parse(data);
             $(`#${res.judge_id}`).text(res.chal_cnt);
-        };
+        });
+    }
+
+    function destroy() {
+        index.ws_send('unregister', 'judgechalcnt_sub');
     }
 
     function connect_sever(idx) {

--- a/src/tests/integrated/acct.py
+++ b/src/tests/integrated/acct.py
@@ -7,6 +7,8 @@ from services.user import UserService
 from services.rate import RateService
 
 from .util import AsyncTest, AccountContext
+from tornado.websocket import websocket_connect
+from tornado.httpclient import HTTPRequest
 
 
 class SignTest(AsyncTest):
@@ -117,6 +119,24 @@ class AcctPageTest(AsyncTest):
 
         with AccountContext('test1@test', 'test') as user_session:
             pass
+
+
+    class WebSocketLogoutTest(AsyncTest):
+        async def main(self):
+            # Test that sign-out publishes logout event and closes websocket
+            with AccountContext('admin@test', 'testtest') as user_session:
+                cookie_value = user_session.cookies.get('id')
+                headers = {"Cookie": f"id={cookie_value}"}
+
+                # connect websocket with same cookie
+                ws = await websocket_connect(HTTPRequest("ws://localhost:5501/be/ws", headers=headers))
+
+                # sign out - this should publish logout event and close websocket
+                user_session.post('sign', data={"reqtype": "signout"})
+
+                # read_message should return None after the server closes the connection
+                msg = await ws.read_message()
+                self.assertIsNone(msg)
 
         # # TODO: session
         # with AccountContext('admin@test', 'testtest') as admin_session:

--- a/src/tests/integrated/bulletin.py
+++ b/src/tests/integrated/bulletin.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 from tornado.websocket import websocket_connect
@@ -50,9 +51,11 @@ class BulletinTest(AsyncTest):
             self.assertTrue(bulletin_list[1]['pinned'])
             self.assertEqual(bulletin_list[1]['color'], 'red')
 
-            # Verify WebSocket received bulletin update
-            import asyncio
-            await asyncio.sleep(0.1)
+            # Wait up to 2 seconds for a message to be received
+            for _ in range(20):
+                if received_messages:
+                    break
+                await asyncio.sleep(0.1)
             self.assertGreater(len(received_messages), 0)
             ws.close()
             self.assertEqual(bulletin_list[1]['name'], 'admin')

--- a/src/tests/integrated/bulletin.py
+++ b/src/tests/integrated/bulletin.py
@@ -1,10 +1,8 @@
-import re
+import json
 
 from tornado.websocket import websocket_connect
-from tornado.escape import xhtml_escape
 
 from services.bulletin import BulletinService
-from utils.htmlgen import markdown_escape
 
 from .util import AsyncTest, AccountContext
 
@@ -13,13 +11,16 @@ class BulletinTest(AsyncTest):
     async def main(self):
         with AccountContext('admin@test', 'testtest') as admin_session:
             # bulletin
+            received_messages = []
             def _message(msg):
                 if msg is None:
                     return
+                data = json.loads(msg)
+                if data.get('type') == 'bulletinsub':
+                    received_messages.append(int(data['data']))
 
-                self.assertEqual(int(msg), 1)
-
-            ws = await websocket_connect('ws://localhost:5501/be/informsub', on_message_callback=_message)
+            ws = await websocket_connect('ws://localhost:5501/be/ws', on_message_callback=_message)
+            await ws.write_message(json.dumps({'type': 'register', 'data': 'bulletinsub'}))
             res = admin_session.post('manage/bulletin/add', data={
                 'reqtype': 'add',
                 'title': 'bulletin 1',
@@ -48,6 +49,12 @@ class BulletinTest(AsyncTest):
             self.assertEqual(bulletin_list[1]['title'], 'bulletin 2 (pinned)')
             self.assertTrue(bulletin_list[1]['pinned'])
             self.assertEqual(bulletin_list[1]['color'], 'red')
+
+            # Verify WebSocket received bulletin update
+            import asyncio
+            await asyncio.sleep(0.1)
+            self.assertGreater(len(received_messages), 0)
+            ws.close()
             self.assertEqual(bulletin_list[1]['name'], 'admin')
             self.assertEqual(bulletin_list[1]['acct_id'], 1)
 

--- a/src/tests/integrated/chal.py
+++ b/src/tests/integrated/chal.py
@@ -1,3 +1,4 @@
+import asyncio
 from decimal import Decimal
 import json
 import shutil
@@ -190,7 +191,6 @@ class ChalListTest(AsyncTest):
             def _message(msg):
                 if msg is None:
                     return
-                import json
                 data = json.loads(msg)
                 if data.get('type') == 'challist_sub':
                     self.assertEqual(int(data['data']), 1)
@@ -202,7 +202,6 @@ class ChalListTest(AsyncTest):
             def _message2(msg):
                 if msg is None:
                     return
-                import json
                 data = json.loads(msg)
                 if data.get('type') == 'challiststatesub':
                     msg_data = json.loads(data['data'])
@@ -295,7 +294,7 @@ class ChalListTest(AsyncTest):
                 payload = json.loads(data['data'])
                 if 'total_result' in payload:
                     tr = payload['total_result']
-                    self.assertTrue(len(tr.get('ce_message', '')) > 0)
+                    self.assertGreater(len(tr.get('ce_message', '')), 0)
                     self.assertNotEqual(tr.get('message_type'), MessageType.NONE.value)
                     got_message = True
                     return
@@ -310,7 +309,6 @@ class ChalListTest(AsyncTest):
 
             await self.wait_for_judge_finish(callback3)
             ws_admin.close()
-            import asyncio
             await asyncio.sleep(1) # HACK: workaround to ensure message is processed
             self.assertTrue(got_message)
 

--- a/src/tests/integrated/chal.py
+++ b/src/tests/integrated/chal.py
@@ -3,6 +3,7 @@ import json
 import shutil
 
 from tornado.websocket import websocket_connect
+from tornado.httpclient import HTTPRequest
 
 from services.pro import ProConst, ProService
 from services.rate import RateService
@@ -44,8 +45,9 @@ class ChalTest(AsyncTest):
 
             shutil.move('code/1/main.cpp', 'code/1/main.py')
 
-            ws = await websocket_connect('ws://localhost:5501/be/chalnewstatesub')
-            await ws.write_message(str(1))
+            ws = await websocket_connect('ws://localhost:5501/be/ws')
+            await ws.write_message(json.dumps({'type': 'register', 'data': 'chalstatesub'}))
+            await ws.write_message(json.dumps({'type': 'chalstatesub_init', 'data': '1'}))
 
             def callback():
                 res = admin_session.post('submit', data={
@@ -102,6 +104,44 @@ class ChalTest(AsyncTest):
 
             await self.wait_for_judge_finish(callback)
 
+            # Test non-owner receives sanitized messages (no CE/IE or extra messages)
+            with AccountContext('test1@test', 'test') as user_session2:
+                cookie_value = user_session2.cookies.get('id')
+                headers = {"Cookie": f"id={cookie_value}"}
+
+                # Read messages from ws_user and check sanitized content
+                def _message(msg):
+                    if msg is None:
+                        return
+                    data = json.loads(msg)
+                    if data.get('type') != 'chalstatesub':
+                        return
+                    payload = json.loads(data['data'])
+                    if 'total_result' in payload:
+                        tr = payload['total_result']
+                        self.assertEqual(tr.get('ce_message', ''), '')
+                        self.assertEqual(tr.get('ie_message', ''), '')
+                        self.assertEqual(tr.get('message_type'), MessageType.NONE.value)
+                        # also check testdata results messages
+                        for td in payload.get('testdata_results', {}).values():
+                            self.assertEqual(td.get('message', ''), '')
+                            self.assertEqual(td.get('message_type'), MessageType.NONE.value)
+                        return
+
+                ws_user = await websocket_connect(HTTPRequest('ws://localhost:5501/be/ws', headers=headers), on_message_callback=_message)
+                await ws_user.write_message(json.dumps({'type': 'register', 'data': 'chalstatesub'}))
+                await ws_user.write_message(json.dumps({'type': 'chalstatesub_init', 'data': '1'}))
+
+                def callback2():
+                    res = admin_session.post('submit', data={
+                        'reqtype': 'rechal',
+                        'chal_id': 1
+                    })
+                    self.assertAPIReturnValue(res.text, ('S', 1))
+
+                await self.wait_for_judge_finish(callback2)
+                ws_user.close()
+
         await ChalService.inst.db.execute('UPDATE problem SET rate_precision = 3 WHERE pro_id=1;')
         err, pro = await ProService.inst.get_pro(1, ProConst.PRO_STATUS_FULL)
         self.assertIsNone(err)
@@ -150,24 +190,33 @@ class ChalListTest(AsyncTest):
             def _message(msg):
                 if msg is None:
                     return
+                import json
+                data = json.loads(msg)
+                if data.get('type') == 'challist_sub':
+                    self.assertEqual(int(data['data']), 1)
 
-                self.assertEqual(int(msg), 1)
-
-            await websocket_connect('ws://localhost:5501/be/challistnewchalsub',
+            ws1 = await websocket_connect('ws://localhost:5501/be/ws',
                                     on_message_callback=_message)
+            await ws1.write_message(json.dumps({'type': 'register', 'data': 'challist_sub'}))
 
-            def _message(msg):
+            def _message2(msg):
                 if msg is None:
                     return
+                import json
+                data = json.loads(msg)
+                if data.get('type') == 'challiststatesub':
+                    msg_data = json.loads(data['data'])
+                    self.assertEqual(int(msg_data['chal_id']), 2)
 
-                self.assertEqual(int(json.loads(msg)['chal_id']), 2)
-
-            ws2 = await websocket_connect('ws://localhost:5501/be/challistnewstatesub',
-                                          on_message_callback=_message)
-
+            ws2 = await websocket_connect('ws://localhost:5501/be/ws',
+                                          on_message_callback=_message2)
+            await ws2.write_message(json.dumps({'type': 'register', 'data': 'challiststatesub'}))
             await ws2.write_message(json.dumps({
-                'chalids': [1, 2],
-                'acct_id': 1,
+                'type': 'challiststatesub_init',
+                'data': json.dumps({
+                    'chalids': [1, 2],
+                    'acct_id': 1,
+                })
             }))
 
             # websocket
@@ -178,6 +227,7 @@ class ChalListTest(AsyncTest):
                 self.assertEqual(chal_id, 2)
 
             await self.wait_for_judge_finish(callback)
+            ws1.close()
             ws2.close()
 
         with AccountContext('admin@test', 'testtest') as admin_session:
@@ -229,6 +279,40 @@ class ChalListTest(AsyncTest):
             self.assertEqual([v.state for v in chal.subtask_results.values()], [ChalConst.STATE_SKIPPED] * len(chal.subtask_results))
             self.assertEqual(chal.total_result.message_type, MessageType.TEXT)
             self.assertTrue(len(chal.total_result.message) > 0)
+
+            # Admin (owner) should receive full CE messages via WS for chal 4
+            cookie_value = admin_session.cookies.get('id')
+            headers = {"Cookie": f"id={cookie_value}"}
+            got_message = False
+            # Read messages and assert owner (admin) receives non-empty messages
+            def _message2(msg):
+                nonlocal got_message
+                if msg is None:
+                    return
+                data = json.loads(msg)
+                if data.get('type') != 'chalstatesub':
+                    return
+                payload = json.loads(data['data'])
+                if 'total_result' in payload:
+                    tr = payload['total_result']
+                    self.assertTrue(len(tr.get('ce_message', '')) > 0)
+                    self.assertNotEqual(tr.get('message_type'), MessageType.NONE.value)
+                    got_message = True
+                    return
+
+            ws_admin = await websocket_connect(HTTPRequest('ws://localhost:5501/be/ws', headers=headers), on_message_callback=_message2)
+            await ws_admin.write_message(json.dumps({'type': 'register', 'data': 'chalstatesub'}))
+            await ws_admin.write_message(json.dumps({'type': 'chalstatesub_init', 'data': '4'}))
+
+            def callback3():
+                res = admin_session.post('submit', data={'reqtype': 'rechal', 'chal_id': 4})
+                self.assertAPIReturnValue(res.text, ('S', 4))
+
+            await self.wait_for_judge_finish(callback3)
+            ws_admin.close()
+            import asyncio
+            await asyncio.sleep(1) # HACK: workaround to ensure message is processed
+            self.assertTrue(got_message)
 
             flt = ChalSearchingParamBuilder().build()
             err, challist = await ChalService.inst.list_chal(0, 20, flt)

--- a/src/tests/integrated/chal.py
+++ b/src/tests/integrated/chal.py
@@ -309,7 +309,7 @@ class ChalListTest(AsyncTest):
 
             await self.wait_for_judge_finish(callback3)
             ws_admin.close()
-            await asyncio.sleep(1) # HACK: workaround to ensure message is processed
+            await asyncio.sleep(2) # HACK: workaround to ensure message is processed
             self.assertTrue(got_message)
 
             flt = ChalSearchingParamBuilder().build()

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -341,16 +341,19 @@ class ContestTest(AsyncTest):
                 })
                 self.assertAPIReturnValue(res.text, ('S', 13))
 
-            ws = await websocket_connect('ws://localhost:5501/be/manage/judgecntws')
+            ws = await websocket_connect('ws://localhost:5501/be/ws')
+            await ws.write_message(json.dumps({'type': 'register', 'data': 'judgechalcnt_sub'}))
 
             def _message(msg):
                 if msg is None:
                     return
+                data = json.loads(msg)
+                if data.get('type') == 'contestnewchalsub':
+                    self.assertEqual(int(data['data']), 1)
 
-                self.assertEqual(int(msg), 1)
-
-            ws2 = await websocket_connect('ws://localhost:5501/be/contests/1/scoreboardsub', on_message_callback=_message)
-            await ws2.write_message('1')
+            ws2 = await websocket_connect('ws://localhost:5501/be/ws', on_message_callback=_message)
+            await ws2.write_message(json.dumps({'type': 'register', 'data': 'contestnewchalsub'}))
+            await ws2.write_message(json.dumps({'type': 'contestnewchalsub_init', 'data': '1'}))
 
             with open('tests/static_file/code/toj674.ac.cpp') as f:
                 res = user_session.post('contests/1/submit', data={
@@ -374,9 +377,12 @@ class ContestTest(AsyncTest):
                 if msg is None:
                     break
 
-                if json.loads(msg)['chal_cnt'] == 0:
-                    ws.close()
-                    break
+                data = json.loads(msg)
+                if data.get('type') == 'judgechalcnt_sub':
+                    judge_data = json.loads(data['data'])
+                    if judge_data['chal_cnt'] == 0:
+                        ws.close()
+                        break
 
             # TODO: map_rate_acct
             # TODO: get_pro_ac_rate
@@ -411,12 +417,14 @@ class ContestTest(AsyncTest):
             def _message(msg):
                 if msg is None:
                     return
-
-                self.assertEqual(int(msg), 1)
-            ws = await websocket_connect('ws://localhost:5501/be/contests/1/manage/qasub', on_message_callback=_message)
+                data = json.loads(msg)
+                if data.get('type') == 'contestnewquessub':
+                    self.assertEqual(int(data['data']), 1)
+            ws = await websocket_connect('ws://localhost:5501/be/ws', on_message_callback=_message)
+            await ws.write_message(json.dumps({'type': 'register', 'data': 'contestnewquessub'}))
             await ws.write_message(json.dumps({
-                "contest_id": 1,
-                "acct_id": 4,
+                'type': 'contestnewquessub_init',
+                'data': '1'
             }))
 
             self.assertTable(
@@ -470,14 +478,20 @@ class ContestTest(AsyncTest):
                 if msg is None:
                     return
 
-                j = json.loads(msg)
-                self.assertEqual(j['contest_id'], 1)
-                self.assertEqual(j['type'], 'reply')
-                self.assertEqual(j['ask_acct_id'], 4)
-            ws = await websocket_connect('ws://localhost:5501/be/contests/1/qasub', on_message_callback=_message)
+                data = json.loads(msg)
+                if data.get('type') == 'contestnewqasub':
+                    j = json.loads(data['data'])
+                    self.assertEqual(j['contest_id'], 1)
+                    self.assertEqual(j['type'], 'reply')
+                    self.assertEqual(j['ask_acct_id'], 4)
+            ws = await websocket_connect('ws://localhost:5501/be/ws', on_message_callback=_message)
+            await ws.write_message(json.dumps({'type': 'register', 'data': 'contestnewqasub'}))
             await ws.write_message(json.dumps({
-                "contest_id": 1,
-                "acct_id": 4,
+                'type': 'contestnewqasub_init',
+                'data': json.dumps({
+                    "contest_id": 1,
+                    "acct_id": 4,
+                })
             }))
 
             res = admin_session.post('contests/1/manage/question', data={
@@ -513,14 +527,20 @@ class ContestTest(AsyncTest):
                 if msg is None:
                     return
 
-                j = json.loads(msg)
-                self.assertEqual(j['contest_id'], 1)
-                self.assertEqual(j['type'], 'add-announce')
+                data = json.loads(msg)
+                if data.get('type') == 'contestnewqasub':
+                    j = json.loads(data['data'])
+                    self.assertEqual(j['contest_id'], 1)
+                    self.assertEqual(j['type'], 'add-announce')
 
-            ws = await websocket_connect('ws://localhost:5501/be/contests/1/qasub', on_message_callback=_message)
+            ws = await websocket_connect('ws://localhost:5501/be/ws', on_message_callback=_message)
+            await ws.write_message(json.dumps({'type': 'register', 'data': 'contestnewqasub'}))
             await ws.write_message(json.dumps({
-                "contest_id": 1,
-                "acct_id": 4,
+                'type': 'contestnewqasub_init',
+                'data': json.dumps({
+                    "contest_id": 1,
+                    "acct_id": 4,
+                })
             }))
             res = admin_session.post('contests/1/manage/announce', data={
                 'reqtype': 'add-announce',
@@ -577,14 +597,20 @@ class ContestTest(AsyncTest):
                 if msg is None:
                     return
 
-                j = json.loads(msg)
-                self.assertEqual(j['contest_id'], 1)
-                self.assertEqual(j['type'], 'edit-announce')
+                data = json.loads(msg)
+                if data.get('type') == 'contestnewqasub':
+                    j = json.loads(data['data'])
+                    self.assertEqual(j['contest_id'], 1)
+                    self.assertEqual(j['type'], 'edit-announce')
 
-            ws = await websocket_connect('ws://localhost:5501/be/contests/1/qasub', on_message_callback=_message)
+            ws = await websocket_connect('ws://localhost:5501/be/ws', on_message_callback=_message)
+            await ws.write_message(json.dumps({'type': 'register', 'data': 'contestnewqasub'}))
             await ws.write_message(json.dumps({
-                "contest_id": 1,
-                "acct_id": 4,
+                'type': 'contestnewqasub_init',
+                'data': json.dumps({
+                    "contest_id": 1,
+                    "acct_id": 4,
+                })
             }))
             res = admin_session.post('contests/1/manage/announce', data={
                 'reqtype': 'edit-announce',
@@ -613,11 +639,9 @@ class ContestTest(AsyncTest):
                 self.assertEqual(j['contest_id'], 1)
                 self.assertEqual(j['type'], 'popup-announce')
 
-            ws = await websocket_connect('ws://localhost:5501/be/contests/1/qasub', on_message_callback=_message)
-            await ws.write_message(json.dumps({
-                "contest_id": 1,
-                "acct_id": 4
-            }))
+            ws = await websocket_connect('ws://localhost:5501/be/ws', on_message_callback=_message)
+            await ws.write_message(json.dumps({'type': 'register', 'data': 'contestnewqasub'}))
+            await ws.write_message(json.dumps({'type': 'contestnewqasub_init', 'data': json.dumps({"contest_id": 1, "acct_id": 4})}))
             res = admin_session.post('contests/1/manage/announce', data={
                 'reqtype': 'popup-announce',
                 'announce_id': 1,

--- a/src/tests/integrated/util.py
+++ b/src/tests/integrated/util.py
@@ -152,7 +152,8 @@ class AsyncTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("id", session.cookies.get_dict())
 
     async def wait_for_judge_finish(self, callback):
-        ws = await websocket_connect("ws://localhost:5501/be/manage/judgecntws")
+        ws = await websocket_connect("ws://localhost:5501/be/ws")
+        await ws.write_message(json.dumps({'type': 'register', 'data': 'judgechalcnt_sub'}))
 
         callback()
 
@@ -162,7 +163,11 @@ class AsyncTest(unittest.IsolatedAsyncioTestCase):
             if msg is None:
                 break
 
-            j = json.loads(msg)
+            data = json.loads(msg)
+            if data.get('type') != 'judgechalcnt_sub':
+                continue
+
+            j = json.loads(data['data'])
             judge_id = j["judge_id"]
             cnt = j["chal_cnt"]
 

--- a/src/tests/unit/test_ws_locks.py
+++ b/src/tests/unit/test_ws_locks.py
@@ -1,0 +1,67 @@
+import asyncio
+import random
+import unittest
+
+from handlers.base import UnifiedWebSocketHandler
+
+
+class DummyConn:
+    def __init__(self, id_):
+        self.id_ = id_
+        self.session_id = f"session-{id_}"
+
+
+class TestWSLocks(unittest.IsolatedAsyncioTestCase):
+    async def test_subscriptions_snapshot_no_crash(self):
+        # Prepare dummy connections
+        conns = [DummyConn(i) for i in range(10)]
+
+        async def modifier_add():
+            for i in range(200):
+                async with UnifiedWebSocketHandler._subscriptions_lock:
+                    UnifiedWebSocketHandler.subscriptions.setdefault(conns[i % 10], set()).add(
+                        f"chan-{i%5}"
+                    )
+                await asyncio.sleep(random.random() * 0.001)
+
+        async def modifier_remove():
+            for i in range(200):
+                async with UnifiedWebSocketHandler._subscriptions_lock:
+                    s = UnifiedWebSocketHandler.subscriptions.get(conns[i % 10])
+                    if s:
+                        s.discard(f"chan-{i%5}")
+                await asyncio.sleep(random.random() * 0.001)
+
+        async def snapshotter():
+            # repeat snapshot and iterate - should not crash with concurrent mods
+            for _ in range(1000):
+                async with UnifiedWebSocketHandler._subscriptions_lock:
+                    snapshot = list(UnifiedWebSocketHandler.subscriptions.items())
+                # iterate outside lock to simulate real dispatching code
+                for conn, types in snapshot:
+                    # simply read and touch item
+                    if types:
+                        max_len = max((len(types), 0))
+                await asyncio.sleep(random.random() * 0.001)
+
+        await asyncio.gather(modifier_add(), modifier_remove(), snapshotter())
+
+    async def test_register_channel_callbacks_concurrent(self):
+        # Register many callbacks concurrently
+        def dummy_cb():
+            pass
+
+        async def reg(i):
+            UnifiedWebSocketHandler.register_channel_callback(f"chan-{i}", dummy_cb)
+            await asyncio.sleep(random.random() * 0.001)
+
+        tasks = [asyncio.create_task(reg(i)) for i in range(50)]
+        await asyncio.gather(*tasks)
+
+        # ensure keys present (note: registration may be scheduled async to subscribe)
+        async with UnifiedWebSocketHandler._channel_callbacks_lock:
+            for i in range(50):
+                self.assertIn(f"chan-{i}", UnifiedWebSocketHandler._channel_callbacks)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/url.py
+++ b/src/url.py
@@ -1,14 +1,12 @@
 import tornado.web
 
 from handlers.acct import AcctConfigHandler, AcctHandler, AcctProClassHandler, SignHandler
+from handlers.base import UnifiedWebSocketHandler
 from handlers.board import BoardHandler
-from handlers.bulletin import BulletinHandler, BulletinSub
+from handlers.bulletin import BulletinHandler
 from handlers.chal import (
     ChalHandler,
     ChalListHandler,
-    ChalListNewChalHandler,
-    ChalListNewStateHandler,
-    ChalNewStateHandler,
 )
 from handlers.code import CodeHandler
 from handlers.contests.url import get_contests_url
@@ -34,7 +32,10 @@ def get_url(db, rs, pool):
         'rs': rs,
     }
 
-    sub_args = {'pool': pool}
+    unified_ws_args = {
+        'db': db,
+        'pool': pool,
+    }
 
     return [
         (r'/be/info', BulletinHandler, args),
@@ -53,9 +54,7 @@ def get_url(db, rs, pool):
         (r'/be/submit', SubmitHandler, args),
         (r'/be/chal/(\d+)', ChalHandler, args),
         (r'/be/chal', ChalListHandler, args),
-        (r'/be/challistnewchalsub', ChalListNewChalHandler, sub_args),
-        (r'/be/challistnewstatesub', ChalListNewStateHandler, sub_args),
-        (r'/be/chalnewstatesub', ChalNewStateHandler, sub_args),
+        (r'/be/ws', UnifiedWebSocketHandler, unified_ws_args),
         (r'/be/pack', PackHandler, args),
         (r'/be/about', AbouotHandler, args),
         (r'/be/question', QuestionHandler, args),
@@ -65,7 +64,6 @@ def get_url(db, rs, pool):
         (r'/be/rank/(\d+)', ProRankHandler, args),
         (r'/be/users', UserRankHandler, args),
         (r'/be/code', CodeHandler, args),
-        (r'/be/informsub', BulletinSub, sub_args),
         (r'/be/dev-info', DevInfoHandler, args),
         (r'/be/report', ReportHandler, args),
 


### PR DESCRIPTION
# Refactor WebSocket: unify handlers, centralize pubsub, and add client API

## Summary
Consolidate multiple WebSocket endpoints into a single `/be/ws` UnifiedWebSocketHandler and migrate channel-specific logic into per-channel callback classes. Update frontend templates and `index.js` to use a unified client API (`register_ws_callback` / `ws_send`) with pending message queueing. Centralize Redis pubsub usage, add a logout pubsub channel, and implement permission-aware sanitization to prevent leaks.

## What was changed (high level)
- Introduce `UnifiedWebSocketHandler` in `src/handlers/base.py`:
  - Single shared Redis pubsub listener for all WebSocket channels
  - Register/unregister flow for message types
  - Background message dispatch with callback interface
  - Ping/pong health checks and session logout handling
- Migrate logic from previous endpoint-specific websocket handlers into channel callback classes:
  - `src/handlers/chal.py`: `ChalListCallback`, `ChalListStateCallback`, `ChalStateCallback`
  - `src/handlers/contests/qa.py`, `src/handlers/contests/manage/qa.py`, `src/handlers/bulletin.py`, `src/handlers/manage/judge.py`, `src/handlers/contests/scoreboard.py`, etc.
- Client API improvements (`src/static/index.js`):
  - `index.ws_init('ws')` for a single connection
  - `index.register_ws_callback(type, cb)` for registering client-side handlers
  - `index.ws_send(type, data)` for sending message or init/unregister actions
  - Queued `ws_pending_registers` and `ws_pending_messages` flushed on `onopen`
- Update templates to use the new client API:
  - `src/static/templ/index.html`, `chal.html`, `challist.html`, `manage/judge.html`, `contests/scoreboard.html`, `manage/info.html`, etc.
  - Replace raw `get_ws()` usage with `register_ws_callback` + `ws_send('..._init', ...)`
  - Added `destroy()` logic to `unregister` where applicable
- Routing:
  - Add `/be/ws` (UnifiedWebSocketHandler) and remove legacy per-channel websocket routes
  - Update `src/url.py` to add unified route and remove old handlers
- Security, sanitization, permissions:
  - `ChalStateCallback` and `ChalListStateCallback` sanitize CE/IE/test data for non-owner and non-admin viewers
  - Channel callbacks perform per-connection initialization checks and permission lookups (via `UserService`)
- Logout behavior:
  - Added a `_LOGOUT_EVENT_CHANNEL` to close WS connections for signed-out sessions
  - `SignHandler/AcctConfigHandler` publishes session keys to logout channel on logout event
- Tests:
  - Updated integration tests to use register/init flow with unified ws; updated cookie handling for ws tests
  - Add tests for owner/admin/sanitized message behavior and logout pubsub

## Why this change
- Maintainability: Consolidates duplicated code and removes multiple WebSocket implementations, making it easier to reason about message dispatch and permissions.
- Performance: Reduces the number of Redis pub/sub connections by using a shared pubsub, lowering resource usage and improving stability under high concurrency.
- Security: Centralizes permission checks and sanitization to block sensitive details from being leaked to non-authorized users.
- Reliability & UX: Client-side queueing ensures registration and messages are not lost during reconnections; callback API is more straightforward and flexible.

## Notable Implementation Details
- Channel callback interface: `register(conn)`, `message(conn, data)`, `unregister(conn)`, and optional `handle_custom_message(conn, msg_type, msg_data)`.
- `UnifiedWebSocketHandler._listen_redis_messages()` listens and distributes messages because a single shared pubsub is more efficient.
- Per-connection state is kept in callback objects to reduce per-message DB queries (using `init` message to prefetch chal/contest state).
- The `index.js` API changes are backward-incompatible for any direct raw websocket usage: external scripts must be updated to use `register_ws_callback` + `ws_send`.
- `conn.acct_id` and `conn.session_id` are used for permission checks; callbacks call `UserService` as needed.

## Migration Notes / Backwards Compatibility
- Any scripts or external clients using the previous per-endpoint websocket URLs must migrate to `ws://<host>/be/ws` and send a `register` message before expecting channel messages.
- Frontend template code that used raw WebSocket creation has been updated in templates; make sure custom JS is updated similarly.

## Testing & Validation
- Manual test cases:
  - Login as different users (admin / owner / non-owner) to ensure permission-based visibility and message sanitization works.
  - Test Q&A flow: contestant ask -> admin receives `contestnewquessub`; reply is published through `contestnewqasub` and only the ask owner receives reply messages.
  - Test challenge owner vs non-owner message behavior with CE/IE/testdata messages.
  - Test logout to verify that connections for a session key get closed.
- Unit/integration:
  - Run existing integration tests (modified to `UnifiedWebSocketHandler`).
  - Add explicit tests for logout channel behavior, `chalstatesub` message sanitization, and `challiststatesub_init` initialization.

## Follow-ups / Next Steps
- Add more automated tests around contest phases (before/during/after) to validate permission and visibility rules.
- Consider telemetry/metrics for `UnifiedWebSocketHandler` to monitor active connections and message distribution performance.
---

## Files / Areas of interest (non-exhaustive)
- Major Server changes:
  - `src/handlers/base.py` — `UnifiedWebSocketHandler` addition
  - `src/handlers/chal.py` — challenge callbacks & routing changes
  - `src/handlers/contests/qa.py`, `src/handlers/contests/manage/qa.py`, `src/handlers/manage/judge.py`,
  - `src/handlers/bulletin.py`, `src/handlers/contests/scoreboard.py`
- Major Client changes:
  - `src/static/index.js` — new client api & pending queues
  - Templates updated: `src/static/templ/index.html`, `chal.html`, `challist.html`, `scoreboard.html`, `manage/judge.html`, `manage/info.html`, etc.
- Routing:
  - `src/url.py` — add `/be/ws`, remove old WebSocket routes
---