### PR TITLE
fix(proset): incorrect problem count in progress bar

### DIFF
--- a/src/static/templ/proset.html
+++ b/src/static/templ/proset.html
@@ -277,9 +277,9 @@
             <label class="form-label">Current Problem Class</label>
             {% if cur_proclass %}
                 <label class="form-label">{{ cur_proclass['name'] }}</label>
-                <p>Progress: <a href="{{ url(f'/proset/?proclass_id={ cur_proclass['proclass_id'] }&show=onlyac') }}">{{ ac_pro_cnt }}</a> / {{ len(cur_proclass['list']) }}</p>
+                <p>Progress: <a href="{{ url(f'/proset/?proclass_id={ cur_proclass['proclass_id'] }&show=onlyac') }}">{{ ac_pro_cnt }}</a> / {{ len(prolist) }}</p>
                 <div class="progress">
-                    <div class="progress-bar" role="progressbar" style="width: {{ ac_pro_cnt / len(cur_proclass['list']) * 100 }}%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
+                    <div class="progress-bar" role="progressbar" style="width: {{ ac_pro_cnt / len(prolist) * 100 }}%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
                 </div>
                 <div style="display: none;" id="curProclassId" proclass="{{ cur_proclass['proclass_id'] }}"></div>
             {% else %}


### PR DESCRIPTION
The progress bar problem count should follow the proset count. Since proclass may contain hidden problems that are not shown in proset, we should rely on proset instead.