### PR TITLE
fix(profile): fix table structure and empty cell padding logic

### DIFF
--- a/src/static/templ/acct/profile.html
+++ b/src/static/templ/acct/profile.html
@@ -140,11 +140,13 @@
                             <td class="_state"><a class="_state-3" href="{{ url(f'/pro/{ pro['pro_id'] }/') }}">{{pro['pro_id']}}</a></td>
                         {% end %}
                     {% end %}
-                    </tr>
-                    {% while cnt != 10 %}
-                        <td></td>
-                        {% set cnt = cnt + 1 %}
+                    {% if total_pro_cnt < 10 %}
+                        {% while cnt != 10 %}
+                            <td></td>
+                            {% set cnt = cnt + 1 %}
+                        {% end %}
                     {% end %}
+                </tr>
                 {% end %}
 	        </tbody>
        </table>

--- a/src/static/templ/acct/profile.html
+++ b/src/static/templ/acct/profile.html
@@ -129,24 +129,24 @@
             <tbody>
                 {% for chunk in prolist %}
                     <tr>
-                    {% for cnt, pro in enumerate(chunk, start=1) %}
-                        {% if pro['state'] == ChalConst.STATE_NOTSTARTED or pro['state'] is None %}
-                            <td class="_state"><a class="_state-4" href="{{ url(f'/pro/{ pro['pro_id'] }/') }}">{{pro['pro_id']}}</a></td>
-                        {% elif pro['state'] == ChalConst.STATE_AC %}
-                            <td class="_state"><a class="_state-1" {% if pro['is_topcoder'] %}style="font-weight: bolder;"{% end %} href="{{ url(f'/pro/{ pro['pro_id'] }/') }}">{{pro['pro_id']}}</a></td>
-                        {% elif pro['state'] in (ChalConst.STATE_PC, ChalConst.STATE_WA) and pro['score'] > 0 %}
-                            <td class="_state"><a class="_state-2" {% if pro['is_topcoder'] %}style="font-weight: bolder;"{% end %} href="{{ url(f'/pro/{ pro['pro_id'] }/') }}">{{pro['pro_id']}}</a></td>
-                        {% else %}
-                            <td class="_state"><a class="_state-3" href="{{ url(f'/pro/{ pro['pro_id'] }/') }}">{{pro['pro_id']}}</a></td>
+                        {% for cnt, pro in enumerate(chunk, start=1) %}
+                            {% if pro['state'] == ChalConst.STATE_NOTSTARTED or pro['state'] is None %}
+                                <td class="_state"><a class="_state-4" href="{{ url(f'/pro/{ pro['pro_id'] }/') }}">{{pro['pro_id']}}</a></td>
+                            {% elif pro['state'] == ChalConst.STATE_AC %}
+                                <td class="_state"><a class="_state-1" {% if pro['is_topcoder'] %}style="font-weight: bolder;"{% end %} href="{{ url(f'/pro/{ pro['pro_id'] }/') }}">{{pro['pro_id']}}</a></td>
+                            {% elif pro['state'] in (ChalConst.STATE_PC, ChalConst.STATE_WA) and pro['score'] > 0 %}
+                                <td class="_state"><a class="_state-2" {% if pro['is_topcoder'] %}style="font-weight: bolder;"{% end %} href="{{ url(f'/pro/{ pro['pro_id'] }/') }}">{{pro['pro_id']}}</a></td>
+                            {% else %}
+                                <td class="_state"><a class="_state-3" href="{{ url(f'/pro/{ pro['pro_id'] }/') }}">{{pro['pro_id']}}</a></td>
+                            {% end %}
                         {% end %}
-                    {% end %}
-                    {% if total_pro_cnt < 10 %}
-                        {% while cnt != 10 %}
-                            <td></td>
-                            {% set cnt = cnt + 1 %}
+                        {% if total_pro_cnt < 10 %}
+                            {% while cnt != 10 %}
+                                <td></td>
+                                {% set cnt = cnt + 1 %}
+                            {% end %}
                         {% end %}
-                    {% end %}
-                </tr>
+                    </tr>
                 {% end %}
 	        </tbody>
        </table>


### PR DESCRIPTION
Before fixing `</tr>`:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/87c52de4-5ede-4c4c-acdc-003bcb96846c" />

After:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/74ce71c4-5c71-477a-89aa-51b4b3b12014" />

Before fixing `{% while cnt != 10 %}` padding logic:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/b30df85a-655d-4cd6-89cf-9a6d268ef91f" />

After:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/f667a243-577f-4089-84eb-78728b8102f7" />

