### PR TITLE
fix(contest): off-by-one error when removing problem

### DIFF
--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -285,7 +285,7 @@ class ContestService:
                         failed.append(pro_id)
                         continue
 
-                await con.execute('DELETE FROM contest_problem_joints WHERE contest_id = $1 AND "order" > $2', contest.contest_id, order)
+                await con.execute('DELETE FROM contest_problem_joints WHERE contest_id = $1 AND "order" >= $2', contest.contest_id, order)
                 for failed_pro_id in failed:
                     contest.pro_list.pop(failed_pro_id)
 


### PR DESCRIPTION
## Description
If the user removes some problems from the contest, the problem whose order equals the problem count after removal won't be deleted from the database. 
For example, if I remove all problems from the contest, the problem with order 0, which is the first problem, won't be deleted.
This is caused by the use of greater-than comparison in the delete problem command, so I change it to the greater-than-or-equal to solve this bug.