### PR TITLE
Fix/contest user pro update

### DIFF
--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -377,7 +377,7 @@ class ChalListHandler(RequestHandler):
             return self.error(("Eparam", "Invalid page offset"))
         try:
             state = int(self.get_argument("state", default="0"))
-            if state not in ChalConst.STATE_STR and state != 0:
+            if state != 0 and state not in ChalConst.STATE_STR: # NOTE: 0 stands for all states
                 raise ValueError()
         except ValueError:
             return self.error(("Eparam", "Invalid state"))

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -377,7 +377,7 @@ class ChalListHandler(RequestHandler):
             return self.error(("Eparam", "Invalid page offset"))
         try:
             state = int(self.get_argument("state", default="0"))
-            if state not in ChalConst.STATE_STR:
+            if state not in ChalConst.STATE_STR and state != 0:
                 raise ValueError()
         except ValueError:
             return self.error(("Eparam", "Invalid state"))

--- a/src/handlers/contests/manage/acct.py
+++ b/src/handlers/contests/manage/acct.py
@@ -183,23 +183,20 @@ class ContestManageAcctHandler(RequestHandler):
                 error_group.append(("Eacces", f"Cannot remove contest creator {a_id}"))
                 continue
 
-            if a_id not in self.contest.user_list:
+            try:
+                current_status = self.contest.user_list[a_id]["status"]
+                if current_status != expected_status:
+                    error_group.append((
+                        "Eacces",
+                        f"Cannot remove account {a_id} with status {current_status.name} from {list_type} list"
+                    ))
+                    continue
+            except KeyError:
                 error_group.append(("Enoext", f"Account {a_id} not in contest"))
                 continue
 
-            current_status = self.contest.user_list[a_id]["status"]
-            if current_status != expected_status:
-                error_group.append((
-                    "Estatus",
-                    f"Cannot remove account {a_id} with status {current_status.name} from {list_type} list"
-                ))
-                continue
-
-            try:
-                self.contest.user_list.pop(a_id)
-                removed_list.append(a_id)
-            except KeyError:
-                continue
+            self.contest.user_list.pop(a_id)
+            removed_list.append(a_id)
 
         update_errors, _ = await ContestService.inst.update_contest(
             self.acct, self.contest, userlist_updated=True

--- a/src/handlers/contests/manage/acct.py
+++ b/src/handlers/contests/manage/acct.py
@@ -52,9 +52,12 @@ class ContestManageAcctHandler(RequestHandler):
             "status": status,
         }
 
