### PR TITLE
perf(manage): optimize update problem config speed

### DIFF
--- a/migration/20260515132400_add_result_table_foreign_key_index.py
+++ b/migration/20260515132400_add_result_table_foreign_key_index.py
@@ -1,0 +1,7 @@
+async def dochange(db, _):
+    await db.execute(
+        "CREATE INDEX testdata_result_pro_id_testdata_id_foreign_key_index ON testdata_result(pro_id, id);"
+    )
+    await db.execute(
+        "CREATE INDEX subtask_result_pro_id_subtask_id_foreign_key_index ON subtask_result(pro_id, subtask_id);"
+    )


### PR DESCRIPTION
In PostgreSQL, adding an index on a foreign key improves foreign key operations such as ON DELETE and ON UPDATE.