### PR TITLE
feat(contests): add system test similar to CF

### DIFF
--- a/migration/20251220163947_add_system_test_metadata.py
+++ b/migration/20251220163947_add_system_test_metadata.py
@@ -1,0 +1,16 @@
+async def dochange(db, rs):
+    """Add metadata column to testdata and subtask_config tables for system test support."""
+
+    # Add metadata column to testdata table
+    print("Adding metadata column to testdata table...")
+    await db.execute(
+        "ALTER TABLE testdata ADD COLUMN metadata jsonb DEFAULT '{}'::jsonb NOT NULL;"
+    )
+
+    # Add metadata column to subtask_config table
+    print("Adding metadata column to subtask_config table...")
+    await db.execute(
+        "ALTER TABLE subtask_config ADD COLUMN metadata jsonb DEFAULT '{}'::jsonb NOT NULL;"
+    )
+
+    print("System test metadata columns migration completed!")

--- a/migration/20251220170234_add_contest_enable_system_test.py
+++ b/migration/20251220170234_add_contest_enable_system_test.py
@@ -1,0 +1,10 @@
+async def dochange(db, rs):
+    """Add enable_system_test column to contest table (default False)."""
+
+    print("Adding enable_system_test column to contest table...")
+    await db.execute(
+        "ALTER TABLE contest ADD COLUMN enable_system_test boolean DEFAULT FALSE NOT NULL;"
+    )
+
+    await rs.delete('contest')
+    print("Contest enable_system_test column migration completed!")

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -275,13 +275,15 @@ class ChalStateCallback:
         def sanitize():
             nonlocal msg_data
             try:
-                if 'total_result' in msg_data and isinstance(msg_data['total_result'], dict):
+                if 'total_result' in msg_data:
+                    assert isinstance(msg_data['total_result'], dict)
                     total_result = msg_data['total_result']
                     total_result['ce_message'] = ''
                     total_result['ie_message'] = ''
                     total_result['message_type'] = MessageType.NONE.value
 
-                if 'testdata_results' in msg_data and isinstance(msg_data['testdata_results'], dict):
+                if 'testdata_results' in msg_data:
+                    assert isinstance(msg_data['testdata_results'], dict)
                     for td in msg_data['testdata_results'].values():
                         if isinstance(td, dict):
                             td['message'] = ''
@@ -323,12 +325,53 @@ class ChalStateCallback:
                 if is_summary:
                     if 'testdata_results' in msg_data:
                         del msg_data['testdata_results']
+
+                    # Filter system-test subtasks if in contest running mode with system test enabled
+                    if chal.contest_id != 0 and 'subtask_results' in msg_data:
+                        err, contest = await ContestService.inst.get_contest(chal.contest_id)
+                        if err:
+                            return None
+                        if contest.enable_system_test and contest.is_running():
+                            # Need to filter out system-test subtasks
+                            err, pro = await ProService.inst.get_pro(chal.pro_id, ProConst.PRO_STATUS_FULL)
+                            if err:
+                                return None
+                            assert isinstance(msg_data['subtask_results'], dict)
+                            filtered_subtasks = {}
+                            for st_id_str, st_data in msg_data['subtask_results'].items():
+                                try:
+                                    st_id = int(st_id_str)
+                                    subtask = pro.config.subtask_configs.get(st_id)
+                                    if subtask and not subtask.is_system_test():
+                                        filtered_subtasks[st_id_str] = st_data
+                                except (ValueError, AttributeError):
+                                    continue
+                            msg_data['subtask_results'] = filtered_subtasks
+
                 elif is_single_testdata:
                     return None
 
             elif style == ChallengeResultStyle.STATE_COUNT:
                 if is_single_testdata:
                     _, testdata_results = await ChalService.inst.get_testdata_results(chal.chal_id)
+
+                    # Filter system-test testdata if in contest running mode with system test enabled
+                    if chal.contest_id != 0:
+                        err, contest = await ContestService.inst.get_contest(chal.contest_id)
+                        if err:
+                            return None
+                        if contest.enable_system_test and contest.is_running():
+                            # Need to filter out system-test testdata
+                            err, pro = await ProService.inst.get_pro(chal.pro_id, ProConst.PRO_STATUS_FULL)
+                            if err:
+                                return None
+                            filtered_results = {}
+                            for td_id, td_result in testdata_results.items():
+                                testdata = pro.config.testdatas.get(td_id)
+                                if testdata and not testdata.is_system_test():
+                                    filtered_results[td_id] = td_result
+                            testdata_results = filtered_results
+
                     state_count = {}
                     for td in testdata_results.values():
                         if td.state not in state_count:
@@ -355,6 +398,42 @@ class ChalStateCallback:
 
                         msg_data['testdata_results'] = {'state_count': state_count}
 
+            elif style == ChallengeResultStyle.FULL:
+                # Filter system-test testdata and subtasks if in contest running mode with system test enabled
+                if is_summary and chal.contest_id != 0:
+                    err, contest = await ContestService.inst.get_contest(chal.contest_id)
+                    if err:
+                        return None
+                    if contest.enable_system_test and contest.is_running():
+                        # Need to filter out system-test testdata and subtasks
+                        err, pro = await ProService.inst.get_pro(chal.pro_id, ProConst.PRO_STATUS_FULL)
+                        if err:
+                            return None
+
+                        if 'testdata_results' in msg_data and isinstance(msg_data['testdata_results'], dict):
+                            filtered_testdata = {}
+                            for td_id_str, td_data in msg_data['testdata_results'].items():
+                                try:
+                                    td_id = int(td_id_str)
+                                    testdata = pro.config.testdatas.get(td_id)
+                                    if testdata and not testdata.is_system_test():
+                                        filtered_testdata[td_id_str] = td_data
+                                except (ValueError, AttributeError):
+                                    continue
+                            msg_data['testdata_results'] = filtered_testdata
+
+                        if 'subtask_results' in msg_data and isinstance(msg_data['subtask_results'], dict):
+                            filtered_subtasks = {}
+                            for st_id_str, st_data in msg_data['subtask_results'].items():
+                                try:
+                                    st_id = int(st_id_str)
+                                    subtask = pro.config.subtask_configs.get(st_id)
+                                    if subtask and not subtask.is_system_test():
+                                        filtered_subtasks[st_id_str] = st_data
+                                except (ValueError, AttributeError):
+                                    continue
+                            msg_data['subtask_results'] = filtered_subtasks
+
             return json.dumps(msg_data)
 
 
@@ -368,8 +447,70 @@ class ChalStateCallback:
 
             challenge_style = contest.pro_list.get(chal.pro_id, {}).get('challenge_style', ChallengeResultStyle.FULL)
 
+            # Filter system-test testdata/subtasks during contest if enabled
+            async def filter_system_test():
+                """Filter out system-test tagged testdata/subtasks during contest
+
+                Returns:
+                    True: Continue processing (not filtered)
+                    False: Skip this message (filtered out)
+                """
+                nonlocal msg_data
+
+                if not contest.enable_system_test or not contest.is_running():
+                    return True  # No filtering needed, continue
+
+                # Get problem config to check metadata
+                err, pro = await ProService.inst.get_pro(chal.pro_id, ProConst.PRO_STATUS_FULL)
+                if err or not pro:
+                    return True  # Can't filter, continue
+
+                # Filter single testdata update (has 'id' at top level)
+                if 'id' in msg_data and 'total_result' not in msg_data:
+                    try:
+                        td_id = int(msg_data['id'])
+                        testdata = pro.config.testdatas.get(td_id)
+                        if testdata and testdata.is_system_test():
+                            # Skip this system-test testdata
+                            return False
+                    except (ValueError, AttributeError, KeyError):
+                        pass
+
+                # Filter testdata_results
+                if 'testdata_results' in msg_data and isinstance(msg_data['testdata_results'], dict):
+                    filtered_testdata = {}
+                    for td_id_str, td_data in msg_data['testdata_results'].items():
+                        try:
+                            td_id = int(td_id_str)
+                            testdata = pro.config.testdatas.get(td_id)
+                            # Only include if not system-test
+                            if testdata and not testdata.is_system_test():
+                                filtered_testdata[td_id_str] = td_data
+                        except (ValueError, AttributeError):
+                            continue
+                    msg_data['testdata_results'] = filtered_testdata
+
+                # Filter subtask_results
+                if 'subtask_results' in msg_data and isinstance(msg_data['subtask_results'], dict):
+                    filtered_subtask = {}
+                    for st_id_str, st_data in msg_data['subtask_results'].items():
+                        try:
+                            st_id = int(st_id_str)
+                            subtask = pro.config.subtask_configs.get(st_id)
+                            # Only include if not system-test
+                            if subtask and not subtask.is_system_test():
+                                filtered_subtask[st_id_str] = st_data
+                        except (ValueError, AttributeError):
+                            continue
+                    msg_data['subtask_results'] = filtered_subtask
+
+                return True  # Continue processing
+
             if contest.is_running():
                 if viewer.acct_id == chal.acct_id:
+                    # Filter system-test first
+                    if not await filter_system_test():
+                        return None  # Filtered out, skip
                     result = await apply_challenge_style(challenge_style)
                     return result if result is not None else None
                 return None

--- a/src/handlers/contests/manage/general.py
+++ b/src/handlers/contests/manage/general.py
@@ -53,6 +53,7 @@ class ContestManageGeneralHandler(RequestHandler):
         is_public_scoreboard = self.get_argument("is_public_scoreboard") == "true"
         allow_view_other_page = self.get_argument("allow_view_other_page") == "true"
         hide_admin = self.get_argument("hide_admin") == "true"
+        enable_system_test = self.get_argument("enable_system_test", default="false") == "true"
         try:
             submission_cd_time = int(self.get_argument("submission_cd_time"))
             if submission_cd_time < 0:
@@ -138,6 +139,7 @@ class ContestManageGeneralHandler(RequestHandler):
         self.contest.hide_admin = hide_admin
         self.contest.submission_cd_time = submission_cd_time
         self.contest.penalty_value = penalty_value
+        self.contest.enable_system_test = enable_system_test
         if self.contest.freeze_scoreboard_period != freeze_scoreboard_period:
             self.contest.freeze_scoreboard_period = freeze_scoreboard_period
             if self.contest.is_start():

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -128,7 +128,7 @@ class ContestManageProHandler(RequestHandler):
         success_list = [pid for pid in proid_list if pid in self.contest.pro_list]
 
         # await self.rs.delete(f"contest_{self.contest.contest_id}_scores")
-        
+
         if error_group:
             await self.add_log(
                 f"{self.acct.name} batch added {len(proid_list)} problems to contest",
@@ -177,6 +177,32 @@ class ContestManageProHandler(RequestHandler):
             ("S", f"Problems {removed_list} successfully removed from problem list. Failed to remove: {failed_remove_list} due to not found in contest.")
         )
 
+    async def _rejudge_challenges(self, pro_id: int, rechals: list, include_system_test: bool = False):
+        """Helper method to rejudge a list of challenges.
+
+        Args:
+            pro_id: Problem ID
+            rechals: List of (chal_id, compiler_type) tuples
+            include_system_test: Whether to include system test testdatas
+        """
+        err, pro = await ProService.inst.get_pro(
+            pro_id, ProConst.PRO_STATUS_CONTEST_USER
+        )
+        if err:
+            return
+
+        for chal_id, compiler_type in rechals:
+            await ChalService.inst.reset_chal(chal_id)
+            await ChalService.inst.emit_chal(
+                chal_id,
+                pro.config,
+                compiler_type,
+                ChalConst.CONTEST_REJUDGE_PRI,
+                pro.problem_type,
+                skip_nonac=False,
+                include_system_test=include_system_test,
+            )
+
     @contest_manage_pro_dispatcher.action("rechal")
     async def rechal_action(self):
         try:
@@ -194,43 +220,47 @@ class ContestManageProHandler(RequestHandler):
         if err:
             return self.error(err)
 
-        async with self.db.acquire() as con:
-            result = await con.fetch(
-                """
-                    SELECT chal_id, compiler_type FROM challenge
-                    WHERE contest_id = $1 AND pro_id = $2;
-                """,
-                self.contest.contest_id,
-                pro_id,
+        if not self.contest.enable_system_test:
+            async with self.db.acquire() as con:
+                result = await con.fetch(
+                    """
+                        SELECT chal_id, compiler_type FROM challenge
+                        WHERE contest_id = $1 AND pro_id = $2;
+                    """,
+                    self.contest.contest_id,
+                    pro_id,
+                )
+            await asyncio.create_task(
+                self._rejudge_challenges(pro_id, result, include_system_test=True)
             )
-
-        # TODO: send notify to user
-        async def _rechal(rechals):
-            err, pro = await ProService.inst.get_pro(
-                pro_id, ProConst.PRO_STATUS_CONTEST_USER
-            )
-            if err:
-                return
-            for chal_id, compiler_type in rechals:
-                _, _ = await ChalService.inst.reset_chal(chal_id)
-                _, _ = await ChalService.inst.emit_chal(
-                    chal_id,
-                    pro.config,
-                    compiler_type,
-                    ChalConst.CONTEST_REJUDGE_PRI,
-                    pro.problem_type,
-                    skip_nonac=False,
+        else:
+            admin_chals = []
+            normal_chals = []
+            async with self.db.acquire() as con:
+                result = await con.fetch(
+                    """
+                        SELECT acct_id, chal_id, compiler_type FROM challenge
+                        WHERE contest_id = $1 AND pro_id = $2;
+                    """,
+                    self.contest.contest_id,
+                    pro_id,
                 )
 
-        await asyncio.create_task(_rechal(rechals=result))
+            for acct_id, chal_id, compiler_type in result:
+                if self.contest.is_admin(acct_id=acct_id):
+                    admin_chals.append((chal_id, compiler_type))
+                else:
+                    normal_chals.append((chal_id, compiler_type))
 
-        await self.add_log(
-            f"{self.acct.name} requested rejudge for problem #{pro_id} with {len(result)} submissions",
-            "contest.manage.pro.rechal",
-            {"pro_id": pro_id, "chal_count": len(result)}
-        )
+            await asyncio.create_task(
+                self._rejudge_challenges(pro_id, admin_chals, include_system_test=True)
+            )
+            await asyncio.create_task(
+                self._rejudge_challenges(pro_id, normal_chals, include_system_test=self.contest.is_end())
+            )
 
         return self.error(("S", f"Problem(#{pro_id}) is rechallenging."))
+
 
     @contest_manage_pro_dispatcher.action("update_score_type")
     async def update_score_type_action(self):
@@ -250,7 +280,7 @@ class ContestManageProHandler(RequestHandler):
         )
         await self.rs.hdel(f"contest_{self.contest.contest_id}_scores", str(pro_id))
         return self.error(("S", "Score type updated successfully."))
-    
+
     @contest_manage_pro_dispatcher.action("update_challenge_style")
     async def update_challenge_style_action(self):
         from services.contests import ChallengeResultStyle
@@ -302,6 +332,56 @@ class ContestManageProHandler(RequestHandler):
         )
 
         return self.error(("S", ""))
+
+    @contest_manage_pro_dispatcher.action("system_test")
+    async def system_test_action(self):
+        """Start system test for all AC challenges for a specific problem.
+
+        System test will rejudge all AC challenges with full testdatas including
+        those tagged as 'system-test'.
+        """
+        pro_id = int(self.get_argument("pro_id"))
+
+        if not self.contest.is_pro(pro_id):
+            return self.error(("Enoext", f"Problem(#{pro_id}) not in contest"))
+
+        if not self.contest.enable_system_test:
+            return self.error(("Econf", "System test is not enabled for this contest"))
+
+        if not self.contest.is_end():
+            return self.error(("Etime", "Contest must be over to start system test"))
+
+        if not JudgeServerClusterService.inst.is_server_online():
+            return self.error(("Ejudge", "No judge available"))
+
+        err, pro = await ProService.inst.get_pro(
+            pro_id, ProConst.PRO_STATUS_CONTEST_USER
+        )
+        if err:
+            return self.error(err)
+
+        async with self.db.acquire() as con:
+            result = await con.fetch(
+                """
+                    SELECT challenge.chal_id, challenge.compiler_type
+                    FROM challenge
+                    INNER JOIN total_result ON challenge.chal_id = total_result.chal_id
+                    WHERE challenge.contest_id = $1
+                    AND challenge.pro_id = $2
+                    AND total_result.state = $3;
+                """,
+                self.contest.contest_id,
+                pro_id,
+                ChalConst.STATE_AC,
+            )
+
+        if len(result) == 0:
+            return self.error(("Enoext", "No AC challenges found for system test"))
+
+        await asyncio.create_task(
+            self._rejudge_challenges(pro_id, result, include_system_test=True)
+        )
+        return self.error(("S", f"System test started for {len(result)} AC challenges on Problem(#{pro_id})."))
 
     @reqenv
     @contest_require_permission("admin")