-        await ContestService.inst.update_contest(
+        error_group, _ = await ContestService.inst.update_contest(
             self.acct, self.contest, userlist_updated=True
         )
+
+        if error_group:
+            return self.error(error_group[0])
 
         if list_type == "normal" or (
             list_type == "admin" and not self.contest.hide_admin
@@ -83,8 +86,24 @@ class ContestManageAcctHandler(RequestHandler):
         if acct_id not in self.contest.user_list:
             return self.error(("Enoext", "User is not in contest"))
 
+        expected_status = None
+        if list_type == "normal":
+            expected_status = UserStatus.APPROVED
+        elif list_type == "admin":
+            expected_status = UserStatus.ADMIN
+        else:
+            return self.error(("Eparam", "Invalid list type"))
+
+        current_status = self.contest.user_list[acct_id]["status"]
+        if current_status != expected_status:
+            return self.error((
+                "Eacces",
+                f"Cannot remove user with status {current_status.name} from {list_type} list"
+            ))
+
         self.contest.user_list.pop(acct_id)
-        await ContestService.inst.update_contest(
+
+        _, _ = await ContestService.inst.update_contest(
             self.acct, self.contest, userlist_updated=True
         )
 
@@ -94,7 +113,7 @@ class ContestManageAcctHandler(RequestHandler):
             await self.rs.delete(f"contest_{self.contest.contest_id}_scores")
 
         return self.error(
-            ("S", f"Account(#{acct_id} successfully removed from user list.")
+            ("S", f"Account(#{acct_id}) successfully removed from user list.")
         )
 
     @contest_manage_acct_dispatcher.action("multi_add")
@@ -120,19 +139,25 @@ class ContestManageAcctHandler(RequestHandler):
                 "status": status,
             }
 
-        await ContestService.inst.update_contest(
+        error_group, _ = await ContestService.inst.update_contest(
             self.acct, self.contest, userlist_updated=True
         )
+
+        success_list = [aid for aid in acct_list if aid in self.contest.user_list and aid != self.contest.contest_creator]
 
         if list_type == "normal" or (
             list_type == "admin" and not self.contest.hide_admin
         ):
             await self.rs.delete(f"contest_{self.contest.contest_id}_scores")
 
+        if error_group:
+            error_msg = f"Successfully added: {success_list}. Errors: {', '.join([f'{code}: {msg}' for code, msg in error_group])}"
+            return self.error(("S", error_msg))
+
         return self.error(
             (
                 "S",
-                f"Accounts({acct_list}) successfully added to user list with {status.name}.",
+                f"Accounts {success_list} successfully added to user list with {status.name}.",
             )
         )
 
@@ -141,27 +166,60 @@ class ContestManageAcctHandler(RequestHandler):
         acct_id = self.get_argument("acct_id")
         list_type = self.get_argument("type")
 
+        expected_status = None
+        if list_type == "normal":
+            expected_status = UserStatus.APPROVED
+        elif list_type == "admin":
+            expected_status = UserStatus.ADMIN
+        else:
+            return self.error(("Eparam", "Invalid list type"))
+
         acct_list = parse_str_to_list(acct_id)
+        error_group = []
+        removed_list = []
 
         for a_id in acct_list:
             if a_id == self.contest.contest_creator:
+                error_group.append(("Eacces", f"Cannot remove contest creator {a_id}"))
                 continue
+
+            if a_id not in self.contest.user_list:
+                error_group.append(("Enoext", f"Account {a_id} not in contest"))
+                continue
+
+            current_status = self.contest.user_list[a_id]["status"]
+            if current_status != expected_status:
+                error_group.append((
+                    "Estatus",
+                    f"Cannot remove account {a_id} with status {current_status.name} from {list_type} list"
+                ))
+                continue
+
             try:
                 self.contest.user_list.pop(a_id)
+                removed_list.append(a_id)
             except KeyError:
                 continue
 
-        await ContestService.inst.update_contest(
+        update_errors, _ = await ContestService.inst.update_contest(
             self.acct, self.contest, userlist_updated=True
         )
+
+        # Combine errors from validation and update
+        if update_errors:
+            error_group.extend(update_errors)
 
         if list_type == "normal" or (
             list_type == "admin" and not self.contest.hide_admin
         ):
             await self.rs.delete(f"contest_{self.contest.contest_id}_scores")
 
+        if error_group:
+            error_msg = f"Successfully removed: {removed_list}. Errors: {', '.join([f'{code}: {msg}' for code, msg in error_group])}"
+            return self.error(("S", error_msg))
+
         return self.error(
-            ("S", f"Accounts(#{acct_list} successfully removed from user list.")
+            ("S", f"Accounts {removed_list} successfully removed from user list.")
         )
 
     @reqenv

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -42,17 +42,15 @@ class ContestManageProHandler(RequestHandler):
         if self.contest.is_pro(pro_id):
             return self.error(("Eexist", f"Problem(#{pro_id}) is already in contest"))
 
-        err, _ = await ProService.inst.get_pro(
-            pro_id, ProConst.PRO_STATUS_CONTEST_USER
-        )
-        if err:
-            return self.error(err)
-
         self.contest.pro_list[pro_id] = {"score_type": ProblemScoreType.IOI2017}
 
-        await ContestService.inst.update_contest(
+        error_group, _ = await ContestService.inst.update_contest(
             self.acct, self.contest, prolist_updated=True
         )
+
+        if error_group:
+            return self.error(error_group[0])
+
         await self.rs.delete(f"contest_{self.contest.contest_id}_scores")
         return self.error(
             ("S", f"Problem(#{pro_id}) successfully added to problem list.")
@@ -70,12 +68,12 @@ class ContestManageProHandler(RequestHandler):
 
         self.contest.pro_list.pop(pro_id)
 
-        await ContestService.inst.update_contest(
+        _, _ = await ContestService.inst.update_contest(
             self.acct, self.contest, prolist_updated=True
         )
         await self.rs.delete(f"contest_{self.contest.contest_id}_scores")
         return self.error(
-            ("S", f"Problem(#${pro_id}) successfully removed from problem list.")
+            ("S", f"Problem(#{pro_id}) successfully removed from problem list.")
         )
 
     @contest_manage_pro_dispatcher.action("multi_add")
@@ -83,19 +81,22 @@ class ContestManageProHandler(RequestHandler):
         proid_list = self.get_argument("pro_id")
         proid_list = parse_str_to_list(proid_list)
         for pro_id in proid_list:
-            err, _ = await ProService.inst.get_pro(
-                pro_id, ProConst.PRO_STATUS_CONTEST_USER
-            )
-            if err:
-                continue
             self.contest.pro_list[pro_id] = {"score_type": ProblemScoreType.IOI2017}
 
-        await ContestService.inst.update_contest(
+        error_group, _ = await ContestService.inst.update_contest(
             self.acct, self.contest, prolist_updated=True
         )
+
+        success_list = [pid for pid in proid_list if pid in self.contest.pro_list]
+
         await self.rs.delete(f"contest_{self.contest.contest_id}_scores")
+
+        if error_group:
+            error_msg = f"Successfully added: {success_list}. Errors: {', '.join([f'{code}: {msg}' for code, msg in error_group])}"
+            return self.error(("S", error_msg))
+
         return self.error(
-            ("S", f"Problems(#{proid_list}) successfully added to problem list.")
+            ("S", f"Problems {success_list} successfully added to problem list.")
         )
 
     @contest_manage_pro_dispatcher.action("multi_remove")
@@ -103,18 +104,23 @@ class ContestManageProHandler(RequestHandler):
         pro_id = self.get_argument("pro_id")
         pro_list = parse_str_to_list(pro_id)
 
+        removed_list = []
+        failed_remove_list = []
         for pro_id in pro_list:
             try:
                 self.contest.pro_list.pop(pro_id)
+                removed_list.append(pro_id)
             except KeyError:
+                failed_remove_list.append(pro_id)
                 continue
 
-        await ContestService.inst.update_contest(
+        _, _ = await ContestService.inst.update_contest(
             self.acct, self.contest, prolist_updated=True
         )
+
         await self.rs.delete(f"contest_{self.contest.contest_id}_scores")
         return self.error(
-            ("S", f"Problems(#${pro_id}) successfully removed from problem list.")
+            ("S", f"Problems {removed_list} successfully removed from problem list. Failed to remove: {failed_remove_list} due to not found in contest.")
         )
 
     @contest_manage_pro_dispatcher.action("rechal")

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -282,41 +282,36 @@ class ContestService:
                 current_pro_ids = set()
 
                 for pro_id, v in list(contest.pro_list.items()):
-                    try:
-                        pro_status_result = await con.fetch(
-                            'SELECT status FROM problem WHERE pro_id = $1',
-                            pro_id
-                        )
+                    pro_status_result = await con.fetch(
+                        'SELECT status FROM problem WHERE pro_id = $1',
+                        pro_id
+                    )
 
-                        if len(pro_status_result) == 0:
-                            error_group.append(('Enoext', f'Problem {pro_id} not found'))
-                            contest.pro_list.pop(pro_id)
-                            continue
-
-                        pro_status = pro_status_result[0]['status']
-                        # STATUS_HIDDEN = 2, cannot be added to contest
-                        if pro_status == ProConst.STATUS_HIDDEN:
-                            error_group.append(('Eacces', f'Cannot add hidden status problem {pro_id}'))
-                            contest.pro_list.pop(pro_id)
-                            continue
-
-                        result = await con.fetch('''
-                            INSERT INTO contest_problem_joints ("contest_id", "pro_id", "score_type", "order")
-                            VALUES ($1, $2, $3, $4)
-                            ON CONFLICT (contest_id, pro_id) DO UPDATE
-                            SET score_type = EXCLUDED.score_type, "order" = EXCLUDED."order"
-                            WHERE
-                                contest_problem_joints.score_type != EXCLUDED.score_type OR
-                                contest_problem_joints.order != EXCLUDED.order
-                            RETURNING pro_id;
-                        ''', contest.contest_id, pro_id, int(v['score_type']), order)
-
-                        current_pro_ids.add(pro_id)
-                        order += 1
-                    except asyncpg.ForeignKeyViolationError:
+                    if len(pro_status_result) == 0:
                         error_group.append(('Enoext', f'Problem {pro_id} not found'))
                         contest.pro_list.pop(pro_id)
                         continue
+
+                    pro_status = pro_status_result[0]['status']
+                    # STATUS_HIDDEN = 2, cannot be added to contest
+                    if pro_status == ProConst.STATUS_HIDDEN:
+                        error_group.append(('Eacces', f'Cannot add hidden status problem {pro_id}'))
+                        contest.pro_list.pop(pro_id)
+                        continue
+
+                    result = await con.fetch('''
+                        INSERT INTO contest_problem_joints ("contest_id", "pro_id", "score_type", "order")
+                        VALUES ($1, $2, $3, $4)
+                        ON CONFLICT (contest_id, pro_id) DO UPDATE
+                        SET score_type = EXCLUDED.score_type, "order" = EXCLUDED."order"
+                        WHERE
+                            contest_problem_joints.score_type != EXCLUDED.score_type OR
+                            contest_problem_joints.order != EXCLUDED.order
+                        RETURNING pro_id;
+                    ''', contest.contest_id, pro_id, int(v['score_type']), order)
+
+                    current_pro_ids.add(pro_id)
+                    order += 1
 
                 removed_pros = existing_pro_ids - current_pro_ids
                 if removed_pros:

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -230,6 +230,9 @@ class ContestService:
         return None, contest_id
 
     async def update_contest(self, acct: Account, contest: Contest, prolist_updated=False, userlist_updated=False):
+        from services.pro import ProConst
+        error_group = []
+
         # update db
         async with self.db.acquire() as con:
             result = await con.fetch(
@@ -268,64 +271,105 @@ class ContestService:
             )
 
             if prolist_updated:
+                # Get existing problems to track operations
+                existing_pros = await con.fetch(
+                    'SELECT pro_id FROM contest_problem_joints WHERE contest_id = $1',
+                    contest.contest_id
+                )
+                existing_pro_ids = {row['pro_id'] for row in existing_pros}
+
                 order = 0
-                failed = []
-                for pro_id, v in contest.pro_list.items():
+                current_pro_ids = set()
+
+                for pro_id, v in list(contest.pro_list.items()):
                     try:
-                        await con.execute('''
+                        pro_status_result = await con.fetch(
+                            'SELECT status FROM problem WHERE pro_id = $1',
+                            pro_id
+                        )
+
+                        if len(pro_status_result) == 0:
+                            error_group.append(('Enoext', f'Problem {pro_id} not found'))
+                            contest.pro_list.pop(pro_id)
+                            continue
+
+                        pro_status = pro_status_result[0]['status']
+                        # STATUS_HIDDEN = 2, cannot be added to contest
+                        if pro_status == ProConst.STATUS_HIDDEN:
+                            error_group.append(('Eacces', f'Cannot add hidden status problem {pro_id}'))
+                            contest.pro_list.pop(pro_id)
+                            continue
+
+                        result = await con.fetch('''
                             INSERT INTO contest_problem_joints ("contest_id", "pro_id", "score_type", "order")
-                            VALUES ($1, $2, $3, $4) ON CONFLICT (contest_id, pro_id) DO UPDATE
+                            VALUES ($1, $2, $3, $4)
+                            ON CONFLICT (contest_id, pro_id) DO UPDATE
                             SET score_type = EXCLUDED.score_type, "order" = EXCLUDED."order"
                             WHERE
                                 contest_problem_joints.score_type != EXCLUDED.score_type OR
-                                contest_problem_joints.order != EXCLUDED.order;
+                                contest_problem_joints.order != EXCLUDED.order
+                            RETURNING pro_id;
                         ''', contest.contest_id, pro_id, int(v['score_type']), order)
+
+                        current_pro_ids.add(pro_id)
                         order += 1
                     except asyncpg.ForeignKeyViolationError:
-                        failed.append(pro_id)
+                        error_group.append(('Enoext', f'Problem {pro_id} not found'))
+                        contest.pro_list.pop(pro_id)
                         continue
 
-                await con.execute('DELETE FROM contest_problem_joints WHERE contest_id = $1 AND "order" >= $2', contest.contest_id, order)
-                for failed_pro_id in failed:
-                    contest.pro_list.pop(failed_pro_id)
+                removed_pros = existing_pro_ids - current_pro_ids
+                if removed_pros:
+                    await con.execute(
+                        'DELETE FROM contest_problem_joints WHERE contest_id = $1 AND pro_id = ANY($2)',
+                        contest.contest_id, list(removed_pros)
+                    )
 
             if userlist_updated:
+                # Ensure contest creator is always admin
                 contest.user_list[contest.contest_creator] = {
                     "status": UserStatus.ADMIN
                 }
-                await con.execute('''
-                    WITH input_data AS (
-                        SELECT
-                            $1::integer           AS contest_id,
-                            unnest($2::integer[]) AS acct_id,
-                            unnest($3::integer[]) AS status
-                    ),
 
-                    upserted AS (
-                        INSERT INTO contest_users (contest_id, acct_id, status)
-                        SELECT contest_id, acct_id, status
-                        FROM input_data
-                        ON CONFLICT (contest_id, acct_id) DO UPDATE
+                # Get existing users to track operations
+                existing_users = await con.fetch(
+                    'SELECT acct_id FROM contest_users WHERE contest_id = $1',
+                    contest.contest_id
+                )
+                existing_acct_ids = {row['acct_id'] for row in existing_users}
+
+                current_acct_ids = set()
+
+                for acct_id, v in list(contest.user_list.items()):
+                    try:
+                        await con.execute('''
+                            INSERT INTO contest_users (contest_id, acct_id, status)
+                            VALUES ($1, $2, $3)
+                            ON CONFLICT (contest_id, acct_id) DO UPDATE
                             SET status = EXCLUDED.status
-                            WHERE contest_users.status != EXCLUDED.status
-                        RETURNING acct_id
-                    )
+                            WHERE contest_users.status != EXCLUDED.status;
+                        ''', contest.contest_id, acct_id, int(v['status']))
 
-                    DELETE FROM contest_users cu
-                    WHERE cu.contest_id = $1
-                    AND NOT EXISTS (
-                        SELECT 1
-                        FROM input_data i
-                        WHERE i.acct_id = cu.acct_id
-                    );
-                ''', contest.contest_id, list(contest.user_list.keys()), [int(v['status']) for v in contest.user_list.values()])
+                        current_acct_ids.add(acct_id)
+                    except asyncpg.ForeignKeyViolationError:
+                        error_group.append(('Enoext', f'Account {acct_id} not found'))
+                        contest.user_list.pop(acct_id)
+                        continue
+
+                # Remove users that are no longer in the list
+                removed_users = existing_acct_ids - current_acct_ids
+                if removed_users:
+                    await con.execute(
+                        'DELETE FROM contest_users WHERE contest_id = $1 AND acct_id = ANY($2)',
+                        contest.contest_id, list(removed_users)
+                    )
 
         b_contest = pickle.dumps(contest)
         await self.rs.hset('contest', str(contest.contest_id), b_contest)
 
         # log
 
-        return None, None
+        return error_group, None
 
     async def add_announce(self, contest_id: int, acct_id: int, subject: str, content: str):
         res = await self.db.fetch('INSERT INTO contest_announcement ("contest_id", "acct_id", "subject", "content", "timestamp") VALUES ($1, $2, $3, $4, NOW()) RETURNING announce_id',
@@ -600,4 +644,3 @@ class ContestService:
         }
 
         return scores
-

--- a/src/services/user.py
+++ b/src/services/user.py
@@ -95,7 +95,7 @@ class UserService:
         specific_ip = result[0]['specific_ip']
 
         if specific_ip and ip and specific_ip != ip:
-            return ('Esignip', 'Login failed'), None
+            return ('Esignip', 'Your ip is not allowed'), None
 
         hpw = base64.b64decode(hpw.encode('utf-8'))
         if bcrypt.hashpw(pw.encode('utf-8'), hpw) == hpw:

--- a/src/static/templ/contests/manage/acct.html
+++ b/src/static/templ/contests/manage/acct.html
@@ -18,7 +18,7 @@
 			}, res => {
                 res = JSON.parse(res);
                 if (res.status == 'S') {
-                    index.show_notify_dialog('Update Successfully', index.DIALOG_TYPE.success);
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.success);
 					setTimeout(() => index.reload(), 1000);
                 } else {
 					$("#acctIdNormal").val('');

--- a/src/static/templ/contests/manage/pro.html
+++ b/src/static/templ/contests/manage/pro.html
@@ -48,8 +48,8 @@
             });
         });
 
-		$("#addPro").on('click', () => post_func('add', $("#proId").val(), () => $("#proID").val('')));
-		$("#removePro").on('click', () => post_func('remove', $("#proId").val(), () => $("#proID").val('')));
+		$("#addPro").on('click', () => post_func('add', $("#proId").val(), () => $("#proId").val('')));
+		$("#removePro").on('click', () => post_func('remove', $("#proId").val(), () => $("#proId").val('')));
 		$("#addProList").on('click', () => post_func('multi_add', $("#proList").val(), () => $("#proList").val('')));
 		$("#removeProList").on('click', () => post_func('multi_remove', $("#proList").val(), () => $("#proList").val('')));
     }

--- a/src/tests/integrated/acct.py
+++ b/src/tests/integrated/acct.py
@@ -45,7 +45,7 @@ class SignTest(AsyncTest):
             'mail': 'admin@test',
             'pw': 'testtest',
         })
-        self.assertAPIReturnValue(res.text, ('Esignip', 'Login failed'))
+        self.assertAPIReturnValue(res.text, ('Esignip', 'Your ip is not allowed'))
 
         err, acct = await UserService.inst.info_acct(1)
         self.assertIsNone(err)

--- a/src/tests/integrated/contest.py
+++ b/src/tests/integrated/contest.py
@@ -206,7 +206,7 @@ class ContestTest(AsyncTest):
                 'reqtype': 'add',
                 'pro_id': 1
             })
-            self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
+            self.assertAPIReturnValue(res.text, ('Eacces', 'Cannot add hidden status problem 1'))
 
             res = admin_session.post('contests/1/manage/pro', data={
                 'reqtype': 'multi_add',
@@ -315,6 +315,16 @@ class ContestTest(AsyncTest):
             res = admin_session.post('contests/1/manage/acct', data={
                 'reqtype': 'remove',
                 'acct_id': 4,
+                'type': 'admin',
+            })
+            self.assertAPIReturnValue(res.text, ('Eacces', f'Cannot remove user with status {UserStatus.APPROVED.name} from admin list'))
+            err, contest = await ContestService.inst.get_contest(1)
+            self.assertIsNone(err)
+            self.assertEqual(contest.user_list[4]['status'], UserStatus.APPROVED)
+
+            res = admin_session.post('contests/1/manage/acct', data={
+                'reqtype': 'remove',
+                'acct_id': 4,
                 'type': 'normal',
             })
             self.assertAPIReturnSuccess(res.text)
@@ -407,6 +417,15 @@ class ContestTest(AsyncTest):
             self.assertIsNone(err)
             self.assertEqual(contest.user_list[4]['status'], UserStatus.REQUESTED)
 
+            # NOTE: Should not allow remove account in request status from manage account page
+            with AccountContext('admin@test', 'testtest') as admin_session:
+                res = admin_session.post('contests/1/manage/acct', data={
+                    'reqtype': 'remove',
+                    'acct_id': 4,
+                    'type': 'normal',
+                })
+                self.assertAPIReturnValue(res.text, ('Eacces', f'Cannot remove user with status {UserStatus.REQUESTED.name} from normal list'))
+
             # NOTE: Should not register again when already requested
             res = user_session.post('contests/1/reg', data={
                 'reqtype': 'reg'
@@ -477,6 +496,14 @@ class ContestTest(AsyncTest):
                 err, contest = await ContestService.inst.get_contest(1)
                 self.assertIsNone(err)
                 self.assertEqual(contest.user_list[4]['status'], UserStatus.REJECTED)
+
+                # NOTE: Should not allow remove account in rejected status from manage account page
+                res = admin_session.post('contests/1/manage/acct', data={
+                    'reqtype': 'remove',
+                    'acct_id': 4,
+                    'type': 'normal',
+                })
+                self.assertAPIReturnValue(res.text, ('Eacces', f'Cannot remove user with status {UserStatus.REJECTED.name} from normal list'))
 
                 # NOTE: Should allow re-approve rejected account
                 res = admin_session.post('contests/1/manage/reg', data={

--- a/src/tests/unit/services/test_contest.py
+++ b/src/tests/unit/services/test_contest.py
@@ -1,0 +1,410 @@
+import unittest
+import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import asyncpg
+
+from services.contests import ContestService, Contest, ContestMode, RegMode, UserStatus, ProblemScoreType
+from services.user import Account, UserConst
+from services.chal import Compiler
+
+
+class TestContestService(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        """Set up test fixtures"""
+        self.fake_conn = AsyncMock()
+
+        fake_tx_cm = MagicMock()
+        fake_tx_cm.__aenter__ = AsyncMock(return_value=None)
+        fake_tx_cm.__aexit__ = AsyncMock(return_value=None)
+        self.fake_conn.transaction = MagicMock(return_value=fake_tx_cm)
+
+        fake_acquire_cm = MagicMock()
+        fake_acquire_cm.__aenter__ = AsyncMock(return_value=self.fake_conn)
+        fake_acquire_cm.__aexit__ = AsyncMock(return_value=None)
+        self.fake_db = MagicMock()
+        self.fake_db.acquire = MagicMock(return_value=fake_acquire_cm)
+        self.fake_rs = AsyncMock()
+        self.service = ContestService(self.fake_db, self.fake_rs)
+
+        # Create a test account
+        self.test_acct = Account(
+            acct_id=1,
+            acct_type=UserConst.ACCTTYPE_USER,
+            name="test_user",
+            mail="test@example.com",
+            photo="",
+            cover="",
+            motto="",
+            lastip="127.0.0.1",
+            last_compiler=Compiler.GPP,
+            proclass_collection=[],
+            specific_ip="",
+        )
+
+        # Create a test contest
+        self.test_contest = Contest(
+            contest_id=100,
+            contest_creator=1,
+            name="Test Contest",
+            contest_mode=ContestMode.IOI,
+            contest_start=datetime.datetime.now(),
+            contest_end=datetime.datetime.now() + datetime.timedelta(hours=5),
+            reg_mode=RegMode.FREE_REG,
+            reg_end=datetime.datetime.now() + datetime.timedelta(hours=4),
+            user_list={},
+            pro_list={},
+        )
+
+    async def test_update_contest_add_problem_success(self):
+        """Test successfully adding a problem to contest"""
+        # Setup
+        self.fake_conn.fetch.side_effect = [
+            [],  # UPDATE contest
+            [],  # SELECT existing problems
+            [{'status': 0}],  # SELECT status - ONLINE (0)
+            [{'pro_id': 10}],  # INSERT problem RETURNING pro_id
+        ]
+        self.fake_conn.execute.return_value = None
+        self.fake_rs.hset.return_value = None
+
+        # Add problem to contest
+        self.test_contest.pro_list[10] = {"score_type": ProblemScoreType.IOI2017}
+
+        # Execute
+        error_group, _ = await self.service.update_contest(
+            self.test_acct, self.test_contest, prolist_updated=True
+        )
+
+        # Assert
+        self.assertEqual(len(error_group), 0)
+        self.assertIn(10, self.test_contest.pro_list)
+
+    async def test_update_contest_add_nonexistent_problem(self):
+        """Test adding a non-existent problem returns error_group"""
+        # Setup
+        call_count = [0]
+        def fetch_side_effect(*_, **__):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return []
+            # Third call is SELECT status which returns empty (not found)
+            return []
+
+        self.fake_conn.fetch.side_effect = fetch_side_effect
+        self.fake_conn.execute.return_value = None
+        self.fake_rs.hset.return_value = None
+
+        # Add non-existent problem to contest
+        self.test_contest.pro_list[999] = {"score_type": ProblemScoreType.IOI2017}
+
+        # Execute
+        error_group, _ = await self.service.update_contest(
+            self.test_acct, self.test_contest, prolist_updated=True
+        )
+
+        # Assert
+        self.assertGreater(len(error_group), 0)
+        self.assertEqual(error_group[0][0], 'Enoext')
+        self.assertIn('999', error_group[0][1])
+        self.assertNotIn(999, self.test_contest.pro_list)
+
+    async def test_update_contest_add_hidden_problem(self):
+        """Test adding a hidden problem returns error_group"""
+        # Setup
+        call_count = [0]
+        def fetch_side_effect(*_, **__):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return []
+            # Third call is SELECT status which returns HIDDEN status (2)
+            return [{'status': 2}]
+
+        self.fake_conn.fetch.side_effect = fetch_side_effect
+        self.fake_conn.execute.return_value = None
+        self.fake_rs.hset.return_value = None
+
+        # Add hidden problem to contest
+        self.test_contest.pro_list[888] = {"score_type": ProblemScoreType.IOI2017}
+
+        # Execute
+        error_group, _ = await self.service.update_contest(
+            self.test_acct, self.test_contest, prolist_updated=True
+        )
+
+        # Assert
+        self.assertGreater(len(error_group), 0)
+        self.assertEqual(error_group[0][0], 'Eacces')
+        self.assertIn('hidden', error_group[0][1].lower())
+        self.assertIn('888', error_group[0][1])
+        self.assertNotIn(888, self.test_contest.pro_list)
+        self.assertNotIn(999, self.test_contest.pro_list)
+
+    async def test_update_contest_add_user_success(self):
+        """Test successfully adding a user to contest"""
+        # Setup
+        self.fake_conn.fetch.side_effect = [
+            [],  # UPDATE contest
+            [],  # SELECT existing users
+        ]
+        self.fake_conn.execute.return_value = None
+        self.fake_rs.hset.return_value = None
+
+        # Add user to contest
+        self.test_contest.user_list[2] = {"status": UserStatus.APPROVED}
+
+        # Execute
+        error_group, _ = await self.service.update_contest(
+            self.test_acct, self.test_contest, userlist_updated=True
+        )
+
+        # Assert
+        self.assertEqual(len(error_group), 0)
+        self.assertIn(2, self.test_contest.user_list)
+        # Contest creator should be auto-added as admin
+        self.assertIn(1, self.test_contest.user_list)
+        self.assertEqual(self.test_contest.user_list[1]["status"], UserStatus.ADMIN)
+
+    async def test_update_contest_add_nonexistent_user(self):
+        """Test adding a non-existent user returns error_group"""
+        # Setup
+        self.fake_conn.fetch.side_effect = [
+            [],  # UPDATE contest
+            [],  # SELECT existing users
+        ]
+
+        async def execute_with_error(*args, **_):
+            if 'INSERT INTO contest_users' in args[0]:
+                raise asyncpg.ForeignKeyViolationError("Account not found")
+
+        self.fake_conn.execute.side_effect = execute_with_error
+        self.fake_rs.hset.return_value = None
+
+        # Add non-existent user to contest
+        self.test_contest.user_list[9999] = {"status": UserStatus.APPROVED}
+
+        # Execute
+        error_group, _ = await self.service.update_contest(
+            self.test_acct, self.test_contest, userlist_updated=True
+        )
+
+        # Assert
+        self.assertGreater(len(error_group), 0)
+        self.assertEqual(error_group[0][0], 'Enoext')
+        self.assertIn('9999', error_group[0][1])
+        self.assertNotIn(9999, self.test_contest.user_list)
+
+    async def test_update_contest_remove_problem(self):
+        """Test removing a problem from contest"""
+        # Setup
+        self.fake_conn.fetch.side_effect = [
+            [],  # UPDATE contest
+            [{'pro_id': 10}, {'pro_id': 20}],  # SELECT existing problems
+            [{'status': 0}],  # SELECT status for problem 10 - ONLINE (0)
+            [{'pro_id': 10}],  # INSERT problem 10 RETURNING pro_id
+        ]
+        self.fake_conn.execute.return_value = None
+        self.fake_rs.hset.return_value = None
+
+        # Initially contest has problem 10, we keep it but remove 20
+        self.test_contest.pro_list[10] = {"score_type": ProblemScoreType.IOI2017}
+
+        # Execute
+        error_group, _ = await self.service.update_contest(
+            self.test_acct, self.test_contest, prolist_updated=True
+        )
+
+        # Assert
+        self.assertEqual(len(error_group), 0)
+        self.assertIn(10, self.test_contest.pro_list)
+
+        # Verify DELETE was called for removed problem
+        delete_calls = [call for call in self.fake_conn.execute.call_args_list
+                       if 'DELETE FROM contest_problem_joints' in str(call)]
+        self.assertGreater(len(delete_calls), 0)
+
+    async def test_update_contest_remove_user(self):
+        """Test removing a user from contest"""
+        # Setup
+        self.fake_conn.fetch.side_effect = [
+            [],  # UPDATE contest
+            [{'acct_id': 1}, {'acct_id': 2}, {'acct_id': 3}],  # SELECT existing users
+        ]
+        self.fake_conn.execute.return_value = None
+        self.fake_rs.hset.return_value = None
+
+        # Initially contest has users 1, 2, 3, we keep 1 and 2 but remove 3
+        self.test_contest.user_list[1] = {"status": UserStatus.ADMIN}
+        self.test_contest.user_list[2] = {"status": UserStatus.APPROVED}
+
+        # Execute
+        error_group, _ = await self.service.update_contest(
+            self.test_acct, self.test_contest, userlist_updated=True
+        )
+
+        # Assert
+        self.assertEqual(len(error_group), 0)
+        self.assertIn(1, self.test_contest.user_list)
+        self.assertIn(2, self.test_contest.user_list)
+
+        # Verify DELETE was called for removed user
+        delete_calls = [call for call in self.fake_conn.execute.call_args_list
+                       if 'DELETE FROM contest_users' in str(call)]
+        self.assertGreater(len(delete_calls), 0)
+
+    async def test_update_contest_ensures_creator_is_admin(self):
+        """Test that contest creator is always set as admin"""
+        # Setup
+        self.fake_conn.fetch.side_effect = [
+            [],  # UPDATE contest
+            [],  # SELECT existing users
+        ]
+        self.fake_conn.execute.return_value = None
+        self.fake_rs.hset.return_value = None
+
+        # Don't explicitly add creator to user_list
+        self.test_contest.user_list[2] = {"status": UserStatus.APPROVED}
+
+        # Execute
+        _, _ = await self.service.update_contest(
+            self.test_acct, self.test_contest, userlist_updated=True
+        )
+
+        # Assert
+        self.assertIn(self.test_contest.contest_creator, self.test_contest.user_list)
+        self.assertEqual(
+            self.test_contest.user_list[self.test_contest.contest_creator]["status"],
+            UserStatus.ADMIN
+        )
+
+    async def test_update_contest_multiple_errors(self):
+        """Test that multiple errors are collected in error_group"""
+        # Setup
+        call_count = [0]
+        def fetch_side_effect(*_, **__):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return []  # UPDATE contest and SELECT existing problems
+            # All subsequent calls are SELECT status which return empty (not found)
+            return []
+
+        self.fake_conn.fetch.side_effect = fetch_side_effect
+        self.fake_conn.execute.return_value = None
+        self.fake_rs.hset.return_value = None
+
+        # Add multiple non-existent problems
+        self.test_contest.pro_list[998] = {"score_type": ProblemScoreType.IOI2017}
+        self.test_contest.pro_list[999] = {"score_type": ProblemScoreType.IOI2017}
+
+        # Execute
+        error_group, _ = await self.service.update_contest(
+            self.test_acct, self.test_contest, prolist_updated=True
+        )
+
+        # Assert
+        self.assertEqual(len(error_group), 2)
+        self.assertEqual(error_group[0][0], 'Enoext')
+        self.assertEqual(error_group[1][0], 'Enoext')
+        self.assertNotIn(998, self.test_contest.pro_list)
+        self.assertNotIn(999, self.test_contest.pro_list)
+
+    async def test_update_contest_cache_updated_correctly(self):
+        """Test that Redis cache is updated after contest update"""
+        # Setup
+        self.fake_conn.fetch.side_effect = [
+            [],  # UPDATE contest
+        ]
+        self.fake_conn.execute.return_value = None
+        self.fake_rs.hset.return_value = None
+
+        # Execute
+        _, _ = await self.service.update_contest(
+            self.test_acct, self.test_contest
+        )
+
+        # Assert
+        self.fake_rs.hset.assert_called_once()
+        call_args = self.fake_rs.hset.call_args
+        self.assertEqual(call_args[0][0], 'contest')
+        self.assertEqual(call_args[0][1], str(self.test_contest.contest_id))
+
+
+class TestContestUserStatusValidation(unittest.IsolatedAsyncioTestCase):
+    """Test user status validation when removing users"""
+
+    def setUp(self):
+        """Set up test contest with various user statuses"""
+        self.test_contest = Contest(
+            contest_id=100,
+            contest_creator=1,
+            name="Test Contest",
+            contest_mode=ContestMode.IOI,
+            contest_start=datetime.datetime.now(),
+            contest_end=datetime.datetime.now() + datetime.timedelta(hours=5),
+            reg_mode=RegMode.FREE_REG,
+            reg_end=datetime.datetime.now() + datetime.timedelta(hours=4),
+            user_list={
+                1: {"status": UserStatus.ADMIN},
+                2: {"status": UserStatus.APPROVED},
+                3: {"status": UserStatus.REQUESTED},
+                4: {"status": UserStatus.REJECTED},
+                5: {"status": UserStatus.ADMIN},
+            },
+            pro_list={},
+        )
+
+    def test_cannot_remove_requested_user_from_normal_list(self):
+        """Test that REQUESTED users cannot be removed via normal list"""
+        # User 3 has REQUESTED status, should not be removable via 'normal' list
+        user_status = self.test_contest.user_list[3]["status"]
+        self.assertEqual(user_status, UserStatus.REQUESTED)
+        self.assertNotEqual(user_status, UserStatus.APPROVED)
+
+    def test_cannot_remove_rejected_user_from_normal_list(self):
+        """Test that REJECTED users cannot be removed via normal list"""
+        # User 4 has REJECTED status, should not be removable via 'normal' list
+        user_status = self.test_contest.user_list[4]["status"]
+        self.assertEqual(user_status, UserStatus.REJECTED)
+        self.assertNotEqual(user_status, UserStatus.APPROVED)
+
+    def test_can_only_remove_approved_from_normal_list(self):
+        """Test that only APPROVED users can be removed via normal list"""
+        # User 2 has APPROVED status, should be removable via 'normal' list
+        user_status = self.test_contest.user_list[2]["status"]
+        self.assertEqual(user_status, UserStatus.APPROVED)
+
+    def test_can_only_remove_admin_from_admin_list(self):
+        """Test that only ADMIN users can be removed via admin list"""
+        # User 1 and 5 have ADMIN status
+        self.assertEqual(self.test_contest.user_list[1]["status"], UserStatus.ADMIN)
+        self.assertEqual(self.test_contest.user_list[5]["status"], UserStatus.ADMIN)
+
+        # User 2 has APPROVED status, should not be removable via 'admin' list
+        self.assertNotEqual(self.test_contest.user_list[2]["status"], UserStatus.ADMIN)
+
+    def test_status_matching_logic(self):
+        """Test the status matching logic used in handlers"""
+        test_cases = [
+            # (list_type, user_status, should_match)
+            ("normal", UserStatus.APPROVED, True),
+            ("normal", UserStatus.ADMIN, False),
+            ("normal", UserStatus.REQUESTED, False),
+            ("normal", UserStatus.REJECTED, False),
+            ("admin", UserStatus.ADMIN, True),
+            ("admin", UserStatus.APPROVED, False),
+            ("admin", UserStatus.REQUESTED, False),
+            ("admin", UserStatus.REJECTED, False),
+        ]
+
+        for list_type, user_status, should_match in test_cases:
+            expected_status = UserStatus.APPROVED if list_type == "normal" else UserStatus.ADMIN
+            actual_match = (user_status == expected_status)
+            self.assertEqual(
+                actual_match,
+                should_match,
+                f"Failed: list_type={list_type}, user_status={user_status.name}, expected_match={should_match}"
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/unit/services/test_contest.py
+++ b/src/tests/unit/services/test_contest.py
@@ -138,7 +138,6 @@ class TestContestService(unittest.IsolatedAsyncioTestCase):
         self.assertIn('hidden', error_group[0][1].lower())
         self.assertIn('888', error_group[0][1])
         self.assertNotIn(888, self.test_contest.pro_list)
-        self.assertNotIn(999, self.test_contest.pro_list)
 
     async def test_update_contest_add_user_success(self):
         """Test successfully adding a user to contest"""


### PR DESCRIPTION
In this PR:
- Enhanced the error messages when updating the problem list and account list in a Contest. Instead of showing a generic “Update Successfully” message, the system now displays detailed errors for each individual problem or account that failed to update.
- Fixed an issue where adding a non-existent account would cause an InternalError.
- Fixed a vulnerability that allowed Requested/Rejected accounts to be deleted through the account management page.
- Improved login error messages to clearly distinguish between IP restriction errors and incorrect username/password errors.
- Fixed an issue where the Challenge List (ChalList) page could not be accessed.
- Added Unit Tests and Integration Tests to cover the above changes.