### PR TITLE
Chore/upgrade mathjax

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -219,7 +219,11 @@ var index = new function() {
                 } else {
                     that.cont_destroy = null;
                 }
-                MathJax.typesetPromise();
+                try {
+                    MathJax.typesetPromise();
+                } catch (e) {
+                    console.warn('MathJax typeset error', e);
+                }
                 that.containerLoadDone = true;
             });
 

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -219,6 +219,7 @@ var index = new function() {
                 } else {
                     that.cont_destroy = null;
                 }
+                MathJax.typesetPromise();
                 that.containerLoadDone = true;
             });
 

--- a/src/static/templ/index.html
+++ b/src/static/templ/index.html
@@ -21,15 +21,24 @@
   <script src="{{ url('/src/index.js') }}"></script>
   <script src="{{ url('/src/pack.js') }}"></script>
   <script type="module"> import pdfjsDist from 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.7.76/+esm' </script>
-  <script src="{{ url('/third/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML') }}" async></script>
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@4.1.0/tex-chtml.js" async></script>
   <script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-        jax: ['output/SVG'],
-        tex2jax:{
-            inlineMath:[['$','$'],['\\(','\\)'], ['$$$', '$$$']],
-            displayMath: [['$$$$$$', '$$$$$$']]
-        }
-    });
+    window.MathJax = {
+      tex: {
+        inlineMath: [
+          ['$', '$'],
+          ['\\(', '\\)'],
+          ['$$$', '$$$']
+        ],
+        displayMath: [
+          ['$$', '$$'],
+          ['$$$$$$', '$$$$$$']
+        ]
+      },
+      svg: {
+        fontCache: 'global'
+      }
+    };
   </script>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" async></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.1.7/purify.min.js" integrity="sha512-BdRNuI8/lsyxkKQVxK1lVtfZshggfXPAwEP+JAOJEKx6Y8SLfcBSRdaWyXQmMxo+wG180uFqXYGjGRL0mh4/Jw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/src/static/templ/index.html
+++ b/src/static/templ/index.html
@@ -22,7 +22,7 @@
   <script src="{{ url('/src/pack.js') }}"></script>
   <script type="module"> import pdfjsDist from 'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.7.76/+esm' </script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@4.1.0/tex-chtml.js" async></script>
-  <script type="text/x-mathjax-config">
+  <script>
     window.MathJax = {
       tex: {
         inlineMath: [
@@ -34,9 +34,6 @@
           ['$$', '$$'],
           ['$$$$$$', '$$$$$$']
         ]
-      },
-      svg: {
-        fontCache: 'global'
       }
     };
   </script>

--- a/src/static/templ/pro.html
+++ b/src/static/templ/pro.html
@@ -2,13 +2,6 @@
 {% from utils.numeric import merge_list_to_str %}
 <link rel="stylesheet" type="text/css" href="{{ url('/src/pro.css') }}">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.7.76/pdf_viewer.min.css" integrity="sha512-8LkkqbXJPviYJENC5Z8qC2uKz27x0tNgrZbzsAzt7zkw0/2lXtSdrslVhfrkcR+6LRmxjZxlqniSyWXimoaH5g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-<script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-        tex2jax:{
-            inlineMath:[['$','$'],['\\(','\\)']]
-        }
-    });
-</script>
 <script type="text/javascript">
     var pdf_url = '';
     var html_url = '';
@@ -71,11 +64,6 @@
         let j_cont = $('#cont');
 
         function _load_html() {
-            scriptTag = document.createElement('script');
-            // TODO: docker
-            scriptTag.src = 'https://toj.tfcis.org/oj/third/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML';
-            document.head.appendChild(scriptTag);
-
             j_cont.load(html_url, function(res, status, xhr) {
                 if (status == 'error') {
                     $('#pdfbtn').show();
@@ -88,7 +76,7 @@
                         viewer = 2;
                     }
                 } else {
-                    MathJax.Hub.Queue(["Typeset",MathJax.Hub,j_cont[0]]);
+                    MathJax.typeset();
                     j_cont.find('pre > code').each(function(i, e) {
                         $(e).addClass('html');
                         hljs.highlightBlock(e);

--- a/src/static/templ/pro.html
+++ b/src/static/templ/pro.html
@@ -76,7 +76,11 @@
                         viewer = 2;
                     }
                 } else {
-                    MathJax.typeset();
+                    try {
+                        MathJax.typeset();
+                    } catch (e) {
+                        console.warn('MathJax typeset error', e);
+                    }
                     j_cont.find('pre > code').each(function(i, e) {
                         $(e).addClass('html');
                         hljs.highlightBlock(e);


### PR DESCRIPTION
Upgrade MathJax from v2 to v4.1.0
Improves rendering features and performance.
Fixes bugs and addresses CVE vulnerabilities.
Ensures consistent LaTeX rendering when updating the page (previously unstable, with occasional failures to render).