### PR TITLE
Add feature to manage random-set contest

### DIFF
--- a/migration/20260102144900_add_random_set.py
+++ b/migration/20260102144900_add_random_set.py
@@ -1,0 +1,15 @@
+import json
+
+async def dochange(db, rs):
+    await db.execute("ALTER TABLE contest ADD COLUMN start_ip character varying(64) DEFAULT '0.0.0.0';")
+    await db.execute("ALTER TABLE contest ADD COLUMN end_ip character varying(64) DEFAULT '0.0.0.0';")
+
+    await db.execute(
+    '''
+        CREATE TABLE contest_ip_joints (
+            contest_id integer NOT NULL,
+            ip character varying(64) NOT NULL,
+            pro_id integer NOT NULL
+        );
+    '''
+    )

--- a/migration/20260102144900_add_random_set.py
+++ b/migration/20260102144900_add_random_set.py
@@ -13,3 +13,17 @@ async def dochange(db, rs):
         );
     '''
     )
+
+    await db.execute(
+    '''
+        ALTER TABLE ONLY contest_ip_joints ADD CONSTRAINT contest_problem_joints_forkey_contest_id
+            FOREIGN KEY (contest_id) REFERENCES contest(contest_id) ON DELETE CASCADE;
+    '''
+    )
+
+    await db.execute(
+    '''
+        ALTER TABLE ONLY contest_ip_joints ADD CONSTRAINT contest_problem_joints_forkey_pro_id
+            FOREIGN KEY (pro_id) REFERENCES problem(pro_id) ON DELETE CASCADE;
+    '''
+    )

--- a/src/handlers/contests/manage/acct.py
+++ b/src/handlers/contests/manage/acct.py
@@ -161,7 +161,7 @@ class ContestManageAcctHandler(RequestHandler):
             return self.error(("Eparam", "Invalid IP address format."))
 
         if start_ip > end_ip:
-            return ('Eparam', 'Invalid IP range'), None
+            return self.error(('Eparam', 'Invalid IP range'))
 
         self.contest.start_ip = start_ip
         self.contest.end_ip = end_ip

--- a/src/handlers/contests/manage/acct.py
+++ b/src/handlers/contests/manage/acct.py
@@ -28,8 +28,8 @@ class ContestManageAcctHandler(RequestHandler):
             contest_id=self.contest.contest_id,
             acct_list=acct_list,
             admin_list=admin_list,
-            start_ip=str(self.contest.ip_range[0]),
-            end_ip=str(self.contest.ip_range[1])
+            start_ip=str(self.contest.start_ip),
+            end_ip=str(self.contest.end_ip)
         )
 
     @contest_manage_acct_dispatcher.action("add")
@@ -163,7 +163,8 @@ class ContestManageAcctHandler(RequestHandler):
         if start_ip > end_ip:
             return ('Eparam', 'Invalid IP range'), None
 
-        self.contest.ip_range = (start_ip, end_ip)
+        self.contest.start_ip = start_ip
+        self.contest.end_ip = end_ip
         await ContestService.inst.update_contest(
             self.acct, self.contest
         )

--- a/src/handlers/contests/manage/acct.py
+++ b/src/handlers/contests/manage/acct.py
@@ -4,6 +4,8 @@ from services.contests import ContestService, UserStatus
 from services.user import UserService
 from utils.numeric import parse_str_to_list
 
+from ipaddress import IPv4Address, AddressValueError
+
 contest_manage_acct_dispatcher = ActionDispatcher()
 
 
@@ -26,6 +28,8 @@ class ContestManageAcctHandler(RequestHandler):
             contest_id=self.contest.contest_id,
             acct_list=acct_list,
             admin_list=admin_list,
+            start_ip=str(self.contest.ip_range[0]),
+            end_ip=str(self.contest.ip_range[1])
         )
 
     @contest_manage_acct_dispatcher.action("add")
@@ -143,6 +147,29 @@ class ContestManageAcctHandler(RequestHandler):
 
         return self.error(
             ("S", f"Accounts(#{acct_list} successfully removed from user list.")
+        )
+
+    @contest_manage_acct_dispatcher.action("update_ip")
+    async def update_ip_action(self):
+        start_ip = self.get_argument("start_ip")
+        end_ip = self.get_argument("end_ip")
+
+        try:
+            start_ip = IPv4Address(start_ip)
+            end_ip = IPv4Address(end_ip)
+        except AddressValueError:
+            return self.error(("Eparam", "Invalid IP address format."))
+
+        if start_ip > end_ip:
+            return ('Eparam', 'Invalid IP range'), None
+
+        self.contest.ip_range = (start_ip, end_ip)
+        await ContestService.inst.update_contest(
+            self.acct, self.contest
+        )
+
+        return self.error(
+            ("S", f"Contest IP range successfully updated.")
         )
 
     @reqenv

--- a/src/handlers/contests/manage/acct.py
+++ b/src/handlers/contests/manage/acct.py
@@ -165,8 +165,8 @@ class ContestManageAcctHandler(RequestHandler):
 
         self.contest.start_ip = start_ip
         self.contest.end_ip = end_ip
-        await ContestService.inst.update_contest(
-            self.acct, self.contest
+        await ContestService.inst.update_ip(
+            self.contest
         )
 
         return self.error(

--- a/src/handlers/contests/manage/general.py
+++ b/src/handlers/contests/manage/general.py
@@ -90,6 +90,10 @@ class ContestManageGeneralHandler(RequestHandler):
         if err:
             return self.error(err)
 
+        if contest_mode != self.contest.contest_mode and ContestMode.RANDOM_SET in (contest_mode, self.contest.contest_mode):
+            if len(self.contest.pro_list) != 0:
+                return self.error(('Echmod', 'Cannot change contest mode when problem list is not empty'))
+
         self.contest.name = name
 
         self.contest.contest_mode = contest_mode

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -3,7 +3,7 @@ import asyncio
 from handlers.base import reqenv, RequestHandler, ActionDispatcher
 from handlers.contests.base import contest_require_permission
 from services.chal import ChalConst, ChalService
-from services.contests import ContestService, ProblemScoreType
+from services.contests import ContestService, ProblemScoreType, ContestMode
 from services.judge import JudgeServerClusterService
 from services.pro import ProService, ProConst
 from utils.numeric import parse_str_to_list
@@ -24,13 +24,22 @@ class ContestManageProHandler(RequestHandler):
                 continue
             pro_list.append(pro)
 
-        await self.render(
-            "contests/manage/pro",
-            page="pro",
-            contest_id=self.contest.contest_id,
-            contest=self.contest,
-            pro_list=pro_list,
-        )
+        if self.contest.contest_mode == ContestMode.RANDOM_SET:
+            await self.render(
+                "contests/manage/rand-pro",
+                page="pro",
+                contest_id=self.contest.contest_id,
+                contest=self.contest,
+                pro_sets=self.contest.pro_sets
+            )
+        else:
+            await self.render(
+                "contests/manage/pro",
+                page="pro",
+                contest_id=self.contest.contest_id,
+                contest=self.contest,
+                pro_list=pro_list,
+            )
 
     @contest_manage_pro_dispatcher.action("add")
     async def add_action(self):
@@ -167,6 +176,71 @@ class ContestManageProHandler(RequestHandler):
 
         pro.status = ProConst.STATUS_ONLINE
         err, _ = await ProService.inst.update_pro(pro)
+        if err:
+            return self.error(err)
+
+        return self.error(("S", ""))
+
+    @contest_manage_pro_dispatcher.action("add_set")
+    async def add_set_action(self):
+        '''
+            Add a problem set in random set mode
+            pro_id should be a list of problem ids separated by comma
+        '''
+        if self.contest.contest_mode != ContestMode.RANDOM_SET:
+            return ('Emod', 'Cannot add problem set to non-random set contests'), None
+
+        pro_ids = self.get_argument("pro_id")
+        pro_ids = parse_str_to_list(pro_ids)
+
+        if len(pro_ids) < 1:
+            return ('Eparam', 'Problem set must contain at least one problem'), None
+
+        pro_set = [(pro_id, ProblemScoreType.IOI2017) for pro_id in pro_ids]
+
+        err, _ = await ContestService.inst.add_pro_set(self.contest, pro_set)
+        if err:
+            return self.error(err)
+
+        return self.error(("S", ""))
+
+    @contest_manage_pro_dispatcher.action("remove_set")
+    async def remove_set_action(self):
+        '''
+            Remove a problem set in random set mode
+            pro_id is the problem set index 
+        '''
+        if self.contest.contest_mode != ContestMode.RANDOM_SET:
+            return ('Emod', 'Cannot remove problem set from non-random set contests'), None
+
+        pro_set_idx = int(self.get_argument("pro_id"))
+        if pro_set_idx < 0 or pro_set_idx > len(self.contest.pro_sets) - 1:
+            return ('Eparam', 'Problem set index out of range'), None
+
+        err, _ = await ContestService.inst.remove_pro_set(self.contest, pro_set_idx)
+        if err:
+            return self.error(err)
+
+        return self.error(("S", ""))
+
+    @contest_manage_pro_dispatcher.action("update_order")
+    async def update_order_action(self):
+        '''
+            Update problem order in random set mode
+            pro_id is a comma separated list of new problem set indices
+        '''
+        if self.contest.contest_mode != ContestMode.RANDOM_SET:
+            return ('Emod', 'Cannot update problem order in non-random set contests'), None
+
+        new_idxs = self.get_argument("pro_id")
+        new_idxs = parse_str_to_list(new_idxs)
+
+        pro_set_len = len(self.contest.pro_sets)
+
+        if len(new_idxs) != pro_set_len or sorted(new_idxs) != list(range(pro_set_len)):
+            return ('Eparam', 'Invalid new indexes for problem sets'), None
+
+        err, _ = await ContestService.inst.reorder_pro_set(self.contest, new_idxs)
         if err:
             return self.error(err)
 

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -43,6 +43,9 @@ class ContestManageProHandler(RequestHandler):
 
     @contest_manage_pro_dispatcher.action("add")
     async def add_action(self):
+        if self.contest.contest_mode == ContestMode.RANDOM_SET:
+            return self.error(('Emod', 'Cannot add individual problems to random set contests'))
+
         pro_id = int(self.get_argument("pro_id"))
 
         if self.contest.is_pro(pro_id):
@@ -60,6 +63,9 @@ class ContestManageProHandler(RequestHandler):
 
     @contest_manage_pro_dispatcher.action("remove")
     async def remove_action(self):
+        if self.contest.contest_mode == ContestMode.RANDOM_SET:
+            return self.error(('Emod', 'Cannot add individual problems to random set contests'))
+
         pro_id = int(self.get_argument("pro_id"))
 
         if not self.contest.is_pro(pro_id):
@@ -77,6 +83,9 @@ class ContestManageProHandler(RequestHandler):
 
     @contest_manage_pro_dispatcher.action("multi_add")
     async def multi_add_action(self):
+        if self.contest.contest_mode == ContestMode.RANDOM_SET:
+            return self.error(('Emod', 'Cannot add individual problems to random set contests'))
+
         pro_id = self.get_argument("pro_id")
         pro_id = parse_str_to_list(pro_id)
         for p_id in pro_id:
@@ -92,6 +101,9 @@ class ContestManageProHandler(RequestHandler):
 
     @contest_manage_pro_dispatcher.action("multi_remove")
     async def multi_remove_action(self):
+        if self.contest.contest_mode == ContestMode.RANDOM_SET:
+            return self.error(('Emod', 'Cannot add individual problems to random set contests'))
+
         pro_id = self.get_argument("pro_id")
         pro_list = parse_str_to_list(pro_id)
 

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -44,7 +44,7 @@ class ContestManageProHandler(RequestHandler):
     @contest_manage_pro_dispatcher.action("add")
     async def add_action(self):
         if self.contest.contest_mode == ContestMode.RANDOM_SET:
-            return self.error(('Emod', 'Cannot add individual problems to random set contests'))
+            return self.error(('Emod', 'Cannot add problems to random set contests'))
 
         pro_id = int(self.get_argument("pro_id"))
 
@@ -64,7 +64,7 @@ class ContestManageProHandler(RequestHandler):
     @contest_manage_pro_dispatcher.action("remove")
     async def remove_action(self):
         if self.contest.contest_mode == ContestMode.RANDOM_SET:
-            return self.error(('Emod', 'Cannot add individual problems to random set contests'))
+            return self.error(('Emod', 'Cannot remove problems from random set contests'))
 
         pro_id = int(self.get_argument("pro_id"))
 
@@ -84,7 +84,7 @@ class ContestManageProHandler(RequestHandler):
     @contest_manage_pro_dispatcher.action("multi_add")
     async def multi_add_action(self):
         if self.contest.contest_mode == ContestMode.RANDOM_SET:
-            return self.error(('Emod', 'Cannot add individual problems to random set contests'))
+            return self.error(('Emod', 'Cannot add problems to random set contests'))
 
         pro_id = self.get_argument("pro_id")
         pro_id = parse_str_to_list(pro_id)
@@ -102,7 +102,7 @@ class ContestManageProHandler(RequestHandler):
     @contest_manage_pro_dispatcher.action("multi_remove")
     async def multi_remove_action(self):
         if self.contest.contest_mode == ContestMode.RANDOM_SET:
-            return self.error(('Emod', 'Cannot add individual problems to random set contests'))
+            return self.error(('Emod', 'Cannot remove problems from random set contests'))
 
         pro_id = self.get_argument("pro_id")
         pro_list = parse_str_to_list(pro_id)

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -214,13 +214,13 @@ class ContestManageProHandler(RequestHandler):
         if err:
             return self.error(err)
 
-        return self.error(("S", ""))
+        return self.error(("S", "Add new problem set successfully"))
 
     @contest_manage_pro_dispatcher.action("remove_set")
     async def remove_set_action(self):
         '''
             Remove a problem set in random set mode
