### PR TITLE
fix(pro): move problem manage button outside the table

### DIFF
--- a/src/static/templ/pro.html
+++ b/src/static/templ/pro.html
@@ -294,10 +294,10 @@
                     {% end %}
                 </tbody>
             </table>
-            {% if user.is_kernel() %}
-                <a class="btn btn-warning" href="{{ url(f'/manage/pro/update/?proid={ pro.pro_id }') }}">Manage</a>
-            {% end %}
         </div>
+        {% if user.is_kernel() %}
+            <a class="btn btn-warning" href="{{ url(f'/manage/pro/update/?proid={ pro.pro_id }') }}">Manage</a>
+        {% end %}
     </div>
 
     <div id="cont" class="col-lg-10 col-12">


### PR DESCRIPTION
Before:

<img width="200" height="136" alt="image" src="https://github.com/user-attachments/assets/291651d2-7dc4-49ff-a7dc-ff6ae6c7384b" />

After:

<img width="200" height="128" alt="image" src="https://github.com/user-attachments/assets/0cb01479-4c64-487b-a34b-2b809779b557" />