--- a/src/handlers/manage/pro/prolist.py
+++ b/src/handlers/manage/pro/prolist.py
@@ -88,6 +88,7 @@ class ManageProListHandler(RequestHandler):
                     ChalConst.NORMAL_REJUDGE_PRI,
                     pro.problem_type,
                     skip_nonac=False,
+                    include_system_test=True,  # Non-contest rejudge includes system-test
                 )
 
         await asyncio.create_task(_rechal(rechals=result))
@@ -139,6 +140,7 @@ class ManageProListHandler(RequestHandler):
                     ChalConst.NORMAL_REJUDGE_PRI,
                     pro.problem_type,
                     skip_nonac=False,
+                    include_system_test=True,  # Non-contest rejudge includes system-test
                 )
 
         await asyncio.create_task(_rechal(rechals=result))

--- a/src/handlers/manage/pro/subtask.py
+++ b/src/handlers/manage/pro/subtask.py
@@ -199,6 +199,38 @@ class ManageProSubtaskHandler(RequestHandler):
         )
         return self.error(("S", ""))
 
+    @subtask_dispatcher.action("updatemetadata")
+    async def update_metadata_action(self):
+        try:
+            pro_id = int(self.get_argument("pro_id"))
+        except ValueError:
+            return self.error(("Eparam", "Invalid problem ID"))
+        try:
+            testdata_id = int(self.get_argument("testdata_id"))
+        except ValueError:
+            return self.error(("Eparam", "Invalid testdata ID"))
+        tags_str = self.get_argument("tags", default="").strip()
+
+        err, pro = await ProService.inst.get_pro(pro_id, ProConst.PRO_STATUS_FULL)
+        if err:
+            return self.error(err)
+
+        subtask_configs = pro.config.subtask_configs
+        if subtask_id not in subtask_configs:
+            return self.error(("Enoext", "Subtask not found"))
+
+        # Parse tags from comma-separated string
+        tags = [tag.strip() for tag in tags_str.split(",") if tag.strip()]
+        subtask_configs[subtask_id].metadata["tags"] = tags
+
+        await ProService.inst.update_pro_config(pro_id, pro.problem_type, pro.config)
+        await LogService.inst.add_log(
+            f"{self.acct.name} has sent a request to update metadata tags of subtask#{subtask_id} for problem #{pro_id}",
+            "manage.pro.update.subtask.updatemetadata",
+            {"tags": tags},
+        )
+        return self.error(("S", ""))
+
     @reqenv
     @require_permission(UserConst.ACCTTYPE_KERNEL)
     async def post(self):

--- a/src/handlers/prospec/batch/submit.py
+++ b/src/handlers/prospec/batch/submit.py
@@ -140,6 +140,15 @@ class BatchSubmitHandler(RequestHandler):
         if err:
             return self.error(err)
 
+        # Only filter system-test if in contest AND contest has system test enabled
+        # Contest Admin always runs full test (include system-test)
+        include_system_test = True
+        if self.contest and self.contest.enable_system_test:
+            # Check if user is contest admin
+            is_admin = self.contest.is_admin(self.acct)
+            if not is_admin:
+                include_system_test = False  # Regular users only run pretest during contest
+
         err, _ = await ChalService.inst.emit_chal(
             chal_id,
             pro.config,
@@ -147,6 +156,7 @@ class BatchSubmitHandler(RequestHandler):
             priority,
             pro.problem_type,
             skip_nonac=False,
+            include_system_test=include_system_test,
         )
         if err:
             return self.error(err)
@@ -206,6 +216,15 @@ class BatchSubmitHandler(RequestHandler):
         if err:
             return self.error(err)
 
+        # Only filter system-test if in contest AND contest has system test enabled
+        # Contest Admin always runs full test (include system-test)
+        include_system_test = True
+        if self.contest and self.contest.enable_system_test:
+            # Check if user is contest admin
+            is_admin = self.contest.is_admin(acct_id=chal.acct_id)
+            if not is_admin:
+                include_system_test = False  # Regular users only run pretest during contest
+
         err, _ = await ChalService.inst.emit_chal(
             chal_id,
             pro.config,
@@ -213,6 +232,7 @@ class BatchSubmitHandler(RequestHandler):
             priority,
             pro.problem_type,
             skip_nonac=False,
+            include_system_test=include_system_test,
         )
         if err:
             return self.error(err)

--- a/src/handlers/prospec/batch/testdata.py
+++ b/src/handlers/prospec/batch/testdata.py
@@ -227,7 +227,9 @@ class BatchTestdataHandler(RequestHandler):
             return self.error(err)
 
         testdatas[new_testdata_id] = BatchTestdata(
-            new_testdata_id, f"{filename}.in", f"{filename}.out"
+            testdata_id=new_testdata_id,
+            inputfile=f"{filename}.in",
+            outputfile=f"{filename}.out"
         )
         await ProService.inst.update_pro_config(pro_id, pro.problem_type, pro.config)
 
@@ -288,6 +290,40 @@ class BatchTestdataHandler(RequestHandler):
             f"{self.acct.name} has sent a request to delete testdata {testdata_id} for problem #{pro_id}",
             "manage.pro.update.testdata.deletesinglefile",
             {"testdata": asdict(deleted_testdata)},
+        )
+
+        return self.error(("S", ""))
+
+    @batch_testdata_dispatcher.action("updatemetadata")
+    async def update_metadata_action(self):
+        try:
+            pro_id = int(self.get_argument("pro_id"))
+        except ValueError:
+            return self.error(("Eparam", "Invalid problem ID"))
+        try:
+            testdata_id = int(self.get_argument("testdata_id"))
+        except ValueError:
+            return self.error(("Eparam", "Invalid testdata ID"))
+
+        tags_str = self.get_argument("tags", default="").strip()
+
+        err, pro = await ProService.inst.get_pro(pro_id, ProConst.PRO_STATUS_FULL)
+        if err:
+            return self.error(err)
+
+        testdatas = pro.config.testdatas
+        if testdata_id not in testdatas:
+            return self.error(("Enoext", "Testdata not found"))
+
+        # Parse tags from comma-separated string
+        tags = [tag.strip() for tag in tags_str.split(",") if tag.strip()]
+        testdatas[testdata_id].metadata["tags"] = tags
+
+        await ProService.inst.update_pro_config(pro_id, pro.problem_type, pro.config)
+        await LogService.inst.add_log(
+            f"{self.acct.name} has sent a request to update metadata tags of testdata {testdata_id} for problem #{pro_id}",
+            "manage.pro.update.testdata.updatemetadata",
+            {"tags": tags},
         )
 
         return self.error(("S", ""))

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -585,7 +585,7 @@ class ChalService:
         return None, Challenge(chal_id, pro_id, acct_id, contest_id, acct_name, compiler_type,
                                timestamp, total_results, subtask_results, testdata_results)
 