-            pro_id is the problem set index 
+            pro_id is the problem set index
         '''
         if self.contest.contest_mode != ContestMode.RANDOM_SET:
             return self.error(('Emod', 'Cannot remove problem set from non-random set contests'))
@@ -233,7 +233,7 @@ class ContestManageProHandler(RequestHandler):
         if err:
             return self.error(err)
 
-        return self.error(("S", ""))
+        return self.error(("S", f"Remove problem set #{pro_set_idx} successfully"))
 
     @contest_manage_pro_dispatcher.action("update_order")
     async def update_order_action(self):
@@ -256,7 +256,7 @@ class ContestManageProHandler(RequestHandler):
         if err:
             return self.error(err)
 
-        return self.error(("S", ""))
+        return self.error(("S", f"Update problem set order successfully"))
 
     @reqenv
     @contest_require_permission("admin")

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -188,13 +188,13 @@ class ContestManageProHandler(RequestHandler):
             pro_id should be a list of problem ids separated by comma
         '''
         if self.contest.contest_mode != ContestMode.RANDOM_SET:
-            return ('Emod', 'Cannot add problem set to non-random set contests'), None
+            return self.error(('Emod', 'Cannot add problem set to non-random set contests'))
 
         pro_ids = self.get_argument("pro_id")
         pro_ids = parse_str_to_list(pro_ids)
 
         if len(pro_ids) < 1:
-            return ('Eparam', 'Problem set must contain at least one problem'), None
+            return self.error(('Eparam', 'Problem set must contain at least one problem'))
 
         pro_set = [(pro_id, ProblemScoreType.IOI2017) for pro_id in pro_ids]
 
@@ -211,11 +211,11 @@ class ContestManageProHandler(RequestHandler):
             pro_id is the problem set index 
         '''
         if self.contest.contest_mode != ContestMode.RANDOM_SET:
-            return ('Emod', 'Cannot remove problem set from non-random set contests'), None
+            return self.error(('Emod', 'Cannot remove problem set from non-random set contests'))
 
         pro_set_idx = int(self.get_argument("pro_id"))
         if pro_set_idx < 0 or pro_set_idx > len(self.contest.pro_sets) - 1:
-            return ('Eparam', 'Problem set index out of range'), None
+            return self.error(('Eparam', 'Problem set index out of range'))
 
         err, _ = await ContestService.inst.remove_pro_set(self.contest, pro_set_idx)
         if err:
@@ -230,7 +230,7 @@ class ContestManageProHandler(RequestHandler):
             pro_id is a comma separated list of new problem set indices
         '''
         if self.contest.contest_mode != ContestMode.RANDOM_SET:
-            return ('Emod', 'Cannot update problem order in non-random set contests'), None
+            return self.error(('Emod', 'Cannot update problem order in non-random set contests'))
 
         new_idxs = self.get_argument("pro_id")
         new_idxs = parse_str_to_list(new_idxs)
@@ -238,7 +238,7 @@ class ContestManageProHandler(RequestHandler):
         pro_set_len = len(self.contest.pro_sets)
 
         if len(new_idxs) != pro_set_len or sorted(new_idxs) != list(range(pro_set_len)):
-            return ('Eparam', 'Invalid new indexes for problem sets'), None
+            return self.error(('Eparam', 'Invalid new indexes for problem sets'))
 
         err, _ = await ContestService.inst.reorder_pro_set(self.contest, new_idxs)
         if err:

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -166,7 +166,7 @@ class ContestService:
                 contest.start_ip = IPv4Address(result['start_ip'])
                 contest.end_ip = IPv4Address(result['end_ip'])
 
-                result = await con.fetch('SELECT pro_id, score_type, order FROM contest_problem_joints WHERE contest_id = $1 ORDER BY "order";', contest_id)
+                result = await con.fetch('SELECT "pro_id", "score_type", "order" FROM contest_problem_joints WHERE contest_id = $1 ORDER BY "order";', contest_id)
                 for pro_id, score_type, order in result:
                     contest.pro_list[pro_id] = {
                         "score_type": ProblemScoreType(int(score_type)),

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -409,7 +409,7 @@ class ContestService:
             }
 
         await self.add_random_pro(contest, [pro_id for pro_id, _ in pro_set])
-        self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
+        await self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
         return None, None
 
     async def add_random_pro(self, contest: Contest, pro_set: list[int]):
@@ -448,7 +448,7 @@ class ContestService:
         remove_pro_ids = contest.pro_sets.pop(pro_set_idx)
         for pro_id in remove_pro_ids:
             contest.pro_list.pop(pro_id)
-        self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
+        await self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
 
         async with self.db.acquire() as con:
             # Remove problems from contest_problem_joints
@@ -485,7 +485,7 @@ class ContestService:
         for ip in contest.ip_pro_list:
             contest.ip_pro_list[ip] = [contest.ip_pro_list[ip][i] for i in new_idxs]
 
-        self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
+        await self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
 
         async with self.db.acquire() as con:
             # Update contest_problem_joints

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -54,7 +54,7 @@ class Contest:
     pro_list: dict[int, dict] = field(default_factory=dict)
     pro_sets: list[list[int]] = field(default_factory=list)
     ip_pro_list: dict[IPv4Address, list[int]] = field(default_factory=dict)
-    ip_range: tuple[IPv4Address, IPv4Address] | None = None
+    ip_range: tuple[IPv4Address, IPv4Address] = None
 
     reg_mode: RegMode
     reg_end: datetime.datetime

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -267,15 +267,6 @@ class ContestService:
     async def update_contest(self, acct: Account, contest: Contest, prolist_updated=False, userlist_updated=False):
         # update db
         async with self.db.acquire() as con:
-
-            result = await con.fetch('SELECT "contest_mode" FROM "contest" WHERE "contest_id" = $1;', contest.contest_id)
-            if len(result) != 1:
-                return ('Enoext', 'Contest not found'), None
-            old_contest_mode = ContestMode(int(result[0]['contest_mode']))
-            if old_contest_mode != contest.contest_mode and ContestMode.RANDOM_SET in (old_contest_mode, contest.contest_mode):
-                if len(contest.pro_list) != 0:
-                    return ('Echmod', 'Cannot change contest mode when problem list is not empty'), None
-
             result = await con.fetch(
                 '''
                     UPDATE "contest"

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -368,10 +368,14 @@ class ContestService:
             return None, None
 
         # Clear existting ip
+        contest.ip_pro_list.clear()
         async with self.db.acquire() as con:
             await con.execute('DELETE FROM contest_ip_joints WHERE contest_id = $1;', contest.contest_id)
 
         # Readd IPs
+        for ip_int in range(int(contest.ip_range[0]), int(contest.ip_range[1]) + 1):
+            ip = IPv4Address(ip_int)
+            contest.ip_pro_list[ip] = []
         for tmp_pro_set in contest.pro_sets:
             pro_set = [(pro_id, contest.pro_list[pro_id]['score_type']) for pro_id in tmp_pro_set]
             await self.add_pro_set(contest, pro_set)
@@ -384,7 +388,14 @@ class ContestService:
                 return ('Eexist', f'Problem {pro_id} already in contest'), None
             contest.pro_list[pro_id] = {} # Add dummy dict for avoiding repeated problem id
 
-        pro_order = len(contest.pro_sets)
+        contest.pro_sets.append([pro_id for pro_id, _ in pro_set])
+
+        pro_order = len(next(iter(contest.ip_pro_list.values()), []))
+        for pro_id, score_type in pro_set:
+            contest.pro_list[pro_id] = {
+                "score_type": score_type,
+                "order": pro_order
+            }
 
         pro_size = len(pro_set)
         if pro_size == 1:
@@ -420,7 +431,15 @@ class ContestService:
         return None, None
 
     async def remove_pro_set(self, contest: Contest , pro_set_idx: int):
+        for pro_list in contest.ip_pro_list.values():
+            pro_list.pop(pro_set_idx)
+
         remove_pro_ids = contest.pro_sets.pop(pro_set_idx)
+        for pro_id in remove_pro_ids:
+            contest.pro_list.pop(pro_id)
+        for pro_id in contest.pro_list:
+            if contest.pro_list[pro_id]['order'] > pro_set_idx:
+                contest.pro_list[pro_id]['order'] -= 1
 
         async with self.db.acquire() as con:
             # Remove problems from contest_problem_joints
@@ -453,6 +472,13 @@ class ContestService:
     async def reorder_pro_set(self, contest: Contest, new_idxs: list[int]):
         # Reorder pro_sets
         contest.pro_sets = [contest.pro_sets[i] for i in new_idxs]
+        # Reorder pro_list order
+        for order, pro_ids in enumerate(contest.pro_sets):
+            for pro_id in pro_ids:
+                contest.pro_list[pro_id]['order'] = order
+        # Reorder ip_pro_list
+        for ip in contest.ip_pro_list:
+            contest.ip_pro_list[ip] = [contest.ip_pro_list[ip][i] for i in new_idxs]
 
         async with self.db.acquire() as con:
             # Update contest_problem_joints

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -371,9 +371,8 @@ class ContestService:
         for ip_int in range(int(contest.start_ip), int(contest.end_ip) + 1):
             ip = IPv4Address(ip_int)
             contest.ip_pro_list[ip] = []
-        for tmp_pro_set in contest.pro_sets:
-            pro_set = [(pro_id, contest.pro_list[pro_id]['score_type']) for pro_id in tmp_pro_set]
-            await self.add_pro_set(contest, pro_set)
+        for pro_set in contest.pro_sets:
+            await self.add_random_pro(contest, pro_set)
 
         await self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
 
@@ -392,19 +391,7 @@ class ContestService:
                 "score_type": score_type,
             }
 
-        pro_size = len(pro_set)
-        if pro_size == 1:
-            for pro_list in contest.ip_pro_list.values():
-                pro_list.append(pro_set[0][0])
-        elif pro_size == 2:
-            for pro_list in contest.ip_pro_list.values():
-                pro_list.append(pro_set[random.randint(0, 1)][0])
-        else:
-            init = 0
-            for pro_list in contest.ip_pro_list.values():
-                init = (init + random.randint(1,pro_size-1)) % pro_size
-                pro_list.append(pro_set[init][0])
-
+        await self.add_random_pro(contest, [pro_id for pro_id, _ in pro_set])
         self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
 
         pro_order = len(contest.pro_sets) - 1
@@ -417,6 +404,27 @@ class ContestService:
                 ''',
                 [(contest.contest_id, pro_id, int(score_type), pro_order) for pro_id, score_type in pro_set]
             )
