### PR TITLE
fix(contest): registration follow spec.

### DIFF
--- a/src/handlers/contests/manage/general.py
+++ b/src/handlers/contests/manage/general.py
@@ -83,13 +83,10 @@ class ContestManageGeneralHandler(RequestHandler):
         err, contest_start = trantime(contest_start)
         if err:
             return self.error(err)
-        assert contest_start
         err, contest_end = trantime(contest_end)
         if err:
             return self.error(err)
-        assert contest_end
         err, reg_end = trantime(reg_end)
-        assert reg_end
         if err:
             return self.error(err)
 
@@ -106,9 +103,19 @@ class ContestManageGeneralHandler(RequestHandler):
             self.contest.reg_mode is RegMode.REG_APPROVAL
             and reg_mode is RegMode.FREE_REG
         ):
-            for acct_id, v in self.contest.user_list.items():
+            for acct_id, v in list(self.contest.user_list.items()):
                 if v["status"] == UserStatus.REQUESTED:
                     self.contest.user_list[acct_id]["status"] = UserStatus.APPROVED
+                elif v["status"] == UserStatus.REJECTED:
+                    self.contest.user_list.pop(acct_id)
+
+        elif (
+            self.contest.reg_mode is RegMode.REG_APPROVAL
+            and reg_mode is RegMode.INVITED
+        ):
+            for acct_id, v in list(self.contest.user_list.items()):
+                if v["status"] in (UserStatus.REQUESTED, UserStatus.REJECTED):
+                    self.contest.user_list.pop(acct_id)
 
         self.contest.reg_mode = reg_mode
         if reg_mode is RegMode.INVITED:

--- a/src/handlers/contests/manage/general.py
+++ b/src/handlers/contests/manage/general.py
@@ -83,9 +83,11 @@ class ContestManageGeneralHandler(RequestHandler):
         err, contest_start = trantime(contest_start)
         if err:
             return self.error(err)
+        assert contest_start
         err, contest_end = trantime(contest_end)
         if err:
             return self.error(err)
+        assert contest_end
         err, reg_end = trantime(reg_end)
         if err:
             return self.error(err)
@@ -93,6 +95,8 @@ class ContestManageGeneralHandler(RequestHandler):
         self.contest.name = name
 
         self.contest.contest_mode = contest_mode
+        if contest_end <= contest_start:
+            return self.error(("Eparam", "Contest end time should be later than start time"))
         self.contest.contest_start = contest_start
         self.contest.contest_end = contest_end
 

--- a/src/handlers/contests/manage/general.py
+++ b/src/handlers/contests/manage/general.py
@@ -89,6 +89,7 @@ class ContestManageGeneralHandler(RequestHandler):
             return self.error(err)
         assert contest_end
         err, reg_end = trantime(reg_end)
+        assert reg_end
         if err:
             return self.error(err)
 
@@ -110,7 +111,10 @@ class ContestManageGeneralHandler(RequestHandler):
                     self.contest.user_list[acct_id]["status"] = UserStatus.APPROVED
 
         self.contest.reg_mode = reg_mode
-        self.contest.reg_end = reg_end
+        if reg_mode is RegMode.INVITED:
+            self.contest.reg_end = contest_end
+        else:
+            self.contest.reg_end = reg_end
 
         self.contest.allow_compilers = allow_compilers
         self.contest.is_public_scoreboard = is_public_scoreboard

--- a/src/handlers/contests/manage/reg.py
+++ b/src/handlers/contests/manage/reg.py
@@ -30,9 +30,13 @@ class ContestManageRegHandler(RequestHandler):
             rejected_list=rejected_list,
         )
 
-    @contest_manage_reg_dispatcher.action("approval")
+    @contest_manage_reg_dispatcher.action("approve")
     async def approval_action(self):
         acct_id = self.acct_id
+        if acct_id not in self.contest.user_list:
+            return self.error(
+                ("Enoext", f"Account(#{acct_id}) is not registered in this contest")
+            )
         old_status = self.contest.user_list[acct_id]["status"]
         if old_status not in (UserStatus.REQUESTED, UserStatus.REJECTED):
             return self.error(

--- a/src/handlers/contests/manage/reg.py
+++ b/src/handlers/contests/manage/reg.py
@@ -10,27 +10,36 @@ class ContestManageRegHandler(RequestHandler):
     @reqenv
     @contest_require_permission("admin")
     async def get(self):
-        reg_list = []
+        requested_list = []
+        rejected_list = []
 
         for acct_id, v in self.contest.user_list.items():
-            if v["status"] in (UserStatus.REJECTED, UserStatus.REQUESTED):
+            if v["status"] == UserStatus.REQUESTED:
                 _, acct = await UserService.inst.info_acct(acct_id)
-                reg_list.append(acct)
+                requested_list.append(acct)
+            elif v["status"] == UserStatus.REJECTED:
+                _, acct = await UserService.inst.info_acct(acct_id)
+                rejected_list.append(acct)
 
         await self.render(
             "contests/manage/reg",
             page="reg",
             contest_id=self.contest.contest_id,
             contest=self.contest,
-            reg_list=reg_list,
+            requested_list=requested_list,
+            rejected_list=rejected_list,
         )
 
     @contest_manage_reg_dispatcher.action("approval")
     async def approval_action(self):
         acct_id = self.acct_id
-        if not self.contest.member_is_status(acct_id, UserStatus.REQUESTED):
+        old_status = self.contest.user_list[acct_id]["status"]
+        if old_status not in (UserStatus.REQUESTED, UserStatus.REJECTED):
             return self.error(
-                ("Enoext", f"Account(#{acct_id}) should be in the request status")
+                (
+                    "Enoext",
+                    f"Account(#{acct_id}) should be in the request or rejected status",
+                )
             )
 
         self.contest.user_list[acct_id]["status"] = UserStatus.APPROVED
@@ -40,7 +49,10 @@ class ContestManageRegHandler(RequestHandler):
         await ContestService.inst.update_contest(
             self.acct, self.contest, userlist_updated=True
         )
-        return self.error(("S", f"Approve account(#{acct_id}) successfully."))
+        if old_status == UserStatus.REQUESTED:
+            return self.error(("S", f"Approve account(#{acct_id}) successfully."))
+        elif old_status == UserStatus.REJECTED:
+            return self.error(("S", f"Re-approve account(#{acct_id}) successfully."))
 
     @contest_manage_reg_dispatcher.action("reject")
     async def reject_action(self):

--- a/src/handlers/contests/reg.py
+++ b/src/handlers/contests/reg.py
@@ -26,17 +26,8 @@ class ContestRegHandler(RequestHandler):
         if self.contest.is_admin(self.acct):
             return self.error(("Eacces", "Contest admin do not need to register"))
 
-        status = None
-        if self.contest.reg_mode is RegMode.FREE_REG:
-            status = UserStatus.APPROVED
-        elif self.contest.reg_mode is RegMode.REG_APPROVAL:
-            status = UserStatus.REQUESTED
-
-        if (
-            acct_id in self.contest.user_list
-            and self.contest.user_list[acct_id]["status"] == status
-        ):
-            return self.error(("Eexist", "Already registered"))
+        if self.contest.reg_mode is RegMode.INVITED:
+            return self.error(("Eacces", "Invited mode do not allow register"))
 
         if datetime.datetime.now(datetime.UTC) > self.contest.reg_end:
             return self.error(
@@ -46,10 +37,18 @@ class ContestRegHandler(RequestHandler):
                 )
             )
 