-    async def emit_chal(self, chal_id: int, pro_config: ProblemConfig, compiler_type: Compiler, priority: int, problem_type: int, skip_nonac: bool=False) -> tuple[None, None] | ErrorType:
+    async def emit_chal(self, chal_id: int, pro_config: ProblemConfig, compiler_type: Compiler, priority: int, problem_type: int, skip_nonac: bool=False, include_system_test: bool=True) -> tuple[None, None] | ErrorType:
         """
         Create and submit tests for a challenge based on the test metadata configuration,
         then send the challenge to the judging cluster.
@@ -597,6 +597,7 @@ class ChalService:
             priority (int): Priority level (within ChalConst.NORMAL_PRI and ChalConst.NORMAL_REJUDGE_PRI).
             problem_type (int): Problem type (from ProType enum).
             skip_nonac (bool): Skip the remaining testdata in the task if any of the testdata got non-AC or PC
+            include_system_test (bool): Whether to include system-test tagged testdatas/subtasks (default True for backward compatibility)
 
         Returns:
             tuple[None, None]: Always returns (None, None) on completion.
@@ -627,7 +628,7 @@ class ChalService:
             spec = batch_spec
             return await spec.emit_chal(
                 self.db, self.rs, chal_id, pro_id, acct_id, contest_id,
-                compiler_type, pro_config, priority, skip_nonac
+                compiler_type, pro_config, priority, skip_nonac, include_system_test
             )
 
         return ('Eunk', 'Unsupported problem type'), None

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -67,6 +67,7 @@ class Contest:
     submission_cd_time: int = 30
     freeze_scoreboard_period: int = 0
     penalty_value: int = 20
+    enable_system_test: bool = False  # Enable system test feature (pretest/final test)
 
     def is_start(self) -> bool:
         return datetime.datetime.now(datetime.UTC) >= self.contest_start
@@ -148,7 +149,8 @@ class ContestService:
                         "hide_admin",
                         "submission_cd_time",
                         "freeze_scoreboard_period",
-                        "penalty_value"
+                        "penalty_value",
+                        "enable_system_test"
                         FROM "contest" WHERE "contest_id" = $1;
                     ''',
                     contest_id
@@ -261,8 +263,9 @@ class ContestService:
                     "hide_admin" = $13,
                     "submission_cd_time" = $14,
                     "freeze_scoreboard_period" = $15,
-                    "penalty_value" = $16
-                    WHERE "contest_id" = $17;
+                    "penalty_value" = $16,
+                    "enable_system_test" = $17
+                    WHERE "contest_id" = $18;
                 ''',
                 contest.name,
                 contest.desc_before_contest,
@@ -279,6 +282,7 @@ class ContestService:
                 contest.submission_cd_time,
                 contest.freeze_scoreboard_period,
                 contest.penalty_value,
+                contest.enable_system_test,
                 contest.contest_id
             )
 

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -98,6 +98,19 @@ class ProConst:
 class BaseTestdata:
     """Base class for all problem type testdata, used for type checking only."""
     testdata_id: int
+    metadata: dict = None
+
+    def __post_init__(self):
+        if self.metadata is None:
+            self.metadata = {}
+
+    def has_tag(self, tag: str) -> bool:
+        """Check if testdata has a specific tag."""
+        return tag in self.metadata.get('tags', [])
+
+    def is_system_test(self) -> bool:
+        """Check if testdata is marked as system test."""
+        return self.has_tag('system-test')
 
 
 @dataclass(slots=True)
@@ -106,6 +119,19 @@ class SubtaskConfig:
     testdatas: list[BaseTestdata]
     dependency_subtasks: set[int]
     rate: int
+    metadata: dict = None
+
+    def __post_init__(self):
+        if self.metadata is None:
+            self.metadata = {}
+
+    def has_tag(self, tag: str) -> bool:
+        """Check if subtask has a specific tag."""
+        return tag in self.metadata.get('tags', [])
+
+    def is_system_test(self) -> bool:
+        """Check if subtask is marked as system test."""
+        return self.has_tag('system-test')
 
 
 @dataclass(slots=True)
@@ -166,6 +192,22 @@ class ProblemConfig:
                 s.add(t.testdata_id)
 
         return [self.testdatas[t_id] for t_id in s]
+
+    def get_pretest_subtasks(self) -> dict[int, SubtaskConfig]:
+        """Get subtasks without system-test tag (for contest pretest)."""
+        return {
+            subtask_id: subtask
+            for subtask_id, subtask in self.subtask_configs.items()
+            if not subtask.is_system_test()
+        }
+
+    def get_system_test_subtasks(self) -> dict[int, SubtaskConfig]:
+        """Get subtasks with system-test tag."""
+        return {
+            subtask_id: subtask
+            for subtask_id, subtask in self.subtask_configs.items()
+            if subtask.is_system_test()
+        }
 
 
 @dataclass(slots=True)
@@ -236,7 +278,7 @@ class ProService:
             # Get testdata with new files structure
             result = await con.fetch(
                 """
-                    SELECT "id", "files"
+                    SELECT "id", "files", "metadata"
                     FROM "testdata" WHERE "pro_id" = $1;
                 """,
                 pro_id,
@@ -247,26 +289,29 @@ class ProService:
             if problem_type == ProType.BATCH:
                 try:
                     spec = batch_spec
-                    for id, files_json in result:
-                        testdatas[id] = spec.parse_testdata_files(id, json.loads(files_json))
+                    for id, files_json, metadata_json in result:
+                        testdata = spec.parse_testdata_files(id, json.loads(files_json))
+                        testdata.metadata = json.loads(metadata_json) if metadata_json else {}
+                        testdatas[id] = testdata
                 except Exception as e:
                     logger.error(f"Error parsing testdata for problem {pro_id}: {e}", exc_info=True)
                     return ("Eunk", "Unknown error"), None
 
             result = await con.fetch(
                 """
-                    SELECT "subtask_id", "rate", "testdatas", "dep_subtasks"
+                    SELECT "subtask_id", "rate", "testdatas", "dep_subtasks", "metadata"
                     FROM "subtask_config" WHERE "pro_id" = $1 ORDER BY "subtask_id" ASC;
                 """,
                 pro_id,
             )
             subtask_configs: dict[int, SubtaskConfig] = {}
-            for subtask_id, rate, testdata_ids, dep_subtasks in result:
+            for subtask_id, rate, testdata_ids, dep_subtasks, metadata_json in result:
                 subtask_configs[subtask_id] = SubtaskConfig(
                     subtask_id,
                     [testdatas[testdata_id] for testdata_id in testdata_ids],
                     set(dep_subtasks),
                     rate,
+                    json.loads(metadata_json) if metadata_json else {},
                 )
 
         # Parse config using ProSpec
@@ -508,10 +553,13 @@ class ProService:
         insert_testdatas_values = []
         for subtask_id, subtask_config in config.subtask_configs.items():
             rate = subtask_config.rate
+            metadata_json = json.dumps(subtask_config.metadata if subtask_config.metadata else {})
             insert_subtask_config_values.append(
                 (
                     pro_id, subtask_id, rate,
-                    [testdata.testdata_id for testdata in subtask_config.testdatas], subtask_config.dependency_subtasks
+                    [testdata.testdata_id for testdata in subtask_config.testdatas],
+                    subtask_config.dependency_subtasks,
+                    metadata_json
                 )
             )
 
@@ -520,8 +568,9 @@ class ProService:
             spec = batch_spec
             for testdata in config.testdatas.values():
                 files_json = spec.build_testdata_files(testdata)
+                metadata_json = json.dumps(testdata.metadata if testdata.metadata else {})
                 insert_testdatas_values.append(
-                    (pro_id, testdata.testdata_id, json.dumps(files_json))
+                    (pro_id, testdata.testdata_id, json.dumps(files_json), metadata_json)
                 )
 
         try:
@@ -559,15 +608,15 @@ class ProService:
 
                     await con.executemany(
                         """INSERT INTO "subtask_config"
-                            ("pro_id", "subtask_id", "rate", "testdatas", "dep_subtasks")
-                            VALUES ($1, $2, $3, $4, $5);""",
+                            ("pro_id", "subtask_id", "rate", "testdatas", "dep_subtasks", "metadata")
+                            VALUES ($1, $2, $3, $4, $5, $6);""",
                         insert_subtask_config_values,
                     )
 
                     await con.executemany(
                         """
-                            INSERT INTO "testdata" ("pro_id", "id", "files")
-                            VALUES ($1, $2, $3);
+                            INSERT INTO "testdata" ("pro_id", "id", "files", "metadata")
+                            VALUES ($1, $2, $3, $4);
                         """,
                         insert_testdatas_values,
                     )

--- a/src/services/prospec/batch.py
+++ b/src/services/prospec/batch.py
@@ -36,8 +36,8 @@ class BatchConfig(BaseConfig):
 
 @dataclass(slots=True)
 class BatchTestdata(BaseTestdata):
-    inputfile: str
-    outputfile: str
+    inputfile: str = ''
+    outputfile: str = ''
 
 
 class BatchProblemSpec(ProSpec):
@@ -113,6 +113,7 @@ class BatchProblemSpec(ProSpec):
         config: ProblemConfig,
         priority: int,
         skip_nonac: bool = False,
+        include_system_test: bool = True,
     ) -> tuple[None, None] | tuple[tuple[str, str], None]:
         """Emit Batch challenge to judge server."""
         from services.chal import ChalConst, COMPILER_INFOS
@@ -136,15 +137,89 @@ class BatchProblemSpec(ProSpec):
 
                     need_judge_testdatas: set[int] = set()
                     subtasks = []
