### PR TITLE
fix(proset): incorrect problem count in proclass list

### DIFF
--- a/src/handlers/pro.py
+++ b/src/handlers/pro.py
@@ -252,6 +252,14 @@ class ProsetHandler(RequestHandler):
                 return
 
             _, acct_states = await RateService.inst.map_rate_acct(self.acct)
+            err, prolist = await ProService.inst.list_pro(
+                self.acct.is_kernel()
+                and ProConst.PRO_STATUS_KERNEL_USER
+                or ProConst.PRO_STATUS_NORMAL_USER
+            )
+            if err:
+                return self.error(err)
+            pro_exists = {pro.pro_id for pro in prolist}
             for i in range(len(proclass_list)):
                 proclass_list[i] = dict(proclass_list[i])
                 proclass = proclass_list[i]
@@ -262,12 +270,16 @@ class ProsetHandler(RequestHandler):
                 if proclass["acct_id"]:
                     proclass["creator_name"] = accts[proclass["acct_id"]]
 
+                total_cnt = len(p["list"])
                 for pro_id in p["list"]:
+                    if pro_id not in pro_exists:
+                        total_cnt -= 1
+                        continue
                     if pro_id in acct_states:
                         ac_cnt += acct_states[pro_id]["state"] == ChalConst.STATE_AC
 
                 proclass["ac_cnt"] = ac_cnt
-                proclass["total_cnt"] = len(p["list"])
+                proclass["total_cnt"] = total_cnt
 
             self.error(("S", proclass_list))
 
@@ -341,9 +353,9 @@ class ProStaticHandler(RequestHandler, tornado.web.StaticFileHandler):
 
         err, _ = await ProService.inst.get_pro(pro_id, allow_statuses)
         if err:
-            if err[0] == 'Enoext':
+            if err[0] == "Enoext":
                 self.set_status(404)
-            elif err[0] == 'Eacces':
+            elif err[0] == "Eacces":
                 self.set_status(403)
             else:
                 self.set_status(500)

--- a/src/tests/integrated/proclass.py
+++ b/src/tests/integrated/proclass.py
@@ -1,6 +1,6 @@
 import json
 
-from services.pro import ProClassService, ProClassConst
+from services.pro import ProConst, ProClassService, ProClassConst
 
 from tests.integrated.util import AsyncTest, AccountContext
 
@@ -276,6 +276,50 @@ class ProClassTest(AsyncTest):
             })
             self.assertAPIReturnValue(res.text, ('Eacces', 'Permission denied'))
 
+            # NOTE: problem status
+            admin_session.post('manage/pro/update', data={
+                'reqtype': 'updategeneral',
+                'pro_id': 1,
+                'name': 'GCD',
+                'status': ProConst.STATUS_HIDDEN,
+                'tags': '',
+                'allow_submit': 'true',
+            })
+            with AccountContext('test1@test', 'test') as user_session:
+                res = user_session.post('proset', data={
+                    'reqtype': 'listproclass',
+                    'proclass_type': 'official',
+                })
+                res = json.loads(res.text)
+                proclass_list = res['data']
+                self.assertNotEqual(proclass_list, [])
+                self.assertEqual(len(proclass_list), 1)
+                self.assertEqual(proclass_list[0]['total_cnt'], 1)
+                self.assertEqual(proclass_list[0]['ac_cnt'], 0)
+                self.assertEqual(proclass_list[0]['proclass_id'], 1)
+
+            admin_session.post('manage/pro/update', data={
+                'reqtype': 'updategeneral',
+                'pro_id': 1,
+                'name': 'GCD',
+                'status': ProConst.STATUS_ONLINE,
+                'tags': '',
+                'allow_submit': 'true',
+            })
+
+            res = admin_session.post('proset', data={
+                'reqtype': 'listproclass',
+                'proclass_type': 'official',
+            })
+            res = json.loads(res.text)
+            proclass_list = res['data']
+            self.assertNotEqual(proclass_list, [])
+            self.assertEqual(len(proclass_list), 1)
+            self.assertEqual(proclass_list[0]['total_cnt'], 2)
+            self.assertEqual(proclass_list[0]['ac_cnt'], 2)
+            self.assertEqual(proclass_list[0]['proclass_id'], 1)
+
+            # NOTE: cleanup
             res = admin_session.post('manage/proclass/update', data={
                 'reqtype': 'remove',
                 'proclass_id': 1,


### PR DESCRIPTION
The progress problem count should follow the proset count. Since proclass may contain hidden problems that are not shown in proset, we should rely on proset instead.