-        if self.contest.reg_mode is RegMode.INVITED:
-            return self.error(("Eacces", "Invited mode do not allow register"))
+        if self.contest.member_is_status(acct_id, UserStatus.REJECTED):
+            assert self.contest.reg_mode is RegMode.REG_APPROVAL
+            return self.error(("Eacces", "Your registration has been rejected, you cannot register"))
 
-        elif self.contest.reg_mode is RegMode.FREE_REG:
+        if self.contest.member_is_status(acct_id, UserStatus.REQUESTED):
+            assert self.contest.reg_mode is RegMode.REG_APPROVAL
+            return self.error(("Eacces", "Your registration is in request status, please wait for approval"))
+
+        if self.contest.member_is_status(acct_id, UserStatus.APPROVED):
+            return self.error(("Eexist", "Your registration has been approved, you cannot register again"))
+
+        if self.contest.reg_mode is RegMode.FREE_REG:
             self.contest.user_list[acct_id] = {"status": UserStatus.APPROVED}
 
         elif self.contest.reg_mode is RegMode.REG_APPROVAL:
@@ -65,20 +64,35 @@ class ContestRegHandler(RequestHandler):
         acct_id = self.acct.acct_id
 
         if self.contest.is_admin(self.acct):
-            return self.error(("Eacces", "Contest admin do not need to register"))
+            return self.error(("Eacces", "Contest admin cannot unregister"))
 
         if self.contest.reg_mode is RegMode.INVITED:
-            return self.error(("Eacces", "Invited mode do not allow register"))
+            return self.error(("Eacces", "Invited mode do not allow unregister"))
+
+        if datetime.datetime.now(datetime.UTC) >= self.contest.contest_start:
+            return self.error(
+                ("Etime", "Contest has started, you cannot unregister now")
+            )
 
         if acct_id not in self.contest.user_list:
             return self.error(("Enoext", "You have not registered yet"))
 
+        if self.contest.member_is_status(acct_id, UserStatus.REJECTED):
+            assert self.contest.reg_mode is RegMode.REG_APPROVAL
+            return self.error(("Eacces", "Your registration has been rejected, you cannot unregister"))
+
         self.contest.user_list.pop(acct_id)
+
 
         await ContestService.inst.update_contest(
             self.acct, self.contest, userlist_updated=True
         )
-        return self.error(("S", "Unregister Successfully"))
+
+        if self.contest.member_is_status(acct_id, UserStatus.REQUESTED):
+            assert self.contest.reg_mode is RegMode.REG_APPROVAL
+            return self.error(("S", "Cancel Register Successfully"))
+        else:
+            return self.error(("S", "Unregister Successfully"))
 
     @reqenv
     @require_permission([UserConst.ACCTTYPE_USER, UserConst.ACCTTYPE_KERNEL])

--- a/src/handlers/contests/reg.py
+++ b/src/handlers/contests/reg.py
@@ -19,15 +19,17 @@ class ContestRegHandler(RequestHandler):
 
         await self.render("contests/reg", contest=self.contest)
 
-    @contest_reg_dispatcher.action("reg")
-    async def register_action(self):
-        acct_id = self.acct.acct_id
-
+    def check(self, action_name):
         if self.contest.is_admin(self.acct):
-            return self.error(("Eacces", "Contest admin do not need to register"))
+            return ("Eacces", f"Contest admin cannot {action_name}")
 
         if self.contest.reg_mode is RegMode.INVITED:
-            return self.error(("Eacces", "Invited mode do not allow register"))
+            return ("Eacces", f"Invited mode do not allow {action_name}")
+
+    @contest_reg_dispatcher.action("reg")
+    async def register_action(self):
+        if error := self.check("register"):
+            return self.error(error)
 
         if datetime.datetime.now(datetime.UTC) > self.contest.reg_end:
             return self.error(
@@ -37,6 +39,7 @@ class ContestRegHandler(RequestHandler):
                 )
             )
 
+        acct_id = self.acct.acct_id
         if self.contest.member_is_status(acct_id, UserStatus.REJECTED):
             assert self.contest.reg_mode is RegMode.REG_APPROVAL
             return self.error(("Eacces", "Your registration has been rejected, you cannot register"))
@@ -59,40 +62,53 @@ class ContestRegHandler(RequestHandler):
         )
         return self.error(("S", "Register Successfully"))
 