-                    for subtask_id, subtask_config in config.subtask_configs.items():
-                        t = tuple(testdata.testdata_id for testdata in subtask_config.testdatas)
-                        need_judge_testdatas.update(t)
-                        subtasks.append({
-                            "id": subtask_id,
-                            "score": subtask_config.rate,
-                            "testdatas": t,
-                            "dependency_subtasks": list(subtask_config.dependency_subtasks),
-                        })
+
+                    if include_system_test:
+                        # Include all subtasks and testdatas
+                        for subtask_id, subtask_config in config.subtask_configs.items():
+                            t = [testdata.testdata_id for testdata in subtask_config.testdatas]
+                            need_judge_testdatas.update(t)
+                            subtasks.append({
+                                "id": subtask_id,
+                                "score": subtask_config.rate,
+                                "testdatas": t,
+                                "dependency_subtasks": list(subtask_config.dependency_subtasks),
+                            })
+                    else:
+                        # Pretest mode: exclude system-test tagged subtasks and testdatas
+                        from services.chal import SubtaskResult, TestdataResult, ChalService, MessageType
+
+                        system_test_subtasks = config.get_system_test_subtasks()
+
+                        # Mark entire system-test subtasks as SKIPPED
+                        for subtask_id, subtask_config in system_test_subtasks.items():
+                            await ChalService.inst.update_subtask_result(
+                                chal_id,
+                                SubtaskResult(subtask_id, ChalConst.STATE_SKIPPED, 0, 0, decimal.Decimal())
+                            )
+                            # Mark all testdatas in this system-test subtask as SKIPPED
+                            for testdata in subtask_config.testdatas:
+                                await ChalService.inst.update_testdata_result(
+                                    chal_id,
+                                    TestdataResult(testdata.testdata_id, ChalConst.STATE_SKIPPED, 0, 0, "", MessageType.NONE)
+                                )
+
+                        # Process pretest subtasks (non-system-test subtasks)
+                        pretest_subtasks = config.get_pretest_subtasks()
+                        for subtask_id, subtask_config in pretest_subtasks.items():
+                            # Filter out system-test tagged testdatas within this subtask
+                            pretest_testdatas = []
+                            for testdata in subtask_config.testdatas:
+                                if testdata.is_system_test():
+                                    # Mark individual system-test testdata as SKIPPED
+                                    await ChalService.inst.update_testdata_result(
+                                        chal_id,
+                                        TestdataResult(testdata.testdata_id, ChalConst.STATE_SKIPPED, 0, 0, "", MessageType.NONE)
+                                    )
+                                else:
+                                    pretest_testdatas.append(testdata.testdata_id)
+
+                            # Only include subtask if it has at least one pretest testdata
+                            if pretest_testdatas:
+                                need_judge_testdatas.update(pretest_testdatas)
+                                subtasks.append({
+                                    "id": subtask_id,
+                                    "score": subtask_config.rate,
+                                    "testdatas": pretest_testdatas,
+                                    "dependency_subtasks": list(subtask_config.dependency_subtasks),
+                                })
+                            else:
+                                # Subtask has no pretest testdatas, mark as SKIPPED
+                                await ChalService.inst.update_subtask_result(
+                                    chal_id,
+                                    SubtaskResult(subtask_id, ChalConst.STATE_SKIPPED, 0, 0, decimal.Decimal())
+                                )
+
+                        run_subtasks = {subtask['id'] for subtask in subtasks}
+                        for subtask in subtasks:
+                            for dep in subtask['dependency_subtasks']:
+                                if dep not in run_subtasks:
+                                    # Dependency subtask is skipped, so this subtask should also be skipped
+                                    await ChalService.inst.update_subtask_result(
+                                        chal_id,
+                                        SubtaskResult(subtask['id'], ChalConst.STATE_JE, 0, 0, decimal.Decimal())
+                                    )
+                                    # Mark all testdatas in this subtask as SKIPPED
+                                    for testdata_id in subtask['testdatas']:
+                                        await ChalService.inst.update_testdata_result(
+                                            chal_id,
+                                            TestdataResult(testdata_id, ChalConst.STATE_SKIPPED, 0, 0, "", MessageType.NONE)
+                                        )
+
+                                    try:
+                                        run_subtasks.remove(subtask['id'])
+                                    except KeyError:
+                                        pass
+
 
                     await con.execute('UPDATE testdata_result SET state = $1 WHERE chal_id = $2 AND id = ANY($3);',
                                     ChalConst.STATE_JUDGE, chal_id, list(need_judge_testdatas))
@@ -426,7 +501,11 @@ class BatchProblemSpec(ProSpec):
                     if t not in testdata_name_2_id:
                         t = os.path.basename(str(t))
                         testdata_name_2_id[t] = testdata_id_counter
-                        testdatas[testdata_id_counter] = BatchTestdata(testdata_id_counter, f"{t}.in", f"{t}.out")
+                        testdatas[testdata_id_counter] = BatchTestdata(
+                            testdata_id=testdata_id_counter,
+                            inputfile=f"{t}.in",
+                            outputfile=f"{t}.out"
+                        )
                         testdata_id_counter += 1
 
                 subtask_configs[test_idx] = SubtaskConfig(test_idx, [], set(), int(test_conf["weight"]))

--- a/src/static/templ/chal.html
+++ b/src/static/templ/chal.html
@@ -3,10 +3,16 @@
 {% from services.contests import ChallengeResultStyle %}
 
 {% set challenge_style = ChallengeResultStyle.FULL %}
+{% set should_hide_system_test = False %}
 {% if chal.contest_id != 0 and contest is not None %}
     {% set challenge_style = contest.pro_list.get(chal.pro_id, {}).get('challenge_style', ChallengeResultStyle.FULL) %}
     {% if contest.is_admin(acct_id=user.acct_id) %}
         {% set challenge_style = ChallengeResultStyle.FULL %}
