### PR TITLE
fix(manage): failed to add problem with webui setup

### DIFF
--- a/migration/20260214_remove_problem_allow_compilers_default_value.py
+++ b/migration/20260214_remove_problem_allow_compilers_default_value.py
@@ -1,0 +1,3 @@
+async def dochange(db, rs):
+    # Happy Valentine's Day :cry:
+    await db.execute('ALTER TABLE problem ALTER COLUMN allow_compilers DROP DEFAULT')

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -185,7 +185,6 @@ class ProService:
         ProService.inst = self
 
     async def get_pro(self, pro_id: int, allow_statuses: Sequence[int]) -> tuple[None, Problem] | ErrorType:
-        from services.chal import Compiler
         from services.prospec.batch import batch_spec
         """
         Fetch problem configuration and metadata by ID, ensuring it's in the allowed status.
@@ -387,6 +386,18 @@ class ProService:
             os.mkdir(f"problem/{pro_id}/res")
             os.mkdir(f"problem/{pro_id}/http")
             os.mkdir(f"problem/{pro_id}/res/testdata")
+            from services.prospec.batch import batch_spec
+
+            config_json = batch_spec.to_json(batch_spec.get_default_config())
+
+            await con.execute(
+                '''
+                UPDATE problem SET config = $1
+                WHERE pro_id = $2;
+                ''',
+                json.dumps(config_json),
+                pro_id,
+            )
 
         await self.rs.delete("prolist")
 

--- a/src/services/prospec/base.py
+++ b/src/services/prospec/base.py
@@ -8,6 +8,16 @@ class ProSpec(ABC):
     """Abstract base class for problem type specifications."""
 
     @abstractmethod
+    def get_default_config(self) -> Any:
+        """
+        Get the default configuration for this problem type.
+
+        Returns:
+            Problem type-specific config object (e.g., BatchConfig) inheriting from BaseConfig
+        """
+        ...
+
+    @abstractmethod
     def from_json(self, data: dict[str, Any]) -> Any:
         """
         Parse JSON data into a problem type-specific configuration.
@@ -98,7 +108,9 @@ class ProSpec(ABC):
         ...
 
     @abstractmethod
-    def parse_testdata_files(self, testdata_id: int, files_json: dict[str, Any]) -> BaseTestdata:
+    def parse_testdata_files(
+        self, testdata_id: int, files_json: dict[str, Any]
+    ) -> BaseTestdata:
         """
         Parse testdata files JSON into a dictionary.
 

--- a/src/services/prospec/batch.py
+++ b/src/services/prospec/batch.py
@@ -41,6 +41,21 @@ class BatchTestdata(BaseTestdata):
 class BatchProblemSpec(ProSpec):
     """Specification for Batch-type problems."""
 
+    def get_default_config(self) -> BatchConfig:
+        from services.chal import Compiler
+        return BatchConfig(
+            chalmeta='',
+            userprog_compile_args='',
+            checker_type=CheckerType.DIFF,
+            checker_compiler=None,
+            checker_compile_args='',
+            summary_type=SummaryType.GROUPMIN,
+            summary_compiler=None,
+            summary_compile_args='',
+            has_grader=False,
+            allow_compilers=set(compiler for compiler in Compiler),
+        )
+
     def from_json(self, data: dict[str, Any]) -> BatchConfig:
         """Parse JSON data into BatchConfig."""
         from services.chal import Compiler


### PR DESCRIPTION
`add_pro()` did not set the default problem spec config, which caused errors.
Also remove the default value from allow_compilers, as it should be defined by each problem spec implementation instead of the database.