+    @contest_reg_dispatcher.action("cancelreq")
+    async def cancel_request_action(self):
+        if error := self.check("cancel request"):
+            return self.error(error)
+
+        if datetime.datetime.now(datetime.UTC) > self.contest.reg_end:
+            return self.error(("Etime", "Registration time has passed, you cannot cancel request now"))
+
+        acct_id = self.acct.acct_id
+        if acct_id not in self.contest.user_list:
+            return self.error(("Enoext", "You have not registered yet"))
+
+        if not self.contest.member_is_status(acct_id, UserStatus.REQUESTED):
+            return self.error(("Eacces", "Your registration is not in request status, you cannot cancel request"))
+
+        self.contest.user_list.pop(acct_id)
+        await ContestService.inst.update_contest(
+            self.acct, self.contest, userlist_updated=True
+        )
+        return self.error(("S", "Cancel Request Successfully"))
+
     @contest_reg_dispatcher.action("unreg")
     async def unregister_action(self):
-        acct_id = self.acct.acct_id
-
-        if self.contest.is_admin(self.acct):
-            return self.error(("Eacces", "Contest admin cannot unregister"))
-
-        if self.contest.reg_mode is RegMode.INVITED:
-            return self.error(("Eacces", "Invited mode do not allow unregister"))
+        if error := self.check("unregister"):
+            return self.error(error)
 
         if datetime.datetime.now(datetime.UTC) >= self.contest.contest_start:
             return self.error(
                 ("Etime", "Contest has started, you cannot unregister now")
             )
 
+        acct_id = self.acct.acct_id
         if acct_id not in self.contest.user_list:
             return self.error(("Enoext", "You have not registered yet"))
 
         if self.contest.member_is_status(acct_id, UserStatus.REJECTED):
             assert self.contest.reg_mode is RegMode.REG_APPROVAL
             return self.error(("Eacces", "Your registration has been rejected, you cannot unregister"))
+        elif self.contest.member_is_status(acct_id, UserStatus.REQUESTED):
+            assert self.contest.reg_mode is RegMode.REG_APPROVAL
+            return self.error(("Eacces", "Your registration is in request status, you cannot unregister"))
 
         self.contest.user_list.pop(acct_id)
-
-
         await ContestService.inst.update_contest(
             self.acct, self.contest, userlist_updated=True
         )
-
-        if self.contest.member_is_status(acct_id, UserStatus.REQUESTED):
-            assert self.contest.reg_mode is RegMode.REG_APPROVAL
-            return self.error(("S", "Cancel Register Successfully"))
-        else:
-            return self.error(("S", "Unregister Successfully"))
+        return self.error(("S", "Unregister Successfully"))
 
     @reqenv
     @require_permission([UserConst.ACCTTYPE_USER, UserConst.ACCTTYPE_KERNEL])

--- a/src/handlers/contests/reg.py
+++ b/src/handlers/contests/reg.py
@@ -15,7 +15,7 @@ class ContestRegHandler(RequestHandler):
             return self.error(("Enoext", "Contest not found"))
 
         if self.contest.is_admin(self.acct):
-            return self.error(("Eacces", "Contest admin do not need to register"))
+            return self.error(("Eacces", "Contest admin cannot register"))
 
         await self.render("contests/reg", contest=self.contest)
 
@@ -24,14 +24,14 @@ class ContestRegHandler(RequestHandler):
             return ("Eacces", f"Contest admin cannot {action_name}")
 
         if self.contest.reg_mode is RegMode.INVITED:
-            return ("Eacces", f"Invited mode do not allow {action_name}")
+            return ("Eacces", f"Invited mode does not allow {action_name}")
 
     @contest_reg_dispatcher.action("reg")
     async def register_action(self):
         if error := self.check("register"):
             return self.error(error)
 