+    {% else %}
+        {# Regular users: hide system-test during contest if system test is enabled #}
+        {% if contest.enable_system_test and contest.is_running() %}
+            {% set should_hide_system_test = True %}
+        {% end %}
     {% end %}
 {% end %}
 
@@ -334,6 +340,12 @@
             </thead>
             <tbody>
             {% for subtask in chal.subtask_results.values() %}
+                {% if should_hide_system_test %}
+                    {% set subtask_config = pro.config.subtask_configs.get(subtask.subtask_id) %}
+                    {% if subtask_config and subtask_config.is_system_test() %}
+                        {% continue %}
+                    {% end %}
+                {% end %}
                 <tr class="states" id="id{{ subtask.subtask_id }}">
                     <td class="idx">{{ '%04d' % (subtask.subtask_id + 1) }}</td>
                     <td class="state state-{{ subtask.state }}">{{ ChalConst.STATE_LONG_STR[subtask.state] }}</td>
@@ -383,6 +395,12 @@
                     <div id="testdata-state-count" class="mb-3">
                         {% set state_count = {} %}
                         {% for testdata in chal.testdata_results.values() %}
+                            {% if should_hide_system_test %}
+                                {% set td_config = pro.config.testdatas.get(testdata.testdata_id) %}
+                                {% if td_config and td_config.is_system_test() %}
+                                    {% continue %}
+                                {% end %}
+                            {% end %}
                             {% if testdata.state not in state_count %}
                                 {% set _ = state_count.update({testdata.state: 0}) %}
                             {% end %}
@@ -429,6 +447,12 @@
                         {% for testdata_result in chal.testdata_results.values() %}
                             {% if testdata_result.testdata_id not in effective_testdata_ids %}
                                 {% continue %}
+                            {% end %}
+                            {% if should_hide_system_test %}
+                                {% set td_config = pro.config.testdatas.get(testdata_result.testdata_id) %}
+                                {% if td_config and td_config.is_system_test() %}
+                                    {% continue %}
+                                {% end %}
                             {% end %}
 
                             {% set message = testdata_result.message %}

--- a/src/static/templ/contests/manage/general.html
+++ b/src/static/templ/contests/manage/general.html
@@ -138,6 +138,7 @@
                 submission_cd_time: submit_cd_time,
                 freeze_scoreboard_period: freeze_period,
                 penalty_value: penalty_value,
+                enable_system_test: $("#enableSystemTest").is(":checked"),
             }, res => {
                 res = JSON.parse(res);
                 if (res.status == 'S') {
@@ -282,6 +283,11 @@
         <div class="mb-1 form-check">
             <label for="allowViewOtherPage" class="form-check-label">Allow View Other Page During Contest (WIP)</label>
             <input type="checkbox" id="allowViewOtherPage" class="form-check-input" {% if contest.allow_view_other_page %} checked {% end %}>
+        </div>
+
+        <div class="mb-1 form-check">
+            <label for="enableSystemTest" class="form-check-label">Enable System Test (Pretest/Final Test)</label>
+            <input type="checkbox" id="enableSystemTest" class="form-check-input" {% if contest.enable_system_test %} checked {% end %}>
         </div>
 
         <div class="mb-1">

--- a/src/static/templ/contests/manage/pro.html
+++ b/src/static/templ/contests/manage/pro.html
@@ -3,47 +3,69 @@
 {% block head %}
 {% from services.contests import ContestMode %}
 <script type="text/javascript" id="contjs">
-	function init() {
+    function init() {
         let contest_id = "{{ contest.contest_id }}";
         let contest_mode = {{ contest.contest_mode }};
         let is_ioi_mode = contest_mode == {{ ContestMode.IOI }};
 
-		const post_func = (reqtype, pro_id, score_type=null, fail_action=null) => {
-			if (pro_id.length == 0) {
-				index.show_notify_dialog('Input invalid.', index.DIALOG_TYPE.warning);
-				return;
-			}
+        const post_func = (reqtype, pro_id, score_type=null, fail_action=null) => {
+            if (pro_id.length == 0) {
+                index.show_notify_dialog('Input invalid.', index.DIALOG_TYPE.warning);
+                return;
+            }
 
-			let data = {
-				reqtype: reqtype,
-				pro_id: pro_id,
-			};
-			if (score_type !== null) {
-				data.score_type = score_type;
-			}
+            let data = {
+                reqtype: reqtype,
+                pro_id: pro_id,
+            };
+            if (score_type !== null) {
+                data.score_type = score_type;
+            }
 
-			$.post(`{{ url(f'/be/contests/{ contest.contest_id }/manage/pro') }}`, data, res => {
+            $.post(`{{ url(f'/be/contests/{ contest.contest_id }/manage/pro') }}`, data, res => {
                 res = JSON.parse(res);
                 if (res.status == 'S') {
                     index.show_notify_dialog(res.data, index.DIALOG_TYPE.success);
-					setTimeout(() => index.reload(), 1000);
+                    setTimeout(() => index.reload(), 1000);
                 } else {
                     if (fail_action != null) fail_action();
                     index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
                 }
-			});
-		};
+            });
+        };
 
-		document.querySelectorAll('button.remove').forEach(el => {
-			el.addEventListener('click', () => post_func('remove', $(el).attr('pro_id')));
-		});
+        document.querySelectorAll('button.remove').forEach(el => {
+            el.addEventListener('click', () => post_func('remove', $(el).attr('pro_id')));
+        });
 
-		document.querySelectorAll('button.rechal').forEach(el => {
-			el.addEventListener('click', () => post_func('rechal', $(el).attr('pro_id')));
-		});
+        document.querySelectorAll('button.rechal').forEach(el => {
+            el.addEventListener('click', () => post_func('rechal', $(el).attr('pro_id')));
+        });
+
+        document.querySelectorAll('button.system-test').forEach(el => {
+            el.addEventListener('click', () => {
+                if (confirm('Make sure you want to perform System Test? This will rejudge all AC submissions.')) {
+                    post_func('system_test', $(el).attr('pro_id'));
+                }
+            });
+        });
 
         document.querySelectorAll('button.public').forEach(el => {
             el.addEventListener('click', () => post_func('public', $(el).attr('pro_id')));
+        });
+
+        $("button.systemtestall").on('click', function(e) {
+            if (!confirm('Make sure you want to perform System Test for all problems? This will rejudge all AC submissions.')) {
+                return;
+            }
+            document.querySelectorAll('button.system-test:not([disabled])').forEach(el => {
+                let pro_id = $(el).attr('pro_id');
+                $.post(`{{ url(f'/be/contests/{ contest.contest_id }/manage/pro') }}`, {
+                    reqtype: "system_test",
+                    pro_id: pro_id
+                });
+            });
+            index.show_notify_dialog('System Test started for all problems', index.DIALOG_TYPE.success);
         });
 
         $("button.publicall").on('click', function(e) {
@@ -56,64 +78,64 @@
             });
         });
 
-		// Handle score type change dropdown
-		$(".score-type-select").on('change', function() {
-			let pro_id = $(this).attr('pro_id');
-			let new_score_type = $(this).val();
-			let old_score_type = $(this).attr('data-old-value');
+        // Handle score type change dropdown
+        $(".score-type-select").on('change', function() {
+            let pro_id = $(this).attr('pro_id');
+            let new_score_type = $(this).val();
+            let old_score_type = $(this).attr('data-old-value');
 
-			if (new_score_type == old_score_type) {
-				return;
-			}
+            if (new_score_type == old_score_type) {
+                return;
+            }
 
-			$.post(`{{ url(f'/be/contests/{ contest.contest_id }/manage/pro') }}`, {
-				reqtype: 'update_score_type',
-				pro_id: pro_id,
-				score_type: new_score_type
-			}, res => {
-				res = JSON.parse(res);
-				if (res.status == 'S') {
-					index.show_notify_dialog(res.data, index.DIALOG_TYPE.success);
-					setTimeout(() => index.reload(), 1000);
-				} else {
-					index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
-					// Reset to old value on error
-					$(this).val(old_score_type);
-				}
-			});
-		});
+            $.post(`{{ url(f'/be/contests/{ contest.contest_id }/manage/pro') }}`, {
+                reqtype: 'update_score_type',
+                pro_id: pro_id,
+                score_type: new_score_type
+            }, res => {
+                res = JSON.parse(res);
+                if (res.status == 'S') {
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.success);
+                    setTimeout(() => index.reload(), 1000);
+                } else {
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
+                    // Reset to old value on error
+                    $(this).val(old_score_type);
+                }
+            });
+        });
 
-		// Handle challenge style change dropdown
-		$(".challenge-style-select").on('change', function() {
-			let pro_id = $(this).attr('pro_id');
-			let new_challenge_style = $(this).val();
-			let old_challenge_style = $(this).attr('data-old-value');
+        // Handle challenge style change dropdown
+        $(".challenge-style-select").on('change', function() {
+            let pro_id = $(this).attr('pro_id');
+            let new_challenge_style = $(this).val();
+            let old_challenge_style = $(this).attr('data-old-value');
 
-			if (new_challenge_style == old_challenge_style) {
-				return;
-			}
+            if (new_challenge_style == old_challenge_style) {
+                return;
+            }
 
-			$.post(`{{ url(f'/be/contests/{ contest.contest_id }/manage/pro') }}`, {
-				reqtype: 'update_challenge_style',
-				pro_id: pro_id,
-				challenge_style: new_challenge_style
-			}, res => {
-				res = JSON.parse(res);
-				if (res.status == 'S') {
-					index.show_notify_dialog(res.data, index.DIALOG_TYPE.success);
-					setTimeout(() => index.reload(), 1000);
-				} else {
-					index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
-					// Reset to old value on error
-					$(this).val(old_challenge_style);
-				}
-			});
-		});
+            $.post(`{{ url(f'/be/contests/{ contest.contest_id }/manage/pro') }}`, {
+                reqtype: 'update_challenge_style',
+                pro_id: pro_id,
+                challenge_style: new_challenge_style
+            }, res => {
+                res = JSON.parse(res);
+                if (res.status == 'S') {
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.success);
+                    setTimeout(() => index.reload(), 1000);
+                } else {
+                    index.show_notify_dialog(res.data, index.DIALOG_TYPE.error);
+                    // Reset to old value on error
+                    $(this).val(old_challenge_style);
+                }
+            });
+        });
 
-		$("#addPro").on('click', () => post_func('add', $("#proId").val(), is_ioi_mode ? parseInt($("#proScoreType").val(), 10) : null, () => $("#proId").val('')));
-		$("#removePro").on('click', () => post_func('remove', $("#proId").val(), null, () => $("#proId").val('')));
-		$("#addProList").on('click', () => post_func('multi_add', $("#proList").val(), is_ioi_mode ? parseInt($("#proListScoreType").val(), 10) : null, () => $("#proList").val('')));
-		$("#removeProList").on('click', () => post_func('multi_remove', $("#proList").val(), null, () => $("#proList").val('')));
+        $("#addPro").on('click', () => post_func('add', $("#proId").val(), is_ioi_mode ? parseInt($("#proScoreType").val(), 10) : null, () => $("#proId").val('')));
+        $("#removePro").on('click', () => post_func('remove', $("#proId").val(), null, () => $("#proId").val('')));
+        $("#addProList").on('click', () => post_func('multi_add', $("#proList").val(), is_ioi_mode ? parseInt($("#proListScoreType").val(), 10) : null, () => $("#proList").val('')));
+        $("#removeProList").on('click', () => post_func('multi_remove', $("#proList").val(), null, () => $("#proList").val('')));
     }
 </script>
 {% end %}