+
+        return None, None
+
+    async def add_random_pro(self, contest: Contest, pro_set: list[int]):
+        '''
+            Append a random problem in pro_set to each ip's problem list
+        '''
+        pro_size = len(pro_set)
+        if pro_size == 1:
+            for pro_list in contest.ip_pro_list.values():
+                pro_list.append(pro_set[0])
+        elif pro_size == 2:
+            for pro_list in contest.ip_pro_list.values():
+                pro_list.append(pro_set[random.randint(0, 1)])
+        else:
+            idx = 0
+            for pro_list in contest.ip_pro_list.values():
+                idx = (idx + random.randint(1,pro_size-1)) % pro_size
+                pro_list.append(pro_set[idx])
+
+        async with self.db.acquire() as con:
             # Insert por_id into contest_ip_joints
             await con.executemany(
                 '''
@@ -426,7 +434,7 @@ class ContestService:
                 [(contest.contest_id, str(ip), pro_list[-1]) for ip, pro_list in contest.ip_pro_list.items()]
             )
 
-        return None, None
+
 
     async def remove_pro_set(self, contest: Contest , pro_set_idx: int):
         for pro_list in contest.ip_pro_list.values():

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -383,6 +383,7 @@ class ContestService:
         for pro_id, _ in pro_set:
             if pro_id in contest.pro_list:
                 return ('Eexist', f'Problem {pro_id} already in contest'), None
+            contest.pro_list[pro_id] = {} # Add dummy dict for avoiding repeated problem id
 
         pro_order = len(contest.pro_sets)
 

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -373,12 +373,14 @@ class ContestService:
             await con.execute('DELETE FROM contest_ip_joints WHERE contest_id = $1;', contest.contest_id)
 
         # Readd IPs
-        for ip_int in range(int(contest.ip_range[0]), int(contest.ip_range[1]) + 1):
+        for ip_int in range(int(contest.start_ip), int(contest.end_ip) + 1):
             ip = IPv4Address(ip_int)
             contest.ip_pro_list[ip] = []
         for tmp_pro_set in contest.pro_sets:
             pro_set = [(pro_id, contest.pro_list[pro_id]['score_type']) for pro_id in tmp_pro_set]
             await self.add_pro_set(contest, pro_set)
+
+        self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
 
         return None, None
 
@@ -410,6 +412,8 @@ class ContestService:
                 init = (init + random.randint(1,pro_size-1)) % pro_size
                 pro_list.append(pro_set[init][0])
 
+        self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
+
         async with self.db.acquire() as con:
             # Insert problems into contest_problem_joints
             await con.executemany(
@@ -440,6 +444,8 @@ class ContestService:
         for pro_id in contest.pro_list:
             if contest.pro_list[pro_id]['order'] > pro_set_idx:
                 contest.pro_list[pro_id]['order'] -= 1
+
+        self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
 
         async with self.db.acquire() as con:
             # Remove problems from contest_problem_joints
@@ -479,6 +485,8 @@ class ContestService:
         # Reorder ip_pro_list
         for ip in contest.ip_pro_list:
             contest.ip_pro_list[ip] = [contest.ip_pro_list[ip][i] for i in new_idxs]
+
+        self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
 
         async with self.db.acquire() as con:
             # Update contest_problem_joints

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -52,6 +52,7 @@ class Contest:
 
     user_list: dict[int, dict] = field(default_factory=dict)
     pro_list: dict[int, dict] = field(default_factory=dict)
+    pro_sets: list[list[int]] = field(default_factory=list)
     ip_pro_list: dict[IPv4Address, list[int]] = field(default_factory=dict)
     ip_range: tuple[IPv4Address, IPv4Address] | None = None
 
@@ -186,6 +187,15 @@ class ContestService:
                     # Sort the problem list for each IP by order
                     for ip in contest.ip_pro_list:
                         contest.ip_pro_list[ip].sort(key=lambda pid: contest.pro_list[pid]['order'])
+
+                    pro_set_count = len(next(iter(contest.ip_pro_list.values()), []))
+                    for order in range(pro_set_count):
+                        result = await con.fetch('''
+                            SELECT pro_id FROM contest_problem_joints
+                            WHERE contest_id = $1 AND "order" = $2;
+                        ''', contest_id, order)
+                        pro_set = [pro_id for pro_id, in result]
+                        contest.pro_sets.append(pro_set)
 
             if contest.is_running():
                 b_contest = pickle.dumps(contest)
@@ -351,6 +361,8 @@ class ContestService:
             if pro_id in contest.pro_list:
                 return ('Eexist', f'Problem {pro_id} already in contest'), None
 
+        contest.pro_sets.append([pro_id for pro_id, _ in pro_set])
+
         pro_order = len(next(iter(contest.ip_pro_list.values()), []))
         for pro_id, score_type in pro_set:
             contest.pro_list[pro_id] = {
@@ -401,7 +413,7 @@ class ContestService:
         for pro_list in contest.ip_pro_list.values():
             pro_list.pop(pro_set_idx)
 
-        remove_pro_ids = [pro_id for pro_id, v in contest.pro_list.items() if v['order'] == pro_set_idx]
+        remove_pro_ids = contest.pro_sets.pop(pro_set_idx)
         for pro_id in remove_pro_ids:
             contest.pro_list.pop(pro_id)
         for pro_id in contest.pro_list:

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -369,14 +369,10 @@ class ContestService:
             return None, None
 
         # Clear existting ip
-        contest.ip_pro_list.clear()
         async with self.db.acquire() as con:
             await con.execute('DELETE FROM contest_ip_joints WHERE contest_id = $1;', contest.contest_id)
 
         # Readd IPs
-        for ip_int in range(int(contest.ip_range[0]), int(contest.ip_range[1]) + 1):
-            ip = IPv4Address(ip_int)
-            contest.ip_pro_list[ip] = []
         for tmp_pro_set in contest.pro_sets:
             pro_set = [(pro_id, contest.pro_list[pro_id]['score_type']) for pro_id in tmp_pro_set]
             await self.add_pro_set(contest, pro_set)
@@ -388,14 +384,7 @@ class ContestService:
             if pro_id in contest.pro_list:
                 return ('Eexist', f'Problem {pro_id} already in contest'), None
 
-        contest.pro_sets.append([pro_id for pro_id, _ in pro_set])
-
-        pro_order = len(next(iter(contest.ip_pro_list.values()), []))
-        for pro_id, score_type in pro_set:
-            contest.pro_list[pro_id] = {
-                "score_type": score_type,
-                "order": pro_order
-            }
+        pro_order = len(contest.pro_sets)
 
         pro_size = len(pro_set)
         if pro_size == 1:
@@ -431,15 +420,7 @@ class ContestService:
         return None, None
 
     async def remove_pro_set(self, contest: Contest , pro_set_idx: int):
-        for pro_list in contest.ip_pro_list.values():
-            pro_list.pop(pro_set_idx)
-
         remove_pro_ids = contest.pro_sets.pop(pro_set_idx)
-        for pro_id in remove_pro_ids:
-            contest.pro_list.pop(pro_id)
-        for pro_id in contest.pro_list:
-            if contest.pro_list[pro_id]['order'] > pro_set_idx:
-                contest.pro_list[pro_id]['order'] -= 1
 
         async with self.db.acquire() as con:
             # Remove problems from contest_problem_joints
@@ -472,13 +453,6 @@ class ContestService:
     async def reorder_pro_set(self, contest: Contest, new_idxs: list[int]):
         # Reorder pro_sets
         contest.pro_sets = [contest.pro_sets[i] for i in new_idxs]
-        # Reorder pro_list order
-        for order, pro_ids in enumerate(contest.pro_sets):
-            for pro_id in pro_ids:
-                contest.pro_list[pro_id]['order'] = order
-        # Reorder ip_pro_list
-        for ip in contest.ip_pro_list:
-            contest.ip_pro_list[ip] = [contest.ip_pro_list[ip][i] for i in new_idxs]
 
         async with self.db.acquire() as con:
             # Update contest_problem_joints

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -9,6 +9,7 @@ from services.chal import Compiler
 from services.user import Account
 
 from ipaddress import IPv4Address
+import random
 
 class RegMode(enum.IntEnum):
     INVITED = 0
@@ -249,6 +250,15 @@ class ContestService:
     async def update_contest(self, acct: Account, contest: Contest, prolist_updated=False, userlist_updated=False):
         # update db
         async with self.db.acquire() as con:
+
+            result = await con.fetch('SELECT "contest_mode" FROM "contest" WHERE "contest_id" = $1;', contest.contest_id)
+            if len(result) != 1:
+                return ('Enoext', 'Contest not found'), None
+            old_contest_mode = ContestMode(int(result[0]['contest_mode']))
+            if old_contest_mode != contest.contest_mode and ContestMode.RANDOM_SET in (old_contest_mode, contest.contest_mode):
+                if len(contest.pro_list) != 0:
+                    return ('Echmod', 'Cannot change contest mode when problem list is not empty'), None
+
             result = await con.fetch(
                 '''
                     UPDATE "contest"
@@ -285,6 +295,8 @@ class ContestService:
             )
 
             if prolist_updated:
+                if contest.contest_mode == ContestMode.RANDOM_SET:
+                    return ('Eprolist', 'Cannot update problem list for random set contests here'), None
                 order = 0
                 failed = []
                 for pro_id, v in contest.pro_list.items():
@@ -329,6 +341,101 @@ class ContestService:
         # log
 
         return None, None