-        if datetime.datetime.now(datetime.UTC) > self.contest.reg_end:
+        if datetime.datetime.now(datetime.UTC) >= self.contest.reg_end:
             return self.error(
                 (
                     "Etime",
@@ -42,14 +42,26 @@ class ContestRegHandler(RequestHandler):
         acct_id = self.acct.acct_id
         if self.contest.member_is_status(acct_id, UserStatus.REJECTED):
             assert self.contest.reg_mode is RegMode.REG_APPROVAL
-            return self.error(("Eacces", "Your registration has been rejected, you cannot register"))
+            return self.error(
+                ("Eacces", "Your registration has been rejected, you cannot register")
+            )
 
         if self.contest.member_is_status(acct_id, UserStatus.REQUESTED):
             assert self.contest.reg_mode is RegMode.REG_APPROVAL
-            return self.error(("Eacces", "Your registration is in request status, please wait for approval"))
+            return self.error(
+                (
+                    "Eacces",
+                    "Your registration is in request status, please wait for approval",
+                )
+            )
 
         if self.contest.member_is_status(acct_id, UserStatus.APPROVED):
-            return self.error(("Eexist", "Your registration has been approved, you cannot register again"))
+            return self.error(
+                (
+                    "Eexist",
+                    "Your registration has been approved, you cannot register again",
+                )
+            )
 
         if self.contest.reg_mode is RegMode.FREE_REG:
             self.contest.user_list[acct_id] = {"status": UserStatus.APPROVED}
@@ -67,15 +79,22 @@ class ContestRegHandler(RequestHandler):
         if error := self.check("cancel request"):
             return self.error(error)
 
-        if datetime.datetime.now(datetime.UTC) > self.contest.reg_end:
-            return self.error(("Etime", "Registration time has passed, you cannot cancel request now"))
+        if datetime.datetime.now(datetime.UTC) >= self.contest.reg_end:
+            return self.error(
+                ("Etime", "Registration time has passed, you cannot cancel request now")
+            )
 
         acct_id = self.acct.acct_id
         if acct_id not in self.contest.user_list:
             return self.error(("Enoext", "You have not registered yet"))
 
         if not self.contest.member_is_status(acct_id, UserStatus.REQUESTED):
-            return self.error(("Eacces", "Your registration is not in request status, you cannot cancel request"))
+            return self.error(
+                (
+                    "Eacces",
+                    "Your registration is not in request status, you cannot cancel request",
+                )
+            )
 
         self.contest.user_list.pop(acct_id)
         await ContestService.inst.update_contest(
@@ -99,10 +118,17 @@ class ContestRegHandler(RequestHandler):
 
         if self.contest.member_is_status(acct_id, UserStatus.REJECTED):
             assert self.contest.reg_mode is RegMode.REG_APPROVAL
-            return self.error(("Eacces", "Your registration has been rejected, you cannot unregister"))
+            return self.error(
+                ("Eacces", "Your registration has been rejected, you cannot unregister")
+            )
         elif self.contest.member_is_status(acct_id, UserStatus.REQUESTED):
             assert self.contest.reg_mode is RegMode.REG_APPROVAL
-            return self.error(("Eacces", "Your registration is in request status, you cannot unregister"))
+            return self.error(
+                (
+                    "Eacces",
+                    "Your registration is in request status, you cannot unregister",
+                )
+            )
 
         self.contest.user_list.pop(acct_id)
         await ContestService.inst.update_contest(

--- a/src/static/templ/contests/info.html
+++ b/src/static/templ/contests/info.html
@@ -42,17 +42,17 @@
             </div>
 
             <div class="card mb-1">
-                <div class="card-header">Registration Before</div>
+                <div class="card-header">Registration Mode</div>
                 <div class="card-body">
                     {% if contest.reg_mode is RegMode.INVITED %}
                         <h5>Invited</h5>
                     {% else %}
-                        <h5>{{ contest.reg_end.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</h5>
                         {% if contest.reg_mode is RegMode.FREE_REG %}
                             <h5>Free Registration, no approval needed</h5>
                         {% elif contest.reg_mode is RegMode.REG_APPROVAL %}
                             <h5>Free Registration, approval needed </h5>
                         {% end %}
+                        <h5>{{ contest.reg_end.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</h5>
                     {% end %}
                 </div>
             </div>

--- a/src/static/templ/contests/info.html
+++ b/src/static/templ/contests/info.html
@@ -66,7 +66,7 @@
                     {% else %}
                         {% set now = datetime.datetime.now(datetime.UTC) %}
                         {% set can_reg = True %}
-                        {% if now >= contest.reg_end %}
+                        {% if now >= contest.reg_end and contest.reg_mode is not RegMode.INVITED %}
                             {% set can_reg = False %}
                             <h5>Registration Ended</h5>
                         {% end %}
@@ -91,6 +91,8 @@
                                 <h5>Waiting Approval</h5>
                             {% elif contest.member_is_status(user, UserStatus.APPROVED) %}
                                 <h5>Registered</h5>
+                            {% elif contest.member_is_status(user, UserStatus.REJECTED) %}
+                                <h5>Rejected</h5>
                             {% else %}
                                 <h5>Not Registered</h5>
                             {% end %}

--- a/src/static/templ/contests/manage/general.html
+++ b/src/static/templ/contests/manage/general.html
@@ -1,6 +1,7 @@
 {% extends 'manage.html' %}
 
 {% block head %}
+{% from services.contests import RegMode %}
 <script src="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.9.4/dist/js/tempus-dominus.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@eonasdan/tempus-dominus@6.9.4/dist/css/tempus-dominus.min.css" crossorigin="anonymous">
 
@@ -31,6 +32,15 @@
         contest_start_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerContestStart'), options);
         contest_end_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerContestEnd'), options);
         reg_end_date_picker = new tempusDominus.TempusDominus(document.getElementById('datepickerRegEnd'), options);
+
+        $("#regMode").on('change', function(e) {
+            if ($(this).val() === "{{ RegMode.INVITED }}") {
+                $("#datepickerRegEndInput").val(contest_end_date_picker.viewDate);
+                $("#datepickerRegEndInput").attr('disabled', true);
+            } else {
+                $("#datepickerRegEndInput").attr('disabled', false);
+            }
+        });
 
         $("button.submit").on('click', function(e) {
             let start_time = null, end_time = null, reg_end_time = null;
@@ -184,7 +194,16 @@
         <div class="mb-1">
             <label for="datepickerRegEnd" class="form-label">Registration End Time</label>
             <div class="input-group" id="datepickerRegEnd">
-                <input id="datepickerRegEndInput" class="form-control" value="{{ contest.reg_end.astimezone(config.TIMEZONE) }}">
+                <input
+                    id="datepickerRegEndInput"
+                    class="form-control"
+                    {% if contest.reg_mode == RegMode.INVITED %}
+                        value="{{ contest.contest_end.astimezone(config.TIMEZONE) }}"
+                        disabled
+                    {% else %}
+                        value="{{ contest.reg_end.astimezone(config.TIMEZONE) }}"
+                    {% end %}
+                >
                 <span class="input-group-text" data-td-target="#datepickerRegEnd" data-td-toggle="datepickerRegEnd">
                     <svg class="svg-inline--fa fa-calendar" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="calendar" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M96 32V64H48C21.5 64 0 85.5 0 112v48H448V112c0-26.5-21.5-48-48-48H352V32c0-17.7-14.3-32-32-32s-32 14.3-32 32V64H160V32c0-17.7-14.3-32-32-32S96 14.3 96 32zM448 192H0V464c0 26.5 21.5 48 48 48H400c26.5 0 48-21.5 48-48V192z"></path></svg>
                 </span>

--- a/src/static/templ/contests/manage/reg.html
+++ b/src/static/templ/contests/manage/reg.html
@@ -23,6 +23,28 @@
             });
         });
 
+		document.querySelectorAll('button.re-approval').forEach(el => {
+            el.addEventListener('click', function (e) {
+                if (!confirm('Are you sure to re-approval this account? Cannot reject this account after re-approval.')) {
+                    return;
+                }
+
+                let acct_id = $(this).attr('acct_id');
+                $.post(`{{ url(f'/be/contests/{ contest_id }/manage/reg') }}`, {
+                    'reqtype': 'approval',
+                    'acct_id': acct_id,
+                }, res => {
+                    res = JSON.parse(res);
+                    if (res.status == 'S') {
+                        index.show_notify_dialog('Update Successfully', index.DIALOG_TYPE.success);
+                        setTimeout(() => index.reload(), 1000);
+                    } else {
+                        index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
+                    }
+                });
+            });
+        });
+
 		document.querySelectorAll('button.reject').forEach(el => {
             el.addEventListener('click', function (e) {
                 let acct_id = $(this).attr('acct_id');
@@ -60,6 +82,7 @@
     </p>
 
     {% else %}
+    <h1>Request User</h1>
     <table class="table table-hover table-sm table-responsive-sm col mx-lg-3">
         <thead>
             <tr>
@@ -69,7 +92,7 @@
             </tr>
         </thead>
         <tbody>
-        {% for acct in reg_list %}
+        {% for acct in requested_list %}
             <tr>
                 <th scope="row"><a href="{{ url(f'/acct/{ acct.acct_id }/') }}">{{ acct.acct_id }}</a></th>
                 <td>{{ acct.name }}</td>
@@ -77,6 +100,29 @@
                     <div class="btn-toolbar">
                         <button class="btn btn-primary me-2 approval" acct_id="{{ acct.acct_id }}">Approval</button>
                         <button class="btn btn-warning me-2 reject" acct_id="{{ acct.acct_id }}">Reject</button>
+                    </div>
+                </td>
+            </tr>
+        {% end %}
+        </tbody>
+    </table>
+    <h1>Rejected User</h1>
+    <table class="table table-hover table-sm table-responsive-sm col mx-lg-3">
+        <thead>
+            <tr>
+                <th scope="col">Account ID</th>
+                <th scope="col">Account</th>
+                <th scope="col">Operation</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for acct in rejected_list %}
+            <tr>
+                <th scope="row"><a href="{{ url(f'/acct/{ acct.acct_id }/') }}">{{ acct.acct_id }}</a></th>
+                <td>{{ acct.name }}</td>
+                <td>
+                    <div class="btn-toolbar">
+                        <button class="btn btn-primary me-2 re-approval" acct_id="{{ acct.acct_id }}">Re Approval</button>
                     </div>
                 </td>
             </tr>

--- a/src/static/templ/contests/manage/reg.html
+++ b/src/static/templ/contests/manage/reg.html
@@ -5,11 +5,11 @@
 	function init() {
         let contest_id = "{{ contest_id }}";
 
-		document.querySelectorAll('button.approval').forEach(el => {
+		document.querySelectorAll('button.approve').forEach(el => {
             el.addEventListener('click', function (e) {
                 let acct_id = $(this).attr('acct_id');
                 $.post(`{{ url(f'/be/contests/{ contest_id }/manage/reg') }}`, {
-                    'reqtype': 'approval',
+                    'reqtype': 'approve',
                     'acct_id': acct_id,
                 }, res => {
                     res = JSON.parse(res);
@@ -23,15 +23,15 @@
             });
         });
 
-		document.querySelectorAll('button.re-approval').forEach(el => {
+		document.querySelectorAll('button.re-approve').forEach(el => {
             el.addEventListener('click', function (e) {
-                if (!confirm('Are you sure to re-approval this account? Cannot reject this account after re-approval.')) {
+                if (!confirm('Are you sure to re-approve this account? Cannot reject this account after re-approve.')) {
                     return;
                 }
 
                 let acct_id = $(this).attr('acct_id');
                 $.post(`{{ url(f'/be/contests/{ contest_id }/manage/reg') }}`, {
-                    'reqtype': 'approval',
+                    'reqtype': 'approve',
                     'acct_id': acct_id,
                 }, res => {
                     res = JSON.parse(res);
@@ -78,7 +78,7 @@
 
     <p>
     Free Registration Mode
-    We don't need to approval any request.
+    We don't need to approve any request.
     </p>
 
     {% else %}
@@ -98,7 +98,7 @@
                 <td>{{ acct.name }}</td>
                 <td>
                     <div class="btn-toolbar">
-                        <button class="btn btn-primary me-2 approval" acct_id="{{ acct.acct_id }}">Approval</button>
+                        <button class="btn btn-primary me-2 approve" acct_id="{{ acct.acct_id }}">Approve</button>
                         <button class="btn btn-warning me-2 reject" acct_id="{{ acct.acct_id }}">Reject</button>
                     </div>
                 </td>
@@ -122,7 +122,7 @@
                 <td>{{ acct.name }}</td>
                 <td>
                     <div class="btn-toolbar">
-                        <button class="btn btn-primary me-2 re-approval" acct_id="{{ acct.acct_id }}">Re Approval</button>
+                        <button class="btn btn-primary me-2 re-approve" acct_id="{{ acct.acct_id }}">Re Approve</button>
                     </div>
                 </td>
             </tr>

--- a/src/static/templ/contests/reg.html
+++ b/src/static/templ/contests/reg.html
@@ -77,7 +77,9 @@
     <div class="col mt-4">
         <div class="mb-1 text-center">
             <label class="form-label">Status: {{ status }}</label>
+            {% if contest.reg_mode is not RegMode.INVITED %}
             <label class="form-label">Registration End: {{ contest.reg_end.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</label>
+            {% end %}
 
             {% set now = datetime.datetime.now(datetime.UTC) %}
             {% if now >= contest.reg_end %}
@@ -87,9 +89,9 @@
             {% if contest.reg_mode is not RegMode.INVITED %}
                 {% if now < contest.reg_end and user.acct_id not in contest.user_list %}
                     <button class="btn btn-primary reg form-control">Register</button>
-                {% elif contest.member_is_status(user, UserStatus.REQUESTED) %}
+                {% elif contest.member_is_status(user, UserStatus.REQUESTED) and now < contest.reg_end %}
                     <button class="btn btn-primary cancel-register form-control">Cancel register</button>
-                {% elif contest.member_is_status(user, UserStatus.APPROVED) %}
+                {% elif contest.member_is_status(user, UserStatus.APPROVED) and now < contest.contest_start %}
                     <button class="btn btn-primary unreg form-control">Unregister</button>
                 {% end %}
             {% end %}

--- a/src/static/templ/contests/reg.html
+++ b/src/static/templ/contests/reg.html
@@ -34,7 +34,6 @@
     }
 </script>
 
-<!-- TODO: Show reject -->
 {% if contest.reg_mode is RegMode.INVITED %}
     {% if user.acct_id in contest.user_list %}
         {% set status = "Invited" %}
@@ -52,6 +51,8 @@
         {% set status = "Waiting Approval" %}
     {% elif contest.member_is_status(user, UserStatus.APPROVED) %}
         {% set status = "Registered" %}
+    {% elif contest.member_is_status(user, UserStatus.REJECTED) %}
+        {% set status = "Rejected" %}
     {% else %}
         {% set status = "Not Registered" %}
     {% end %}

--- a/src/static/templ/contests/reg.html
+++ b/src/static/templ/contests/reg.html
@@ -66,16 +66,16 @@
             <label class="form-label">Registration End: {{ contest.reg_end.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</label>
 
             {% set now = datetime.datetime.now(datetime.UTC) %}
-            {% set is_reged = user.acct_id in contest.user_list and contest.user_list[user.acct_id]['status'] in (UserStatus.REQUESTED, UserStatus.APPROVED) %}
-
             {% if now >= contest.reg_end %}
                 <h4 class="form-label">Registration Ended</h4>
             {% end %}
 
             {% if contest.reg_mode is not RegMode.INVITED %}
-                {% if not is_reged and now < contest.reg_end %}
+                {% if now < contest.reg_end and user.acct_id not in contest.user_list %}
                     <button class="btn btn-primary reg form-control">Register</button>
-                {% elif is_reged %}
+                {% elif contest.member_is_status(user, UserStatus.REQUESTED) %}
+                    <button class="btn btn-primary unreg form-control">Cancel register</button>
+                {% elif contest.member_is_status(user, UserStatus.APPROVED) %}
                     <button class="btn btn-primary unreg form-control">Unregister</button>
                 {% end %}
             {% end %}

--- a/src/static/templ/contests/reg.html
+++ b/src/static/templ/contests/reg.html
@@ -10,7 +10,7 @@
             }, res => {
                 res = JSON.parse(res);
                 if (res.status == 'S') {
-                    index.show_notify_dialog('Register Successfully', index.DIALOG_TYPE.success);
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.success);
                 } else {
                     index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
                 }
@@ -24,7 +24,21 @@
             }, res => {
                 res = JSON.parse(res);
                 if (res.status == 'S') {
-                    index.show_notify_dialog('Unregister Successfully', index.DIALOG_TYPE.success);
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.success);
+                } else {
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
+                }
+                index.reload();
+            })
+        });
+
+        $("button.cancel-register").on('click', e => {
+            $.post(`{{ url(f'/be/contests/{ contest.contest_id }/reg') }}`, {
+                'reqtype': 'cancelreq',
+            }, res => {
+                res = JSON.parse(res);
+                if (res.status == 'S') {
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.success);
                 } else {
                     index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
                 }
@@ -74,7 +88,7 @@
                 {% if now < contest.reg_end and user.acct_id not in contest.user_list %}
                     <button class="btn btn-primary reg form-control">Register</button>
                 {% elif contest.member_is_status(user, UserStatus.REQUESTED) %}
-                    <button class="btn btn-primary unreg form-control">Cancel register</button>
+                    <button class="btn btn-primary cancel-register form-control">Cancel register</button>
                 {% elif contest.member_is_status(user, UserStatus.APPROVED) %}
                     <button class="btn btn-primary unreg form-control">Unregister</button>
                 {% end %}

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -322,6 +322,22 @@ class ContestTest(AsyncTest):
             self.assertIsNone(err)
             self.assertNotIn(4, contest.user_list)
 
+        with AccountContext('contest1@test', 'test') as user_session:
+            # NOTE: Should not allow register in INVITED mode
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'reg'
+            })
+            self.assertAPIReturnValue(res.text, ("Eacces", "Invited mode do not allow register"))
+            err, contest = await ContestService.inst.get_contest(1)
+            self.assertIsNone(err)
+            self.assertNotIn(4, contest.user_list)
+
+            # NOTE: Should not allow unregister in INVITED mode
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'unreg'
+            })
+            self.assertAPIReturnValue(res.text, ("Eacces", "Invited mode do not allow unregister"))
+
         with AccountContext('admin@test', 'testtest') as admin_session:
             config = copy.deepcopy(default_config)
             config['reg_mode'] = RegMode.FREE_REG
@@ -339,6 +355,29 @@ class ContestTest(AsyncTest):
             err, contest = await ContestService.inst.get_contest(1)
             self.assertIsNone(err)
             self.assertEqual(contest.user_list[4]['status'], UserStatus.APPROVED)
+
+            # NOTE: Should not register again when already approved
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'reg'
+            })
+            self.assertAPIReturnValue(res.text, ("Eexist", "Your registration has been approved, you cannot register again"))
+
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'unreg'
+            })
+            self.assertAPIReturnSuccess(res.text)
+
+            # NOTE: Should not unregister again when not registered
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'unreg'
+            })
+            self.assertAPIReturnValue(res.text, ("Enoext", "You have not registered yet"))
+
+            # NOTE: Restore
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'reg'
+            })
+            self.assertAPIReturnSuccess(res.text)
 
         with AccountContext('admin@test', 'testtest') as admin_session:
             res = admin_session.post('contests/1/manage/acct', data={
@@ -368,12 +407,46 @@ class ContestTest(AsyncTest):
             self.assertIsNone(err)
             self.assertEqual(contest.user_list[4]['status'], UserStatus.REQUESTED)
 
+            # NOTE: Should not register again when already requested
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'reg'
+            })
+            self.assertAPIReturnValue(res.text, ("Eacces", "Your registration is in request status, please wait for approval"))
+
+            # NOTE: Should allow cancel register when in request status
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'unreg'
+            })
+            self.assertAPIReturnSuccess(res.text)
+
+            # NOTE: Should not unregister again when not registered or requested
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'unreg'
+            })
+            self.assertAPIReturnValue(res.text, ("Enoext", "You have not registered yet"))
+
+            # NOTE: Restore
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'reg'
+            })
+            self.assertAPIReturnSuccess(res.text)
+
         with AccountContext('admin@test', 'testtest') as admin_session:
             res = admin_session.post('contests/1/manage/reg', data={
                 'reqtype': 'approval',
                 'acct_id': 4,
             })
             self.assertAPIReturnSuccess(res.text)
+            err, contest = await ContestService.inst.get_contest(1)
+            self.assertIsNone(err)
+            self.assertEqual(contest.user_list[4]['status'], UserStatus.APPROVED)
+
+            # NOTE: Should not allow reject when already approved
+            res = admin_session.post('contests/1/manage/reg', data={
+                'reqtype': 'reject',
+                'acct_id': 4,
+            })
+            self.assertAPIReturnValue(res.text, ("Enoext", "Account(#4) should be in the request status"))
             err, contest = await ContestService.inst.get_contest(1)
             self.assertIsNone(err)
             self.assertEqual(contest.user_list[4]['status'], UserStatus.APPROVED)
@@ -387,7 +460,6 @@ class ContestTest(AsyncTest):
             self.assertIsNone(err)
             self.assertNotIn(4, contest.user_list)
 
-        with AccountContext('contest1@test', 'test') as user_session:
             res = user_session.post('contests/1/reg', data={
                 'reqtype': 'reg'
             })
@@ -396,15 +468,28 @@ class ContestTest(AsyncTest):
             self.assertIsNone(err)
             self.assertEqual(contest.user_list[4]['status'], UserStatus.REQUESTED)
 
-        with AccountContext('admin@test', 'testtest') as admin_session:
-            res = admin_session.post('contests/1/manage/reg', data={
-                'reqtype': 'reject',
-                'acct_id': 4,
+            with AccountContext('admin@test', 'testtest') as admin_session:
+                res = admin_session.post('contests/1/manage/reg', data={
+                    'reqtype': 'reject',
+                    'acct_id': 4,
+                })
+                self.assertAPIReturnSuccess(res.text)
+                err, contest = await ContestService.inst.get_contest(1)
+                self.assertIsNone(err)
+                self.assertEqual(contest.user_list[4]['status'], UserStatus.REJECTED)
+
+            # NOTE: Should not allow request register when already rejected
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'reg'
             })
-            self.assertAPIReturnSuccess(res.text)
-            err, contest = await ContestService.inst.get_contest(1)
-            self.assertIsNone(err)
-            self.assertEqual(contest.user_list[4]['status'], UserStatus.REJECTED)
+            self.assertAPIReturnValue(res.text, ("Eacces", "Your registration has been rejected, you cannot register"))
+
+            # NOTE: Should not allow cancel register request when already rejected
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'unreg'
+            })
+            self.assertAPIReturnValue(res.text, ("Eacces", "Your registration has been rejected, you cannot unregister"))
+
 
         with AccountContext('admin@test', 'testtest') as admin_session:
             res = admin_session.post('contests/1/manage/acct', data={

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -478,6 +478,26 @@ class ContestTest(AsyncTest):
                 self.assertIsNone(err)
                 self.assertEqual(contest.user_list[4]['status'], UserStatus.REJECTED)
 
+                # NOTE: Should allow re-approve rejected account
+                res = admin_session.post('contests/1/manage/reg', data={
+                    'reqtype': 'approval',
+                    'acct_id': 4,
+                })
+                self.assertAPIReturnValue(res.text, ('S', 'Re-approve account(#4) successfully.'))
+                err, contest = await ContestService.inst.get_contest(1)
+                assert contest
+                self.assertIsNone(err)
+                self.assertEqual(contest.user_list[4]['status'], UserStatus.APPROVED)
+
+                # NOTE:: Restore to rejected
+                contest.user_list[4]['status'] = UserStatus.REJECTED
+                await ContestService.inst.update_contest(None, contest, userlist_updated=True)
+                err, contest = await ContestService.inst.get_contest(1)
+                assert contest
+                self.assertIsNone(err)
+                self.assertEqual(contest.user_list[4]['status'], UserStatus.REJECTED)
+
+
             # NOTE: Should not allow request register when already rejected
             res = user_session.post('contests/1/reg', data={
                 'reqtype': 'reg'

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -415,7 +415,7 @@ class ContestTest(AsyncTest):
 
             # NOTE: Should allow cancel register when in request status
             res = user_session.post('contests/1/reg', data={
-                'reqtype': 'unreg'
+                'reqtype': 'cancelreq'
             })
             self.assertAPIReturnSuccess(res.text)
 
@@ -506,9 +506,9 @@ class ContestTest(AsyncTest):
 
             # NOTE: Should not allow cancel register request when already rejected
             res = user_session.post('contests/1/reg', data={
-                'reqtype': 'unreg'
+                'reqtype': 'cancelreq'
             })
-            self.assertAPIReturnValue(res.text, ("Eacces", "Your registration has been rejected, you cannot unregister"))
+            self.assertAPIReturnValue(res.text, ("Eacces", "Your registration is not in request status, you cannot cancel request"))
 
 
         with AccountContext('admin@test', 'testtest') as admin_session:

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -87,7 +87,7 @@ class ContestTest(AsyncTest):
             self.assertEqual(contest.freeze_scoreboard_period, 0)
             self.assertEqual(contest.contest_start, to_utc(contest_start))
             self.assertEqual(contest.contest_end, to_utc(contest_end))
-            # NOTE: If reg_mode is INVITED, reg_end should be the same as contest_start
+            # NOTE: If reg_mode is INVITED, reg_end should be the same as contest_end
             self.assertEqual(contest.reg_end, to_utc(contest_end))
             self.assertEqual(contest.contest_creator, 1)
 
@@ -327,7 +327,7 @@ class ContestTest(AsyncTest):
             res = user_session.post('contests/1/reg', data={
                 'reqtype': 'reg'
             })
-            self.assertAPIReturnValue(res.text, ("Eacces", "Invited mode do not allow register"))
+            self.assertAPIReturnValue(res.text, ("Eacces", "Invited mode does not allow register"))
             err, contest = await ContestService.inst.get_contest(1)
             self.assertIsNone(err)
             self.assertNotIn(4, contest.user_list)
@@ -336,7 +336,7 @@ class ContestTest(AsyncTest):
             res = user_session.post('contests/1/reg', data={
                 'reqtype': 'unreg'
             })
-            self.assertAPIReturnValue(res.text, ("Eacces", "Invited mode do not allow unregister"))
+            self.assertAPIReturnValue(res.text, ("Eacces", "Invited mode does not allow unregister"))
 
         with AccountContext('admin@test', 'testtest') as admin_session:
             config = copy.deepcopy(default_config)
@@ -433,7 +433,7 @@ class ContestTest(AsyncTest):
 
         with AccountContext('admin@test', 'testtest') as admin_session:
             res = admin_session.post('contests/1/manage/reg', data={
-                'reqtype': 'approval',
+                'reqtype': 'approve',
                 'acct_id': 4,
             })
             self.assertAPIReturnSuccess(res.text)
@@ -480,7 +480,7 @@ class ContestTest(AsyncTest):
 
                 # NOTE: Should allow re-approve rejected account
                 res = admin_session.post('contests/1/manage/reg', data={
-                    'reqtype': 'approval',
+                    'reqtype': 'approve',
                     'acct_id': 4,
                 })
                 self.assertAPIReturnValue(res.text, ('S', 'Re-approve account(#4) successfully.'))
@@ -489,7 +489,7 @@ class ContestTest(AsyncTest):
                 self.assertIsNone(err)
                 self.assertEqual(contest.user_list[4]['status'], UserStatus.APPROVED)
 
-                # NOTE:: Restore to rejected
+                # NOTE: Restore to rejected
                 contest.user_list[4]['status'] = UserStatus.REJECTED
                 await ContestService.inst.update_contest(None, contest, userlist_updated=True)
                 err, contest = await ContestService.inst.get_contest(1)
@@ -523,10 +523,10 @@ class ContestTest(AsyncTest):
             for acct_id in range(3, 9 + 1, 1):
                 self.assertIn(acct_id, contest.user_list)
 
-        with AccountContext('admin@test', 'testtest') as admin_session:
             contest_start = now - datetime.timedelta(days=2)
             config = copy.deepcopy(default_config)
             config['contest_start'] = self.get_isoformat(contest_start)
+            config['reg_mode'] = RegMode.FREE_REG
             res = admin_session.post('contests/1/manage/general', data=config)
             self.assertAPIReturnSuccess(res.text)
             err, contest = await ContestService.inst.get_contest(1)
@@ -536,6 +536,13 @@ class ContestTest(AsyncTest):
 
         with AccountContext('contest1@test', 'test') as user_session:
             res = user_session.get('contests/1/pro/5/cont.pdf')
+            self.assertEqual(res.status_code, 200)
+
+            # NOTE: Should not allow unregister when contest has started
+            res = user_session.post('contests/1/reg', data={
+                'reqtype': 'unreg'
+            })
+            self.assertAPIReturnValue(res.text, ("Etime", "Contest has started, you cannot unregister now"))
 
             res = user_session.post('contests/1/submit', data={
                 'reqtype': 'submit',

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -87,7 +87,8 @@ class ContestTest(AsyncTest):
             self.assertEqual(contest.freeze_scoreboard_period, 0)
             self.assertEqual(contest.contest_start, to_utc(contest_start))
             self.assertEqual(contest.contest_end, to_utc(contest_end))
-            self.assertEqual(contest.reg_end, to_utc(reg_end))
+            # NOTE: If reg_mode is INVITED, reg_end should be the same as contest_start
+            self.assertEqual(contest.reg_end, to_utc(contest_end))
             self.assertEqual(contest.contest_creator, 1)
 
             # NOTE: Should not let contest_end <= contest_start

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -90,6 +90,12 @@ class ContestTest(AsyncTest):
             self.assertEqual(contest.reg_end, to_utc(reg_end))
             self.assertEqual(contest.contest_creator, 1)
 
+            # NOTE: Should not let contest_end <= contest_start
+            config = copy.deepcopy(default_config)
+            config['contest_start'] = self.get_isoformat(contest_end + datetime.timedelta(days=1))
+            res = admin_session.post('contests/1/manage/general', data=config)
+            self.assertAPIReturnValue(res.text, ('Eparam', 'Contest end time should be later than start time'))
+
             # test desc
             res = admin_session.post('contests/1/manage/desc', data={
                 'reqtype': 'update',
@@ -763,8 +769,10 @@ class ContestTest(AsyncTest):
 
         # NOTE: contest end
         with AccountContext('admin@test', 'testtest') as admin_session:
+            contest_start = now - datetime.timedelta(days=2)
             contest_end = now - datetime.timedelta(days=1)
             config = copy.deepcopy(default_config)
+            config['contest_start'] = self.get_isoformat(contest_start)
             config['contest_end'] = self.get_isoformat(contest_end)
             res = admin_session.post('contests/1/manage/general', data=config)
             self.assertAPIReturnSuccess(res.text)


### PR DESCRIPTION
In previous implementations, the Registration process was not well-defined, leading to inconsistencies—such as users being able to unregister after a contest had started.
In this PR, we have fixed these issues according to the TOJ Spec. Additionally, we now allow:
Admins to re-approve accounts that were previously rejected
Users to cancel their registration requests
We also fixed several text display issues.