@@ -124,99 +146,115 @@
 
 <div class="col-lg-10 ms-lg-2 mt-lg-2">
 
-	<div class="accordion">
-		<div class="accordion-item">
-			<h2 class="accordion-header" id="headingOne">
-				<button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-					Problem List
-				</button>
-			</h2>
+    <div class="accordion">
+        <div class="accordion-item">
+            <h2 class="accordion-header" id="headingOne">
+                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+                    Problem List
+                </button>
+            </h2>
 
-			<div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="headingOne" data-bs-parent="#accordionExample">
-				<div class="accordion-body">
-					<form id="form">
-						<label for="#name" class="form-label">Problem ID (Single)</label>
-						<div class="input-group mb-1">
-							<input type="number" class="form-control" placeholder="pro id" id="proId">
-							{% if contest.contest_mode == ContestMode.IOI %}
-							<select class="form-select" id="proScoreType" style="max-width: 150px;">
-								<option value="{{ ProblemScoreType.IOI2017 }}">IOI2017</option>
-								<option value="{{ ProblemScoreType.IOI2013 }}">IOI2013</option>
-							</select>
-							{% end %}
-							<button class="btn btn-primary" id="addPro" type="button">Add</button>
-							<button class="btn btn-warning" id="removePro" type="button">Remove</button>
-						</div>
+            <div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="headingOne" data-bs-parent="#accordionExample">
+                <div class="accordion-body">
+                    <form id="form">
+                        <label for="#name" class="form-label">Problem ID (Single)</label>
+                        <div class="input-group mb-1">
+                            <input type="number" class="form-control" placeholder="pro id" id="proId">
+                            {% if contest.contest_mode == ContestMode.IOI %}
+                            <select class="form-select" id="proScoreType" style="max-width: 150px;">
+                                <option value="{{ ProblemScoreType.IOI2017 }}">IOI2017</option>
+                                <option value="{{ ProblemScoreType.IOI2013 }}">IOI2013</option>
+                            </select>
+                            {% end %}
+                            <button class="btn btn-primary" id="addPro" type="button">Add</button>
+                            <button class="btn btn-warning" id="removePro" type="button">Remove</button>
+                        </div>
 
-						<label for="#name" class="form-label">Problem ID List (Multi)</label>
-						<div class="input-group mb-1">
-							<input type="text" class="form-control" placeholder="pro id list" id="proList">
-							{% if contest.contest_mode == ContestMode.IOI %}
-							<select class="form-select" id="proListScoreType" style="max-width: 150px;">
-								<option value="{{ ProblemScoreType.IOI2017 }}">IOI2017</option>
-								<option value="{{ ProblemScoreType.IOI2013 }}">IOI2013</option>
-							</select>
-							{% end %}
-							<button class="btn btn-primary" id="addProList" type="button">Add</button>
-							<button class="btn btn-warning" id="removeProList" type="button">Remove</button>
-						</div>
-					</form>
+                        <label for="#name" class="form-label">Problem ID List (Multi)</label>
+                        <div class="input-group mb-1">
+                            <input type="text" class="form-control" placeholder="pro id list" id="proList">
+                            {% if contest.contest_mode == ContestMode.IOI %}
+                            <select class="form-select" id="proListScoreType" style="max-width: 150px;">
+                                <option value="{{ ProblemScoreType.IOI2017 }}">IOI2017</option>
+                                <option value="{{ ProblemScoreType.IOI2013 }}">IOI2013</option>
+                            </select>
+                            {% end %}
+                            <button class="btn btn-primary" id="addProList" type="button">Add</button>
+                            <button class="btn btn-warning" id="removeProList" type="button">Remove</button>
+                        </div>
+                    </form>
 
+                    {% if contest.enable_system_test %}
+                    <button
+                        class="btn btn-info me-2 systemtestall"
+                        {% if not contest.is_end() %} disabled {% end %}
+                    >System Test All</button>
+                    {% end %}
                     <button
                         class="btn btn-danger me-2 publicall"
                         {% if not contest.is_end() %} disabled {% end %}
                     >Public All Problem</button>
 
-					<table class="table table-hover table-sm table-responsive-sm col mx-lg-3">
-					<thead>
-						<tr>
-							<th scope="col">Pro ID</th>
-							<th scope="col">Problem Name</th>
-							<th scope="col">Score Type</th>
-							<th scope="col">Challenge Style</th>
-							<th scope="col">Operation</th>
-						</tr>
-					</thead>
-					<tbody>
-					{% for pro in pro_list %}
-						<tr>
-							<th scope="row"><a href="{{ url(f'/contests/{ contest.contest_id }/pro/{ pro.pro_id }/') }}">{{ pro.pro_id }}</a></th>
-							<td>{{ pro.name }}</td>
-							{% if contest.contest_mode == ContestMode.IOI %}
-                <td>
-                  <select class="form-select form-select-sm score-type-select" pro_id="{{ pro.pro_id }}" data-old-value="{{ contest.pro_list[pro.pro_id]['score_type'] }}" style="width: auto;">
-                    <option value="1" {% if contest.pro_list[pro.pro_id]['score_type'] == 1 %}selected{% end %}>IOI2017</option>
-                    <option value="0" {% if contest.pro_list[pro.pro_id]['score_type'] == 0 %}selected{% end %}>IOI2013</option>
-                  </select>
-                </td>
-							{% else %}
-							  <td>ICPC</td>
-							{% end %}
-							<td>
-								<select class="form-select form-select-sm challenge-style-select" pro_id="{{ pro.pro_id }}" data-old-value="{{ contest.pro_list[pro.pro_id].get('challenge_style', 1) }}" style="width: auto;">
-									<option value="{{ ChallengeResultStyle.FULL }}" {% if contest.pro_list[pro.pro_id].get('challenge_style', 1) == ChallengeResultStyle.FULL %}selected{% end %}>Full</option>
-									<option value="{{ ChallengeResultStyle.STATE_COUNT }}" {% if contest.pro_list[pro.pro_id].get('challenge_style', 1) == ChallengeResultStyle.STATE_COUNT %}selected{% end %}>State Count</option>
-									<option value="{{ ChallengeResultStyle.SUBTASK_ONLY }}" {% if contest.pro_list[pro.pro_id].get('challenge_style', 1) == ChallengeResultStyle.SUBTASK_ONLY %}selected{% end %}>Subtask Only</option>
-									<option value="{{ ChallengeResultStyle.TOTAL_ONLY }}" {% if contest.pro_list[pro.pro_id].get('challenge_style', 1) == ChallengeResultStyle.TOTAL_ONLY %}selected{% end %}>Total Only</option>
-								</select>
-							</td>
-							<td>
-								<button class="btn btn-warning me-2 remove" pro_id="{{ pro.pro_id }}">Remove</button>
-								<button class="btn btn-danger me-2 rechal" pro_id="{{ pro.pro_id }}">Rechallenge</button>
-                <button
-                    class="btn btn-danger me-2 public"
-                    pro_id="{{ pro.pro_id }}"
-                    {% if not contest.is_end() or pro.status != ProConst.STATUS_CONTEST %} disabled {% end %}
-                >Public Problem</button>
-							</td>
-						</tr>
-					{% end %}
-					</tbody>
-					</table>
-				</div>
-			</div>
-		</div>
-	</div>
+                    <table class="table table-hover table-sm table-responsive-sm col mx-lg-3">
+                    <thead>
+                        <tr>
+                            <th scope="col">Pro ID</th>
+                            <th scope="col">Problem Name</th>
+                            <th scope="col">Score Type</th>
+                            <th scope="col">Challenge Style</th>
+                            <th scope="col">Operation</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for pro in pro_list %}
+                        <tr>
+                            <th scope="row"><a href="{{ url(f'/contests/{ contest.contest_id }/pro/{ pro.pro_id }/') }}">{{ pro.pro_id }}</a></th>
+                            <td>{{ pro.name }}</td>
+                            {% if contest.contest_mode == ContestMode.IOI %}
+                                <td>
+                                <select class="form-select form-select-sm score-type-select" pro_id="{{ pro.pro_id }}" data-old-value="{{ contest.pro_list[pro.pro_id]['score_type'] }}" style="width: auto;">
+                                    <option value="1" {% if contest.pro_list[pro.pro_id]['score_type'] == 1 %}selected{% end %}>IOI2017</option>
+                                    <option value="0" {% if contest.pro_list[pro.pro_id]['score_type'] == 0 %}selected{% end %}>IOI2013</option>
+                                </select>
+                                </td>
+                            {% else %}
+                                <td>ICPC</td>
+                            {% end %}
+                            <td>
+                                <select class="form-select form-select-sm challenge-style-select" pro_id="{{ pro.pro_id }}" data-old-value="{{ contest.pro_list[pro.pro_id].get('challenge_style', 1) }}" style="width: auto;">
+                                    <option value="{{ ChallengeResultStyle.FULL }}" {% if contest.pro_list[pro.pro_id].get('challenge_style', 1) == ChallengeResultStyle.FULL %}selected{% end %}>Full</option>
+                                    <option value="{{ ChallengeResultStyle.STATE_COUNT }}" {% if contest.pro_list[pro.pro_id].get('challenge_style', 1) == ChallengeResultStyle.STATE_COUNT %}selected{% end %}>State Count</option>
+                                    <option value="{{ ChallengeResultStyle.SUBTASK_ONLY }}" {% if contest.pro_list[pro.pro_id].get('challenge_style', 1) == ChallengeResultStyle.SUBTASK_ONLY %}selected{% end %}>Subtask Only</option>
+                                    <option value="{{ ChallengeResultStyle.TOTAL_ONLY }}" {% if contest.pro_list[pro.pro_id].get('challenge_style', 1) == ChallengeResultStyle.TOTAL_ONLY %}selected{% end %}>Total Only</option>
+                                </select>
+                            </td>
+                            <td>
+                                <button class="btn btn-warning me-2 remove" pro_id="{{ pro.pro_id }}">Remove</button>
+                                <button class="btn btn-danger me-2 rechal" pro_id="{{ pro.pro_id }}">Rechallenge</button>
+
+                                {% if contest.enable_system_test %}
+                                    <button
+                                        class="btn btn-info me-2 system-test"
+                                        pro_id="{{ pro.pro_id }}"
+                                        {% if not contest.is_end() %} disabled {% end %}
+                                        title="{% if not contest.is_end() %}Contest 尚未結束{% else %}執行 System Test (重新評測所有 AC 提交){% end %}"
+                                    >System Test</button>
+                                {% end %}
+
+                                <button
+                                    class="btn btn-danger me-2 public"
+                                    pro_id="{{ pro.pro_id }}"
+                                    {% if not contest.is_end() or pro.status != ProConst.STATUS_CONTEST %} disabled {% end %}
+                                >Public Problem</button>
+                            </td>
+                        </tr>
+                    {% end %}
+                    </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 {% end %}