+
+    async def add_pro_set(self, contest: Contest , pro_set: list[tuple[int, ProblemScoreType]]):
+        if contest.contest_mode != ContestMode.RANDOM_SET:
+            return ('Emod', 'Cannot add problem set to non-random set contests'), None
+        if len(pro_set) < 1:
+            return ('Eparam', 'Problem set must contain at least one problem'), None
+        for pro_id, _ in pro_set:
+            if pro_id in contest.pro_list:
+                return ('Eexist', f'Problem {pro_id} already in contest'), None
+
+        pro_order = len(next(iter(contest.ip_pro_list.values()), []))
+        for pro_id, score_type in pro_set:
+            contest.pro_list[pro_id] = {
+                "score_type": score_type,
+                "order": pro_order
+            }
+
+        pro_size = len(pro_set)
+        if pro_size == 1:
+            for pro_list in contest.ip_pro_list.values():
+                pro_list.append(pro_set[0][0])
+        elif pro_size == 2:
+            for pro_list in contest.ip_pro_list.values():
+                pro_list.append(pro_set[random.randint(0, 1)][0])
+        else:
+            init = 0
+            for pro_list in contest.ip_pro_list.values():
+                init = (init + random.randint(1,pro_size-1)) % pro_size
+                pro_list.append(pro_set[init][0])
+
+        async with self.db.acquire() as con:
+            # Insert problems into contest_problem_joints
+            await con.executemany(
+                '''
+                INSERT INTO contest_problem_joints ("contest_id", "pro_id", "score_type", "order")
+                VALUES ($1, $2, $3, $4)
+                ''',
+                [(contest.contest_id, pro_id, int(score_type), pro_order) for pro_id, score_type in pro_set]
+            )
+            # Insert por_id into contest_ip_joints
+            await con.executemany(
+                '''
+                INSERT INTO contest_ip_joints ("contest_id", "ip", "pro_id")
+                VALUES ($1, $2, $3)
+                ''',
+                [(contest.contest_id, str(ip), pro_list[-1]) for ip, pro_list in contest.ip_pro_list.items()]
+            )
+
+        return None, None
+
+    async def remove_pro_set(self, contest: Contest , pro_set_idx: int):
+        if contest.contest_mode != ContestMode.RANDOM_SET:
+            return ('Emod', 'Cannot remove problem set from non-random set contests'), None
+        max_order = len(next(iter(contest.ip_pro_list.values()), [])) - 1
+        if pro_set_idx < 0 or pro_set_idx > max_order:
+            return ('Eparam', 'Problem set index out of range'), None
+
+        for pro_list in contest.ip_pro_list.values():
+            pro_list.pop(pro_set_idx)
+
+        remove_pro_ids = [pro_id for pro_id, v in contest.pro_list.items() if v['order'] == pro_set_idx]
+        for pro_id in remove_pro_ids:
+            contest.pro_list.pop(pro_id)
+        for pro_id in contest.pro_list:
+            if contest.pro_list[pro_id]['order'] > pro_set_idx:
+                contest.pro_list[pro_id]['order'] -= 1
+
+        async with self.db.acquire() as con:
+            # Remove problems from contest_problem_joints
+            await con.executemany(
+                '''
+                DELETE FROM contest_problem_joints
+                WHERE "contest_id" = $1 AND "pro_id" = $2
+                ''',
+                [(contest.contest_id, pro_id) for pro_id in remove_pro_ids]
+            )
+            # Subtract order for problems with order > pro_set_idx
+            await con.execute(
+                '''
+                UPDATE contest_problem_joints
+                SET "order" = "order" - 1
+                WHERE "contest_id" = $1 AND "order" > $2
+                ''',
+                contest.contest_id, pro_set_idx
+            )
+            # Remove pro_id from contest_ip_joints
+            await con.executemany(
+                '''
+                DELETE FROM contest_ip_joints
+                WHERE "contest_id" = $1 AND "pro_id" = $2
+                ''',
+                [(contest.contest_id, pro_id) for pro_id in remove_pro_ids]
+            )
+        return None, None
+
 
     async def add_announce(self, contest_id: int, acct_id: int, subject: str, content: str):
         res = await self.db.fetch('INSERT INTO contest_announcement ("contest_id", "acct_id", "subject", "content", "timestamp") VALUES ($1, $2, $3, $4, NOW()) RETURNING announce_id',

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -482,6 +482,37 @@ class ContestService:
             )
         return None, None
 