--- a/src/static/templ/manage/pro/updatesubtask.html
+++ b/src/static/templ/manage/pro/updatesubtask.html
@@ -161,7 +161,36 @@
 				});
             });
         });
-	}
+
+        document.querySelectorAll('button.set-metadata-tags').forEach(el => {
+            el.addEventListener('click', function(e) {
+                let subtask = $(this).parents('.accordion-collapse').attr('subtask');
+                let tags = $(this).siblings('#metadata-tags').val();
+
+                $.post(`{{ url('/be/manage/pro/updatesubtask') }}`, {
+                    'reqtype': 'updatemetadata',
+                    'pro_id': pro_id,
+                    'subtask': subtask,
+                    'tags': tags,
+                }, function (res) {
+                    let msg = '';
+                    let dialog_type = null;
+
+                    res = JSON.parse(res);
+                    if (res.status == 'S') {
+                        dialog_type = index.DIALOG_TYPE.success;
+                        msg = `Subtask #${parseInt(subtask) + 1} metadata tags updated successfully.`;
+                    } else {
+                        dialog_type = index.DIALOG_TYPE.error;
+                        msg = res.data;
+                    }
+
+                    index.show_notify_dialog(msg, dialog_type);
+                    index.reload();
+                });
+            });
+        });
+    }
 </script>
 {% end %}
 
@@ -205,6 +234,12 @@
                     <div class="input-group mb-3">
                         <input id="depsubtasks" class="form-control mb-1" type="text" value="{{ merge_list_to_str(list(map(lambda x: x+1, subtask_config.dependency_subtasks))) }}" placeholder="Dependency Subtasks">
                         <button class="btn btn-primary set-depsubtasks">Update Dependency Subtasks</button>
+                    </div>
+
+                    <label for="metadata-tags" class="form-label">Metadata Tags (comma-separated). Use <code>system-test</code> to mark as system test (final test)</label>
+                    <div class="input-group mb-3">
+                        <input id="metadata-tags" class="form-control mb-1" type="text" value="{{ ','.join(subtask_config.metadata.get('tags', [])) }}" placeholder="e.g., system-test">
+                        <button class="btn btn-primary set-metadata-tags">Update Tags</button>
                     </div>
 				</div>
 			</div>

--- a/src/static/templ/prospec/batch/manage/updatetestdata.html
+++ b/src/static/templ/prospec/batch/manage/updatetestdata.html
@@ -226,7 +226,36 @@
 				});
 			});
         });
-	}
+
+        document.querySelectorAll('button.update-metadata-tags').forEach(el => {
+            el.addEventListener('click', function (e) {
+                let testdata_id = $(this).parents('tr').attr('testdata_id');
+                let tags = $(this).siblings('#metadata-tags').val();
+
+                $.post(`{{ url('/be/manage/pro/updatetestdata') }}`, {
+                    'reqtype': 'updatemetadata',
+                    'pro_id': pro_id,
+                    'testdata_id': testdata_id,
+                    'tags': tags,
+                }, function (res) {
+                    let msg = '';
+                    let dialog_type = null;
+
+                    res = JSON.parse(res);
+                    if (res.status == 'S') {
+                        dialog_type = index.DIALOG_TYPE.success;
+                        msg = `Testdata ${parseInt(testdata_id) + 1} metadata tags updated successfully.`;
+                    } else {
+                        dialog_type = index.DIALOG_TYPE.error;
+                        msg = res.data;
+                    }
+
+                    index.show_notify_dialog(msg, dialog_type);
+                    index.reload();
+                });
+            });
+        });
+    }
 </script>
 {% end %}
 
@@ -296,6 +325,7 @@
                 <th scope="col">ID</th>
                 <th scope="col">Input Filename</th>
                 <th scope="col">Output Filename</th>
+                <th scope="col">Tags</th>
                 <th scope="col">Operation</th>
             </tr>
         </thead>
@@ -306,6 +336,12 @@
                     <th scope="row">{{ testdata_id + 1 }}</th>
                     <td><a class="preview-file input">{{ testdata.inputfile }}</a></td>
                     <td><a class="preview-file output">{{ testdata.outputfile }}</a></td>
+                    <td>
+                        <div class="input-group input-group-sm">
+                            <input id="metadata-tags" class="form-control" type="text" value="{{ ','.join(testdata.metadata.get('tags', [])) }}" placeholder="e.g., system-test">
+                            <button class="btn btn-primary btn-sm update-metadata-tags">Update</button>
+                        </div>
+                    </td>
                     <td>
                         <div class="btn-toolbar">
                             <div class="dropdown me-2">

--- a/src/tests/unit/services/prospec/batch/test_emit_chal.py
+++ b/src/tests/unit/services/prospec/batch/test_emit_chal.py
@@ -167,13 +167,13 @@ class TestBatchProblemSpecEmitChal(unittest.IsolatedAsyncioTestCase):
         # First subtask has no dependencies
         subtask1 = next(s for s in subtasks if s['id'] == 1)
         self.assertEqual(subtask1['score'], 50)
-        self.assertEqual(subtask1['testdatas'], (1, 2))
+        self.assertEqual(subtask1['testdatas'], [1, 2])
         self.assertEqual(subtask1['dependency_subtasks'], [])
 
         # Second subtask depends on first
         subtask2 = next(s for s in subtasks if s['id'] == 2)
         self.assertEqual(subtask2['score'], 50)
-        self.assertEqual(subtask2['testdatas'], (3,))
+        self.assertEqual(subtask2['testdatas'], [3,])
         self.assertEqual(subtask2['dependency_subtasks'], [1])
 
     @patch('services.judge.JudgeServerClusterService')


### PR DESCRIPTION
System tests allow partial test data to be executed first in a contest to quickly verify results, with the complete test data being executed after the contest ends. This reduces the load on the judge system.
To support this, tags have been introduced for subtasks and test data to mark whether they are used for system tests.