+    async def reorder_pro_set(self, contest: Contest, new_idxs: list[int]):
+        if contest.contest_mode != ContestMode.RANDOM_SET:
+            return ('Emod', 'Cannot reorder problem sets for non-random set contests'), None
+        old_size = len(next(iter(contest.ip_pro_list.values()), []))
+        if len(new_idxs) != old_size or sorted(new_idxs) != list(range(old_size)):
+            return ('Eparam', 'Invalid new indexes for problem sets'), None
+
+        # Reorder pro_sets
+        contest.pro_sets = [contest.pro_sets[i] for i in new_idxs]
+        # Reorder pro_list order
+        for order, pro_ids in enumerate(contest.pro_sets):
+            for pro_id in pro_ids:
+                contest.pro_list[pro_id]['order'] = order
+        # Reorder ip_pro_list
+        for ip in contest.ip_pro_list:
+            contest.ip_pro_list[ip] = [contest.ip_pro_list[ip][i] for i in new_idxs]
+
+        async with self.db.acquire() as con:
+            # Update contest_problem_joints
+            for order, pro_ids in enumerate(contest.pro_sets):
+                if new_idxs[order] == order:
+                    continue
+                await con.executemany(
+                    '''
+                    UPDATE contest_problem_joints
+                    SET "order" = $3
+                    WHERE "contest_id" = $1 AND "pro_id" = $2
+                    ''',
+                    [(contest.contest_id, pro_id, order) for pro_id in pro_ids]
+                )
+        return None, None
 
     async def add_announce(self, contest_id: int, acct_id: int, subject: str, content: str):
         res = await self.db.fetch('INSERT INTO contest_announcement ("contest_id", "acct_id", "subject", "content", "timestamp") VALUES ($1, $2, $3, $4, NOW()) RETURNING announce_id',

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass, field
 import pickle
 
 import asyncpg
+from ipaddress import IPv4Address
+import random
 
 from services.chal import Compiler
 from services.user import Account
 
-from ipaddress import IPv4Address
-import random
 
 class RegMode(enum.IntEnum):
     INVITED = 0

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -357,12 +357,6 @@ class ContestService:
         return None, None
 
     async def update_ip(self, contest: Contest):
-        if contest.ip_range is None:
-            contest.ip_range = (IPv4Address('0.0.0.0'), IPv4Address('0.0.0.0'))
-
-        if contest.ip_range[0] > contest.ip_range[1]:
-            return ('Eparam', 'Invalid IP range'), None
-
         async with self.db.acquire() as con:
             await con.execute('''
                 UPDATE contest
@@ -390,10 +384,6 @@ class ContestService:
         return None, None
 
     async def add_pro_set(self, contest: Contest , pro_set: list[tuple[int, ProblemScoreType]]):
-        if contest.contest_mode != ContestMode.RANDOM_SET:
-            return ('Emod', 'Cannot add problem set to non-random set contests'), None
-        if len(pro_set) < 1:
-            return ('Eparam', 'Problem set must contain at least one problem'), None
         for pro_id, _ in pro_set:
             if pro_id in contest.pro_list:
                 return ('Eexist', f'Problem {pro_id} already in contest'), None
@@ -441,12 +431,6 @@ class ContestService:
         return None, None
 
     async def remove_pro_set(self, contest: Contest , pro_set_idx: int):
-        if contest.contest_mode != ContestMode.RANDOM_SET:
-            return ('Emod', 'Cannot remove problem set from non-random set contests'), None
-        max_order = len(next(iter(contest.ip_pro_list.values()), [])) - 1
-        if pro_set_idx < 0 or pro_set_idx > max_order:
-            return ('Eparam', 'Problem set index out of range'), None
-
         for pro_list in contest.ip_pro_list.values():
             pro_list.pop(pro_set_idx)
 
@@ -486,12 +470,6 @@ class ContestService:
         return None, None
 
     async def reorder_pro_set(self, contest: Contest, new_idxs: list[int]):
-        if contest.contest_mode != ContestMode.RANDOM_SET:
-            return ('Emod', 'Cannot reorder problem sets for non-random set contests'), None
-        old_size = len(next(iter(contest.ip_pro_list.values()), []))
-        if len(new_idxs) != old_size or sorted(new_idxs) != list(range(old_size)):
-            return ('Eparam', 'Invalid new indexes for problem sets'), None
-
         # Reorder pro_sets
         contest.pro_sets = [contest.pro_sets[i] for i in new_idxs]
         # Reorder pro_list order

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -8,6 +8,7 @@ import asyncpg
 from services.chal import Compiler
 from services.user import Account
 
+from ipaddress import IPv4Address
 
 class RegMode(enum.IntEnum):
     INVITED = 0
@@ -18,6 +19,7 @@ class RegMode(enum.IntEnum):
 class ContestMode(enum.IntEnum):
     IOI = 0
     ACM = 1
+    RANDOM_SET = 2
 
 class ProblemScoreType(enum.IntEnum):
     IOI2013 = 0
@@ -49,6 +51,8 @@ class Contest:
 
     user_list: dict[int, dict] = field(default_factory=dict)
     pro_list: dict[int, dict] = field(default_factory=dict)
+    ip_pro_list: dict[IPv4Address, list[int]] = field(default_factory=dict)
+    ip_range: tuple[IPv4Address, IPv4Address] | None = None
 
     reg_mode: RegMode
     reg_end: datetime.datetime
@@ -157,10 +161,11 @@ class ContestService:
                 contest.contest_end = contest.contest_end
                 contest.reg_end = contest.reg_end
 
-                result = await con.fetch('SELECT pro_id, score_type FROM contest_problem_joints WHERE contest_id = $1 ORDER BY "order";', contest_id)
-                for pro_id, score_type in result:
+                result = await con.fetch('SELECT pro_id, score_type, order FROM contest_problem_joints WHERE contest_id = $1 ORDER BY "order";', contest_id)
+                for pro_id, score_type, order in result:
                     contest.pro_list[pro_id] = {
-                        "score_type": ProblemScoreType(int(score_type))
+                        "score_type": ProblemScoreType(int(score_type)),
+                        "order": int(order) # Only used for random set contests
                     }
 
                 result = await con.fetch('SELECT acct_id, status FROM contest_users WHERE contest_id = $1 ORDER BY acct_id', contest_id)
@@ -168,6 +173,18 @@ class ContestService:
                     contest.user_list[acct_id] = {
                         "status": UserStatus(int(status))
                     }
+
+                if contest.contest_mode == ContestMode.RANDOM_SET:
+                    result = await con.fetch('SELECT ip, pro_id FROM contest_ip_joints WHERE contest_id = $1; ORDER BY ip', contest_id)
+                    for ip_raw, pro_id in result:
+                        ip = IPv4Address(ip_raw)
+                        if ip not in contest.ip_pro_list:
+                            contest.ip_pro_list[ip] = []
+                        contest.ip_pro_list[ip].append(pro_id)
+
+                    # Sort the problem list for each IP by order
+                    for ip in contest.ip_pro_list:
+                        contest.ip_pro_list[ip].sort(key=lambda pid: contest.pro_list[pid]['order'])
 
             if contest.is_running():
                 b_contest = pickle.dumps(contest)

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -358,7 +358,10 @@ class ContestService:
 
     async def update_ip(self, contest: Contest):
         if contest.ip_range is None:
-            return ('Eparam', 'IP range is not set'), None
+            contest.ip_range = (IPv4Address('0.0.0.0'), IPv4Address('0.0.0.0'))
+
+        if contest.ip_range[0] > contest.ip_range[1]:
+            return ('Eparam', 'Invalid IP range'), None
 
         async with self.db.acquire() as con:
             await con.execute('''

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -138,7 +138,7 @@ class ContestService:
                         "desc_after_contest",
 
                         "contest_mode", "contest_start", "contest_end",
-                        "reg_mode", "reg_end",
+                        "reg_mode", "reg_end", "start_ip", "end_ip",
 
                         "allow_compilers",
                         "is_public_scoreboard",
@@ -162,6 +162,10 @@ class ContestService:
                 contest.contest_start = contest.contest_start
                 contest.contest_end = contest.contest_end
                 contest.reg_end = contest.reg_end
+                if result['start_ip'] is not None and result['end_ip'] is not None:
+                    contest.ip_range = (IPv4Address(result['start_ip']), IPv4Address(result['end_ip']))
+                else:
+                    contest.ip_range = None
 
                 result = await con.fetch('SELECT pro_id, score_type, order FROM contest_problem_joints WHERE contest_id = $1 ORDER BY "order";', contest_id)
                 for pro_id, score_type, order in result:
@@ -349,6 +353,36 @@ class ContestService:
         await self.rs.hset('contest', str(contest.contest_id), b_contest)
 
         # log
+
+        return None, None
+
+    async def update_ip(self, contest: Contest):
+        if contest.ip_range is None:
+            return ('Eparam', 'IP range is not set'), None
+
+        async with self.db.acquire() as con:
+            await con.execute('''
+                UPDATE contest
+                SET start_ip = $1, end_ip = $2
+                WHERE contest_id = $3;
+            ''', str(contest.ip_range[0]), str(contest.ip_range[1]), contest.contest_id)
+
+        if contest.contest_mode != ContestMode.RANDOM_SET:
+            # Updated, but not random set contest, nothing more to do
+            return None, None
+
+        # Clear existting ip
+        contest.ip_pro_list.clear()
+        async with self.db.acquire() as con:
+            await con.execute('DELETE FROM contest_ip_joints WHERE contest_id = $1;', contest.contest_id)
+
+        # Readd IPs
+        for ip_int in range(int(contest.ip_range[0]), int(contest.ip_range[1]) + 1):
+            ip = IPv4Address(ip_int)
+            contest.ip_pro_list[ip] = []
+        for tmp_pro_set in contest.pro_sets:
+            pro_set = [(pro_id, contest.pro_list[pro_id]['score_type']) for pro_id in tmp_pro_set]
+            await self.add_pro_set(contest, pro_set)
 
         return None, None
 

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -54,7 +54,8 @@ class Contest:
     pro_list: dict[int, dict] = field(default_factory=dict)
     pro_sets: list[list[int]] = field(default_factory=list)
     ip_pro_list: dict[IPv4Address, list[int]] = field(default_factory=dict)
-    ip_range: tuple[IPv4Address, IPv4Address] = None
+    start_ip: IPv4Address
+    end_ip: IPv4Address
 
     reg_mode: RegMode
     reg_end: datetime.datetime
@@ -162,10 +163,8 @@ class ContestService:
                 contest.contest_start = contest.contest_start
                 contest.contest_end = contest.contest_end
                 contest.reg_end = contest.reg_end
-                if result['start_ip'] is not None and result['end_ip'] is not None:
-                    contest.ip_range = (IPv4Address(result['start_ip']), IPv4Address(result['end_ip']))
-                else:
-                    contest.ip_range = None
+                contest.start_ip = IPv4Address(result['start_ip'])
+                contest.end_ip = IPv4Address(result['end_ip'])
 
                 result = await con.fetch('SELECT pro_id, score_type, order FROM contest_problem_joints WHERE contest_id = $1 ORDER BY "order";', contest_id)
                 for pro_id, score_type, order in result:
@@ -362,7 +361,7 @@ class ContestService:
                 UPDATE contest
                 SET start_ip = $1, end_ip = $2
                 WHERE contest_id = $3;
-            ''', str(contest.ip_range[0]), str(contest.ip_range[1]), contest.contest_id)
+            ''', str(contest.start_ip), str(contest.end_ip), contest.contest_id)
 
         if contest.contest_mode != ContestMode.RANDOM_SET:
             # Updated, but not random set contest, nothing more to do

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -452,12 +452,12 @@ class ContestService:
 
         async with self.db.acquire() as con:
             # Remove problems from contest_problem_joints
-            await con.executemany(
+            await con.execute(
                 '''
                 DELETE FROM contest_problem_joints
-                WHERE "contest_id" = $1 AND "pro_id" = $2
+                WHERE "contest_id" = $1 AND "order" = $2;
                 ''',
-                [(contest.contest_id, pro_id) for pro_id in remove_pro_ids]
+                contest.contest_id, pro_set_idx
             )
             # Subtract order for problems with order > pro_set_idx
             await con.execute(

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -387,6 +387,20 @@ class ContestService:
                 return ('Eexist', f'Problem {pro_id} already in contest'), None
             contest.pro_list[pro_id] = {} # Add dummy dict for avoiding repeated problem id
 
+        pro_order = len(contest.pro_sets)
+        async with self.db.acquire() as con:
+            try:
+                # Insert problems into contest_problem_joints
+                await con.executemany(
+                    '''
+                    INSERT INTO contest_problem_joints ("contest_id", "pro_id", "score_type", "order")
+                    VALUES ($1, $2, $3, $4)
+                    ''',
+                    [(contest.contest_id, pro_id, int(score_type), pro_order) for pro_id, score_type in pro_set]
+                )
+            except asyncpg.ForeignKeyViolationError:
+                return ('Enoext', 'One or more problem IDs do not exist'), None
+
         contest.pro_sets.append([pro_id for pro_id, _ in pro_set])
 
         for pro_id, score_type in pro_set:
@@ -396,18 +410,6 @@ class ContestService:
 
         await self.add_random_pro(contest, [pro_id for pro_id, _ in pro_set])
         self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
-
-        pro_order = len(contest.pro_sets) - 1
-        async with self.db.acquire() as con:
-            # Insert problems into contest_problem_joints
-            await con.executemany(
-                '''
-                INSERT INTO contest_problem_joints ("contest_id", "pro_id", "score_type", "order")
-                VALUES ($1, $2, $3, $4)
-                ''',
-                [(contest.contest_id, pro_id, int(score_type), pro_order) for pro_id, score_type in pro_set]
-            )
-
         return None, None
 
     async def add_random_pro(self, contest: Contest, pro_set: list[int]):

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -170,7 +170,6 @@ class ContestService:
                 for pro_id, score_type, order in result:
                     contest.pro_list[pro_id] = {
                         "score_type": ProblemScoreType(int(score_type)),
-                        "order": int(order) # Only used for random set contests
                     }
 
                 result = await con.fetch('SELECT acct_id, status FROM contest_users WHERE contest_id = $1 ORDER BY acct_id', contest_id)
@@ -180,16 +179,21 @@ class ContestService:
                     }
 
                 if contest.contest_mode == ContestMode.RANDOM_SET:
-                    result = await con.fetch('SELECT ip, pro_id FROM contest_ip_joints WHERE contest_id = $1; ORDER BY ip', contest_id)
+                    result = await con.fetch(
+                        '''
+                            SELECT ip, contest_ip_joints.pro_id 
+                            FROM contest_ip_joints INNER JOIN contest_problem_joints 
+                            ON contest_ip_joints.contest_id = contest_problem_joints.contest_id 
+                               AND contest_ip_joints.pro_id = contest_problem_joints.pro_id
+                            WHERE contest_ip_joints.contest_id = $1 ORDER BY contest_ip_joints.ip, contest_problem_joints."order" ASC;
+                        ''',
+                        contest_id
+                    )
                     for ip_raw, pro_id in result:
                         ip = IPv4Address(ip_raw)
                         if ip not in contest.ip_pro_list:
                             contest.ip_pro_list[ip] = []
                         contest.ip_pro_list[ip].append(pro_id)
-
-                    # Sort the problem list for each IP by order
-                    for ip in contest.ip_pro_list:
-                        contest.ip_pro_list[ip].sort(key=lambda pid: contest.pro_list[pid]['order'])
 
                     pro_set_count = len(next(iter(contest.ip_pro_list.values()), []))
                     for order in range(pro_set_count):
@@ -392,11 +396,9 @@ class ContestService:
 
         contest.pro_sets.append([pro_id for pro_id, _ in pro_set])
 
-        pro_order = len(next(iter(contest.ip_pro_list.values()), []))
         for pro_id, score_type in pro_set:
             contest.pro_list[pro_id] = {
                 "score_type": score_type,
-                "order": pro_order
             }
 
         pro_size = len(pro_set)
@@ -414,6 +416,7 @@ class ContestService:
 
         self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
 
+        pro_order = len(contest.pro_sets) - 1
         async with self.db.acquire() as con:
             # Insert problems into contest_problem_joints
             await con.executemany(
@@ -441,10 +444,6 @@ class ContestService:
         remove_pro_ids = contest.pro_sets.pop(pro_set_idx)
         for pro_id in remove_pro_ids:
             contest.pro_list.pop(pro_id)
-        for pro_id in contest.pro_list:
-            if contest.pro_list[pro_id]['order'] > pro_set_idx:
-                contest.pro_list[pro_id]['order'] -= 1
-
         self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
 
         async with self.db.acquire() as con:
@@ -478,10 +477,6 @@ class ContestService:
     async def reorder_pro_set(self, contest: Contest, new_idxs: list[int]):
         # Reorder pro_sets
         contest.pro_sets = [contest.pro_sets[i] for i in new_idxs]
-        # Reorder pro_list order
-        for order, pro_ids in enumerate(contest.pro_sets):
-            for pro_id in pro_ids:
-                contest.pro_list[pro_id]['order'] = order
         # Reorder ip_pro_list
         for ip in contest.ip_pro_list:
             contest.ip_pro_list[ip] = [contest.ip_pro_list[ip][i] for i in new_idxs]

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -375,7 +375,7 @@ class ContestService:
             pro_set = [(pro_id, contest.pro_list[pro_id]['score_type']) for pro_id in tmp_pro_set]
             await self.add_pro_set(contest, pro_set)
 
-        self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
+        await self.rs.hset('contest', str(contest.contest_id), pickle.dumps(contest))
 
         return None, None
 

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -195,7 +195,10 @@ class ContestService:
                             contest.ip_pro_list[ip] = []
                         contest.ip_pro_list[ip].append(pro_id)
 
-                    pro_set_count = len(next(iter(contest.ip_pro_list.values()), []))
+                    pro_set_count = await con.fetchval('''
+                        SELECT COUNT(DISTINCT "order") FROM contest_problem_joints
+                        WHERE contest_id = $1;
+                    ''', contest_id)
                     for order in range(pro_set_count):
                         result = await con.fetch('''
                             SELECT pro_id FROM contest_problem_joints

--- a/src/static/templ/contests/manage/acct.html
+++ b/src/static/templ/contests/manage/acct.html
@@ -30,6 +30,7 @@
 			});
 		};
 
+		var j_form = $('#ip-form');
         const ip_re = /^(((?!25?[6-9])[12]\d|[1-9])?\d\.?\b){4}$/;
 		j_form.find('button.submit').on('click', function(e) {
             var type = j_form.find('#type').val();
@@ -41,10 +42,10 @@
                 return;
             }
             if(start_ip.length == 0 && end_ip.length == 0) {
-                start_ip = end_ip = '0.0.0.0':
+                start_ip = end_ip = '0.0.0.0';
             } 
 
-            $.post(`{{ url('/be/contests/{ contest_id }/manage/acct') }}`, {
+            $.post(`{{ url(f'/be/contests/{ contest_id }/manage/acct') }}`, {
                 'reqtype': 'update_ip',
                 'start_ip': start_ip,
                 'end_ip': end_ip,
@@ -192,7 +193,7 @@
 
 			<div id="collapseTwo" class="accordion-collapse collapse show" aria-labelledby="headingTwo" data-bs-parent="#accordionExample">
 				<div class="accordion-body">
-					<form id="form">
+					<form id="ip-form">
                         <div class="mb-3">
                             <label>Start IP</label>
                             <input class="form-control" id="start_ip" type="text" value="{{ start_ip }}">

--- a/src/static/templ/contests/manage/acct.html
+++ b/src/static/templ/contests/manage/acct.html
@@ -30,6 +30,35 @@
 			});
 		};
 
+        const ip_re = /^(((?!25?[6-9])[12]\d|[1-9])?\d\.?\b){4}$/;
+		j_form.find('button.submit').on('click', function(e) {
+            var type = j_form.find('#type').val();
+            const start_ip = j_form.find('#start_ip').val().trim();
+            const end_ip = j_form.find('#end_ip').val().trim();
+
+            if((start_ip.length > 0 || end_ip.length > 0) && (!ip_re.test(start_ip) || !ip_re.test(end_ip))) {
+                index.show_notify_dialog('IP format error, please input correct IP address.', index.DIALOG_TYPE.error);
+                return;
+            }
+            if(start_ip.length == 0 && end_ip.length == 0) {
+                start_ip = end_ip = '0.0.0.0':
+            } 
+
+            $.post(`{{ url('/be/contests/{ contest_id }/manage/acct') }}`, {
+                'reqtype': 'update_ip',
+                'start_ip': start_ip,
+                'end_ip': end_ip,
+            }, function(res) {
+                res = JSON.parse(res);
+                if (res.status == 'S') {
+                    index.show_notify_dialog('Update Successfully', index.DIALOG_TYPE.success);
+                    index.reload();
+                } else {
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
+                }
+            });
+		});
+
 		document.querySelectorAll('button.remove').forEach(el => {
 			el.addEventListener('click', () => post_func('remove', $(el).attr('acct_id'),
 				$(el).hasClass('normal') ? "normal" : "admin"
@@ -149,6 +178,32 @@
 					{% end %}
 					</tbody>
 					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="accordion">
+		<div class="accordion-item">
+			<h2 class="accordion-header" id="headingTwo">
+				<button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="true" aria-controls="collapseOne">
+                    IP Whitelist
+				</button>
+			</h2>
+
+			<div id="collapseTwo" class="accordion-collapse collapse show" aria-labelledby="headingTwo" data-bs-parent="#accordionExample">
+				<div class="accordion-body">
+					<form id="form">
+                        <div class="mb-3">
+                            <label>Start IP</label>
+                            <input class="form-control" id="start_ip" type="text" value="{{ start_ip }}">
+                        </div>
+                        <div class="mb-3">
+                            <label>End IP</label>
+                            <input class="form-control" id="end_ip" type="text" value="{{ end_ip }}">
+                        </div>
+                        <button type="button" class="btn btn-primary submit">Update</button>
+                        <button type="button" class="btn btn-secondary cancel">Cancel</button>
+                    </form>
 				</div>
 			</div>
 		</div>

--- a/src/static/templ/contests/manage/general.html
+++ b/src/static/templ/contests/manage/general.html
@@ -143,6 +143,7 @@
             <select id="contestMode" class="form-select">
                 <option value="{{ ContestMode.IOI }}"{% if contest.contest_mode == ContestMode.IOI %} selected {% end %}>IOI</option>
                 <option value="{{ ContestMode.ACM }}"{% if contest.contest_mode == ContestMode.ACM %} selected {% end %}>ACM</option>
+                <option value="{{ ContestMode.RANDOM_SET }}"{% if contest.contest_mode == ContestMode.RANDOM_SET %} selected {% end %}>Random Set</option>
             </select>
         </div>
 

--- a/src/static/templ/contests/manage/rand-pro.html
+++ b/src/static/templ/contests/manage/rand-pro.html
@@ -40,16 +40,22 @@
             if (ord1 === ord2) return;
             
             // Swap contents of Problem Set & Operation columns
-            let td1 = rows[ord1].querySelectorAll("td");
-            let td2 = rows[ord2].querySelectorAll("td");
-            let tmp = td1[0].innerHTML;
-            td1[0].innerHTML = td2[0].innerHTML;
-            td2[0].innerHTML = tmp;
-            tmp = td1[1].innerHTML;
-            td1[1].innerHTML = td2[1].innerHTML;
-            td2[1].innerHTML = tmp;
+            let row1 = rows[ord1];
+            let row2 = rows[ord2];
 
-            // update pro_set_ids & pro_set_ord
+            let placeholder = document.createElement("tr");
+
+            row1.parentNode.insertBefore(placeholder, row1);
+            row2.parentNode.insertBefore(row1, row2);
+
+            placeholder.parentNode.insertBefore(row2, placeholder);
+            placeholder.remove();
+
+            rows = tbody.querySelectorAll("tr");
+            rows.forEach((row, index) => {
+                row.querySelector("th").textContent = index + 1;
+            });
+
             const idx1 = pro_set_ids[ord1];
             const idx2 = pro_set_ids[ord2];
             pro_set_ids[ord1] = idx2;

--- a/src/static/templ/contests/manage/rand-pro.html
+++ b/src/static/templ/contests/manage/rand-pro.html
@@ -1,0 +1,125 @@
+{% extends 'manage.html' %}
+
+{% block head %}
+<script type="text/javascript" id="contjs">
+	function init() {
+        let contest_id = "{{ contest.contest_id }}";
+
+		const post_func = (reqtype, pro_id, fail_action=null) => {
+			if (pro_id.length == 0) {
+				index.show_notify_dialog('Input cannot empty.', index.DIALOG_TYPE.warning);
+				return;
+			}
+
+			$.post(`{{ url(f'/be/contests/{ contest.contest_id }/manage/pro') }}`, {
+				reqtype: reqtype,
+				pro_id: pro_id,
+			}, res => {
+                res = JSON.parse(res);
+                if (res.status == 'S') {
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.success);
+					setTimeout(() => index.reload(), 1000);
+                } else {
+                    if (fail_action != null) fail_action();
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
+                }
+			});
+		};
+
+		document.querySelectorAll('button.remove').forEach(el => {
+			el.addEventListener('click', () => post_func('remove', $(el).attr('pro_id')));
+		});
+
+		document.querySelectorAll('button.rechal').forEach(el => {
+			el.addEventListener('click', () => post_func('rechal', $(el).attr('pro_id')));
+		});
+
+        document.querySelectorAll('button.public').forEach(el => {
+            el.addEventListener('click', () => post_func('public', $(el).attr('pro_id')));
+        });
+
+        $("button.publicall").on('click', function(e) {
+            document.querySelectorAll('button.public').forEach(el => {
+                let pro_id = $(el).attr('pro_id');
+                $.post(`{{ url(f'/be/contests/{ contest.contest_id }/manage/pro') }}`, {
+                    reqtype: "public",
+                    pro_id: pro_id
+                });
+            });
+        });
+
+		$("#addProSet").on('click', () => post_func('add_set', $("#proSet").val(), () => $("#proSet").val('')));
+		$("#removeProSet").on('click', () => post_func('remove', $("#proId").val(), () => $("#proID").val('')));
+    }
+</script>
+{% end %}
+
+{% block content %}
+{% from services.pro import ProConst %}
+
+<div class="col-lg-10 ms-lg-2 mt-lg-2">
+
+	<div class="accordion">
+		<div class="accordion-item">
+			<h2 class="accordion-header" id="headingOne">
+				<button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+					Problem List
+				</button>
+			</h2>
+
+			<div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="headingOne" data-bs-parent="#accordionExample">
+				<div class="accordion-body">
+					<form id="form">
+						<label for="#name" class="form-label">Problem ID Set</label>
+						<div class="input-group mb-1">
+							<input type="text" class="form-control" placeholder="pro id set" id="proSet">
+							<button class="btn btn-primary" id="addProSet" type="button">Add</button>
+						</div>
+					</form>
+
+                    <button
+                        class="btn btn-danger me-2 publicall"
+                        {% if not contest.is_end() %} disabled {% end %}
+                    >Public All Problem</button>
+
+					<table class="table table-hover table-sm table-responsive-sm col mx-lg-3">
+					<thead>
+						<tr>
+							<th scope="col">Pro Order</th>
+							<th scope="col">Problem Set</th>
+							<th scope="col">Operation</th>
+						</tr>
+					</thead>
+					<tbody>
+					{% for id, pro_set in enumerate(pro_sets) %}
+						<tr>
+                            <th scope="row">{{ id + 1 }}</th>
+                            <td>
+                                {% for pro in pro_set %}
+                                    {{ pro.id }}{% if not loop.last %}, {% end %}
+                                {% end %}
+                            </td>
+							<td>
+								<button class="btn btn-primary me-2 moveUp" pro_set_id="{{ id }}">Move Up</button>
+                                <button class="btn btn-primary me-2 moveDown" pro_set_id="{{ id }}">Move Down</button>
+								<button class="btn btn-warning me-2 remove" pro_set_id="{{ id }}">Remove</button>
+							</td>
+						</tr>
+					{% end %}
+					</tbody>
+					</table>
+
+                    <button
+                        class="btn btn-secondary me-2 cancelOrder"
+                    >Cancel Problem Order</button>
+                    <button
+                        class="btn btn-primary me-2 saveOrder"
+                    >Save Problem Order</button>
+
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+{% end %}

--- a/src/static/templ/contests/manage/rand-pro.html
+++ b/src/static/templ/contests/manage/rand-pro.html
@@ -94,9 +94,9 @@
 		$("#addProSet").on('click', () => post_func('add_set', $("#proSet").val(), () => $("#proSet").val('')));
 
         // Send new ids order as csv to backend
-        $("button.saveOrder").on('click', () => post_func('update_order', pro_set_ids.join(','), () => location.reload()));
+        $("button.saveOrder").on('click', () => post_func('update_order', pro_set_ids.join(','), () => index.reload()));
         $("button.cancelOrder").on('click', function() {
-            location.reload();
+            index.reload();
         });
     }
 </script>

--- a/src/static/templ/contests/manage/rand-pro.html
+++ b/src/static/templ/contests/manage/rand-pro.html
@@ -137,9 +137,7 @@
 						<tr>
                             <th scope="row">{{ id + 1 }}</th>
                             <td>
-                                {% for pro in pro_set %}
-                                    {{ pro.id }}{% if not loop.last %}, {% end %}
-                                {% end %}
+                                {{ ','.join(str(pro_id) for pro_id in pro_set) }}
                             </td>
 							<td>
 								<button class="btn btn-primary me-2 moveUp" pro_set_id="{{ id }}">Move Up</button>

--- a/src/static/templ/contests/manage/rand-pro.html
+++ b/src/static/templ/contests/manage/rand-pro.html
@@ -5,6 +5,13 @@
 	function init() {
         let contest_id = "{{ contest.contest_id }}";
 
+        let pro_set_ids = [];
+        let pro_set_ord = [];
+        for (let i = 0; i < {{ len(pro_sets) }}; i++) {
+            pro_set_ids.push(i);
+            pro_set_ord.push(i);
+        }
+
 		const post_func = (reqtype, pro_id, fail_action=null) => {
 			if (pro_id.length == 0) {
 				index.show_notify_dialog('Input cannot empty.', index.DIALOG_TYPE.warning);
@@ -26,17 +33,44 @@
 			});
 		};
 
+        function swapRows(ord1, ord2) {
+            let tbody = document.querySelector("table tbody");
+            let rows = tbody.querySelectorAll("tr");
+            if (ord1 < 0 || ord2 < 0 || ord1 >= rows.length || ord2 >= rows.length) return;
+            if (ord1 === ord2) return;
+            
+            // Swap contents of Problem Set & Operation columns
+            let td1 = rows[ord1].querySelectorAll("td");
+            let td2 = rows[ord2].querySelectorAll("td");
+            let tmp = td1.innerHTML;
+            td1.innerHTML = td2.innerHTML;
+            td2.innerHTML = tmp;
+
+            // update pro_set_ids & pro_set_ord
+            const idx1 = pro_set_ids[ord1];
+            const idx2 = pro_set_ids[ord2];
+            pro_set_ids[ord1] = idx2;
+            pro_set_ids[ord2] = idx1;
+            pro_set_ord[idx1] = ord2;
+            pro_set_ord[idx2] = ord1;
+        }
+
+		document.querySelectorAll('button.moveUp').forEach(el => {
+            el.addEventListener('click', function() {
+                const idx = parseInt($(el).attr('pro_set_id'));
+                swapRows(pro_set_ord[idx], pro_set_ord[idx] - 1);
+            }
+		});
+		document.querySelectorAll('button.moveDown').forEach(el => {
+            el.addEventListener('click', function() {
+                const idx = parseInt($(el).attr('pro_set_id'));
+                swapRows(pro_set_ord[idx], pro_set_ord[idx] + 1);
+            }
+		});
+
 		document.querySelectorAll('button.remove').forEach(el => {
-			el.addEventListener('click', () => post_func('remove', $(el).attr('pro_id')));
+			el.addEventListener('click', () => post_func('remove_set', $(el).attr('pro_set_id')));
 		});
-
-		document.querySelectorAll('button.rechal').forEach(el => {
-			el.addEventListener('click', () => post_func('rechal', $(el).attr('pro_id')));
-		});
-
-        document.querySelectorAll('button.public').forEach(el => {
-            el.addEventListener('click', () => post_func('public', $(el).attr('pro_id')));
-        });
 
         $("button.publicall").on('click', function(e) {
             document.querySelectorAll('button.public').forEach(el => {
@@ -49,7 +83,12 @@
         });
 
 		$("#addProSet").on('click', () => post_func('add_set', $("#proSet").val(), () => $("#proSet").val('')));
-		$("#removeProSet").on('click', () => post_func('remove', $("#proId").val(), () => $("#proID").val('')));
+
+        // Send new ids order as csv to backend
+        document.querySelector("button.saveOrder").on('click', () = post_func('save_order', pro_set_ids.join(','), () => location.reload()));
+        document.querySelector("button.cancelOrder").on('click', function() {
+            location.reload();
+        });
     }
 </script>
 {% end %}

--- a/src/static/templ/contests/manage/rand-pro.html
+++ b/src/static/templ/contests/manage/rand-pro.html
@@ -42,9 +42,12 @@
             // Swap contents of Problem Set & Operation columns
             let td1 = rows[ord1].querySelectorAll("td");
             let td2 = rows[ord2].querySelectorAll("td");
-            let tmp = td1.innerHTML;
-            td1.innerHTML = td2.innerHTML;
-            td2.innerHTML = tmp;
+            let tmp = td1[0].innerHTML;
+            td1[0].innerHTML = td2[0].innerHTML;
+            td2[0].innerHTML = tmp;
+            tmp = td1[1].innerHTML;
+            td1[1].innerHTML = td2[1].innerHTML;
+            td2[1].innerHTML = tmp;
 
             // update pro_set_ids & pro_set_ord
             const idx1 = pro_set_ids[ord1];
@@ -59,13 +62,13 @@
             el.addEventListener('click', function() {
                 const idx = parseInt($(el).attr('pro_set_id'));
                 swapRows(pro_set_ord[idx], pro_set_ord[idx] - 1);
-            }
+            })
 		});
 		document.querySelectorAll('button.moveDown').forEach(el => {
             el.addEventListener('click', function() {
                 const idx = parseInt($(el).attr('pro_set_id'));
                 swapRows(pro_set_ord[idx], pro_set_ord[idx] + 1);
-            }
+            })
 		});
 
 		document.querySelectorAll('button.remove').forEach(el => {
@@ -85,8 +88,8 @@
 		$("#addProSet").on('click', () => post_func('add_set', $("#proSet").val(), () => $("#proSet").val('')));
 
         // Send new ids order as csv to backend
-        document.querySelector("button.saveOrder").on('click', () = post_func('update_order', pro_set_ids.join(','), () => location.reload()));
-        document.querySelector("button.cancelOrder").on('click', function() {
+        $("button.saveOrder").on('click', () => post_func('update_order', pro_set_ids.join(','), () => location.reload()));
+        $("button.cancelOrder").on('click', function() {
             location.reload();
         });
     }

--- a/src/static/templ/contests/manage/rand-pro.html
+++ b/src/static/templ/contests/manage/rand-pro.html
@@ -85,7 +85,7 @@
 		$("#addProSet").on('click', () => post_func('add_set', $("#proSet").val(), () => $("#proSet").val('')));
 
         // Send new ids order as csv to backend
-        document.querySelector("button.saveOrder").on('click', () = post_func('save_order', pro_set_ids.join(','), () => location.reload()));
+        document.querySelector("button.saveOrder").on('click', () = post_func('update_order', pro_set_ids.join(','), () => location.reload()));
         document.querySelector("button.cancelOrder").on('click', function() {
             location.reload();
         });

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -832,6 +832,7 @@ class RandomContestTest(AsyncTest):
                 'reqtype': 'add_set',
                 'pro_id': '6'
             })
+            self.assertAPIReturnSuccess(res.text)
             err, contest = await ContestService.inst.get_contest(2)
             self.assertIsNone(err)
             self.assertEqual(len(contest.pro_list), 7)
@@ -848,6 +849,7 @@ class RandomContestTest(AsyncTest):
             self.assertIsNone(err)
             self.assertEqual(str(contest.start_ip), '192.168.2.1')
             self.assertEqual(str(contest.end_ip), '192.168.2.16')
+            self.assertEqual(len(contest.ip_pro_list), 16)
             for ip_pro in contest.ip_pro_list.values():
                 self.assertIn(ip_pro[0], [8,7,9,11])
                 self.assertIn(ip_pro[1], [5,10])
@@ -857,9 +859,11 @@ class RandomContestTest(AsyncTest):
                 'reqtype': 'update_order',
                 'pro_id': '1,0,2'
             })
+            self.assertAPIReturnSuccess(res.text)
             err, contest = await ContestService.inst.get_contest(2)
             self.assertIsNone(err)
             self.assertEqual(len(contest.pro_list), 7)
+            self.assertEqual(len(contest.ip_pro_list), 16)
             for ip_pro in contest.ip_pro_list.values():
                 self.assertIn(ip_pro[0], [5,10])
                 self.assertIn(ip_pro[1], [8,7,9,11])
@@ -869,8 +873,10 @@ class RandomContestTest(AsyncTest):
                 'reqtype': 'remove_set',
                 'pro_id': '1'
             })
+            self.assertAPIReturnSuccess(res.text)
             err, contest = await ContestService.inst.get_contest(2)
             self.assertIsNone(err)
+            self.assertEqual(len(contest.ip_pro_list), 16)
             self.assertEqual(len(contest.pro_list), 3)
             for ip_pro in contest.ip_pro_list.values():
                 self.assertIn(ip_pro[0], [5,10])

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -687,3 +687,222 @@ class ContestTest(AsyncTest):
         # test scoreboard, challist
         # hide_admin: bool = True
         # test rechal
+
+class RandomContestTest(AsyncTest):
+    async def main(self):
+        with AccountContext('admin@test', 'testtest') as admin_session:
+            res = admin_session.post('contests/manage/add', data={
+                'reqtype': 'add',
+                'name': 'random contest 1'
+            })
+            self.assertEqual(json.loads(res.text)['data'], 2)
+            err, contest = await ContestService.inst.get_contest(2)
+            self.assertIsNone(err)
+            self.assertEqual(contest.name, 'random contest 1')
+
+            # update general
+            now = datetime.datetime.now()
+            contest_start = now + datetime.timedelta(days=1)
+            contest_end = now + datetime.timedelta(days=4)
+            reg_end = now + datetime.timedelta(days=1) - datetime.timedelta(hours=8)
+            default_config = {
+                'reqtype': 'update',
+                'name': 'random contest 1',
+
+                'contest_mode': ContestMode.IOI,
+                'contest_start': self.get_isoformat(contest_start),
+                'contest_end': self.get_isoformat(contest_end),
+
+                'reg_mode': RegMode.INVITED,
+                'reg_end': self.get_isoformat(reg_end),
+
+                'allow_compilers[]': [Compiler.GPP, Compiler.CLANGPP],
+                'is_public_scoreboard': 'true',
+                'allow_view_other_page': 'true',
+                'hide_admin': 'true',
+
+                'submission_cd_time': 60,
+                'freeze_scoreboard_period': 0
+            }
+            res = admin_session.post('contests/2/manage/general', data=default_config)
+            self.assertAPIReturnSuccess(res.text)
+
+            # add problem
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'add',
+                'pro_id': 5
+            })
+            self.assertAPIReturnSuccess(res.text)
+            err, contest = await ContestService.inst.get_contest(2)
+            self.assertIsNone(err)
+            self.assertIn(5, contest.pro_list)
+
+            random_set_config = {
+                'reqtype': 'update',
+                'name': 'random contest 1',
+
+                'contest_mode': ContestMode.RANDOM_SET,
+                'contest_start': self.get_isoformat(contest_start),
+                'contest_end': self.get_isoformat(contest_end),
+
+                'reg_mode': RegMode.INVITED,
+                'reg_end': self.get_isoformat(reg_end),
+
+                'allow_compilers[]': [Compiler.GPP, Compiler.CLANGPP],
+                'is_public_scoreboard': 'true',
+                'allow_view_other_page': 'true',
+                'hide_admin': 'true',
+
+                'submission_cd_time': 60,
+                'freeze_scoreboard_period': 0
+            }
+            res = admin_session.post('contests/2/manage/general', data=random_set_config)
+            self.assertAPIReturnValue(res.text, ('Echmod', 'Cannot change contest mode when problem list is not empty'))
+
+            # Remove problem and try again
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'remove',
+                'pro_id': 5
+            })
+            res = admin_session.post('contests/2/manage/general', data=random_set_config)
+            self.assertAPIReturnSuccess(res.text)
+
+            err, contest = await ContestService.inst.get_contest(2)
+            assert contest
+            self.assertIsNone(err)
+            self.assertEqual(contest.contest_mode, ContestMode.RANDOM_SET)
+
+            _, contest_list = await ContestService.inst.get_contest_list()
+            self.assertEqual(len(contest_list), 2)
+            self.assertEqual(contest_list[1]['name'], 'random contest 1')
+            self.assertEqual(contest_list[1]['contest_mode'], ContestMode.RANDOM_SET)
+            self.assertTrue(contest_list[1]['is_public_scoreboard'])
+
+            res = admin_session.post('contests/2/manage/acct', data={
+                'reqtype': 'update_ip',
+                'start_ip': '255.255.193.256',
+                'end_ip': '192.168.1.16'
+            })
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Invalid IP address format.'))
+
+            res = admin_session.post('contests/2/manage/acct', data={
+                'reqtype': 'update_ip',
+                'start_ip': '192.168.1.16',
+                'end_ip': '192.168.1.1'
+            })
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Invalid IP range'))
+
+            res = admin_session.post('contests/2/manage/acct', data={
+                'reqtype': 'update_ip',
+                'start_ip': '192.168.1.1',
+                'end_ip': '192.168.1.16'
+            })
+            self.assertAPIReturnSuccess(res.text)
+            err, contest = await ContestService.inst.get_contest(2)
+            self.assertIsNone(err)
+            self.assertEqual(str(contest.start_ip), '192.168.1.1')
+            self.assertEqual(str(contest.end_ip), '192.168.1.16')
+
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'add_set',
+                'pro_id': '8,7,9,11'
+            })
+            self.assertAPIReturnSuccess(res.text)
+            err, contest = await ContestService.inst.get_contest(2)
+            self.assertIsNone(err)
+            pre_pro = None
+            self.assertEqual(len(contest.pro_list), 4)
+            self.assertEqual(len(contest.ip_pro_list), 16)
+            for ip_pro in contest.ip_pro_list.values():
+                self.assertIn(ip_pro[0], [7,8,9,11])
+                self.assertNotEqual(ip_pro[0], pre_pro)
+                pre_pro = ip_pro[0]
+
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'add_set',
+                'pro_id': '5,10'
+            })
+            err, contest = await ContestService.inst.get_contest(2)
+            self.assertIsNone(err)
+            self.assertEqual(len(contest.pro_list), 6)
+            for ip_pro in contest.ip_pro_list.values():
+                self.assertIn(ip_pro[1], [5,10])
+
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'add_set',
+                'pro_id': '6'
+            })
+            err, contest = await ContestService.inst.get_contest(2)
+            self.assertIsNone(err)
+            self.assertEqual(len(contest.pro_list), 7)
+            for ip_pro in contest.ip_pro_list.values():
+                self.assertEqual(ip_pro[2], 6)
+
+            res = admin_session.post('contests/2/manage/acct', data={
+                'reqtype': 'update_ip',
+                'start_ip': '192.168.2.1',
+                'end_ip': '192.168.2.16'
+            })
+            self.assertAPIReturnSuccess(res.text)
+            err, contest = await ContestService.inst.get_contest(2)
+            self.assertIsNone(err)
+            self.assertEqual(str(contest.start_ip), '192.168.2.1')
+            self.assertEqual(str(contest.end_ip), '192.168.2.16')
+            for ip_pro in contest.ip_pro_list.values():
+                self.assertIn(ip_pro[0], [8,7,9,11])
+                self.assertIn(ip_pro[1], [5,10])
+                self.assertEqual(ip_pro[2], 6)
+
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'update_order',
+                'pro_id': '1,0,2'
+            })
+            err, contest = await ContestService.inst.get_contest(1)
+            self.assertIsNone(err)
+            self.assertEqual(len(contest.pro_list), 7)
+            for ip_pro in contest.ip_pro_list.values():
+                self.assertIn(ip_pro[0], [5,10])
+                self.assertIn(ip_pro[1], [8,7,9,11])
+                self.assertEqual(ip_pro[2], 6)
+
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'remove_set',
+                'pro_id': '1'
+            })
+            err, contest = await ContestService.inst.get_contest(1)
+            self.assertIsNone(err)
+            self.assertEqual(len(contest.pro_list), 3)
+            for ip_pro in contest.ip_pro_list.values():
+                self.assertIn(ip_pro[0], [5,10])
+                self.assertEqual(ip_pro[1], 6)
+
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'add_set',
+                'pro_id': '11,6'
+            })
+            self.assertAPIReturnValue(res.text, ('Eexist', 'Problem 6 already in contest'))
+            err, contest = await ContestService.inst.get_contest(2)
+            self.assertIsNone(err)
+            self.assertEqual(len(contest.pro_list), 3)
+
+            invalid_order = ['1,1', '0,2', '2,0', 'a,b', '1', '1,2,3']
+            for order in invalid_order:
+                res = admin_session.post('contests/2/manage/pro', data={
+                    'reqtype': 'update_order',
+                    'pro_id': order
+                })
+                self.assertAPIReturnValue(res.text, ('Eparam', 'Invalid new indexes for problem sets'))
+                err, contest = await ContestService.inst.get_contest(2)
+                self.assertIsNone(err)
+                self.assertEqual(len(contest.pro_list), 3)
+
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'remove_set',
+                'pro_id': '2'
+            })
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Problem set index out of range'))
+            err, contest = await ContestService.inst.get_contest(2)
+            self.assertIsNone(err)
+            self.assertEqual(len(contest.pro_list), 3)
+
+

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -184,6 +184,22 @@ class ContestTest(AsyncTest):
             self.assertIsNone(err)
             self.assertEqual(pro.status, ProConst.STATUS_CONTEST)
 
+            res = admin_session.post('contests/1/manage/pro' , data={
+                'reqtype': 'add_set',
+                'pro_id': '5-7'
+            })
+            self.assertAPIReturnValue(res.text, ('Emod', 'Cannot add problem set to non-random set contests'))
+            res = admin_session.post('contests/1/manage/pro' , data={
+                'reqtype': 'remove_set',
+                'pro_id': '1'
+            })
+            self.assertAPIReturnValue(res.text, ('Emod', 'Cannot remove problem set from non-random set contests'))
+            res = admin_session.post('contests/1/manage/pro' , data={
+                'reqtype': 'update_order',
+                'pro_id': '1'
+            })
+            self.assertAPIReturnValue(res.text, ('Emod', 'Cannot update problem order in non-random set contests'))
+
         with AccountContext('admin@test', 'testtest') as admin_session:
             res = admin_session.post('contests/1/manage/acct', data={
                 'reqtype': 'add',
@@ -882,13 +898,30 @@ class RandomContestTest(AsyncTest):
                 self.assertIn(ip_pro[0], [5,10])
                 self.assertEqual(ip_pro[1], 6)
 
+        with AccountContext('admin@test', 'testtest') as admin_session:
             res = admin_session.post('contests/2/manage/pro', data={
                 'reqtype': 'add_set',
                 'pro_id': '11,6'
             })
             self.assertAPIReturnValue(res.text, ('Eexist', 'Problem 6 already in contest'))
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'add_set',
+                'pro_id': '7,20,8'
+            })
+            self.assertAPIReturnValue(res.text, ('Enoext', 'One or more problem IDs do not exist'))
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'add',
+                'pro_id': '11'
+            })
+            self.assertAPIReturnValue(res.text,('Emod', 'Cannot add problems to random set contests'))
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'multi_add',
+                'pro_id': '7-8'
+            })
+            self.assertAPIReturnValue(res.text,('Emod', 'Cannot add problems to random set contests'))
             err, contest = await ContestService.inst.get_contest(2)
             self.assertIsNone(err)
+            self.assertEqual(len(contest.ip_pro_list), 16)
             self.assertEqual(len(contest.pro_list), 3)
 
             invalid_order = ['1,1', '0,2', '2,0', 'a,b', '1', '1,2,3']
@@ -898,17 +931,28 @@ class RandomContestTest(AsyncTest):
                     'pro_id': order
                 })
                 self.assertAPIReturnValue(res.text, ('Eparam', 'Invalid new indexes for problem sets'))
-                err, contest = await ContestService.inst.get_contest(2)
-                self.assertIsNone(err)
-                self.assertEqual(len(contest.pro_list), 3)
+            self.assertEqual(len(contest.ip_pro_list), 16)
+            self.assertEqual(len(contest.pro_list), 3)
+            for ip_pro in contest.ip_pro_list.values():
+                self.assertIn(ip_pro[0], [5,10])
+                self.assertEqual(ip_pro[1], 6)
 
             res = admin_session.post('contests/2/manage/pro', data={
                 'reqtype': 'remove_set',
                 'pro_id': '2'
             })
             self.assertAPIReturnValue(res.text, ('Eparam', 'Problem set index out of range'))
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'remove',
+                'pro_id': '6'
+            })
+            self.assertAPIReturnValue(res.text,('Emod', 'Cannot remove problems from random set contests'))
+            res = admin_session.post('contests/2/manage/pro', data={
+                'reqtype': 'multi_remove',
+                'pro_id': '5-6'
+            })
+            self.assertAPIReturnValue(res.text,('Emod', 'Cannot remove problems from random set contests'))
             err, contest = await ContestService.inst.get_contest(2)
             self.assertIsNone(err)
+            self.assertEqual(len(contest.ip_pro_list), 16)
             self.assertEqual(len(contest.pro_list), 3)
-
-

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -857,7 +857,7 @@ class RandomContestTest(AsyncTest):
                 'reqtype': 'update_order',
                 'pro_id': '1,0,2'
             })
-            err, contest = await ContestService.inst.get_contest(1)
+            err, contest = await ContestService.inst.get_contest(2)
             self.assertIsNone(err)
             self.assertEqual(len(contest.pro_list), 7)
             for ip_pro in contest.ip_pro_list.values():
@@ -869,7 +869,7 @@ class RandomContestTest(AsyncTest):
                 'reqtype': 'remove_set',
                 'pro_id': '1'
             })
-            err, contest = await ContestService.inst.get_contest(1)
+            err, contest = await ContestService.inst.get_contest(2)
             self.assertIsNone(err)
             self.assertEqual(len(contest.pro_list), 3)
             for ip_pro in contest.ip_pro_list.values():

--- a/src/tests/integrated/main.py
+++ b/src/tests/integrated/main.py
@@ -21,7 +21,7 @@ from .acct import SignTest, AcctPageTest
 from .board import BoardTest
 from .bulletin import BulletinTest
 from .chal import ChalTest, ChalListTest
-from .contest import ContestTest
+from .contest import ContestTest, RandomContestTest
 from .proclass import ProClassTest
 from .ques import QuesTest
 from .submit import SubmitTest
@@ -203,7 +203,8 @@ class IntegratedTest(AsyncTest):
             BatchSubtaskTest().main,
             ManageProFileManagerTest().main,
             ManagePackTest().main,
-            ContestTest().main
+            ContestTest().main,
+            RandomContestTest().main,
         ]
         for f in s:
             r = await f()


### PR DESCRIPTION
## Description
TOJ will be used as an online judge for exams.   
To avoiding cheating, we introduced a new "Random Set" contest mode in this PR. 
 
In this contest mode, each problem number corresponds to a problem set.  
And if a problem set contains more than 2 problems, any adjacent contestants will always see different problems. Otherwise, the assignment is randomized.  

## Implementation
- **IP-Based Assignment:** Because the exams are held in the classroom, the adjacent computers always have adjacent IP addresses. This allows us to assign problems based on the request's IP address.
- **Admin Controls:** The admin interface allows for:
  - Defining the IP range for the contest.
  - Adding, removing, and reordering problem sets.
- **Database Changes:** 
  - One new table `contest_ip_joints` is added to record the problems assign to the ip.
  - Two columns `start_ip` and `end_ip` are added to table `contests` to record the contests' ip range.

### Note
This PR only completes the admin-side features, user-side features like scoreboard will be done later.