### PR TITLE
fix: RateService not initialized when install first pro

### DIFF
--- a/scripts/install_first_pro.py
+++ b/scripts/install_first_pro.py
@@ -9,6 +9,7 @@ from redis import asyncio as aioredis
 
 from services.pro import ProService
 from services.pack import PackService
+from services.rate import RateService
 import config
 
 async def main():
@@ -16,6 +17,7 @@ async def main():
     rs = aioredis.Redis(host=config.REDIS_HOST, port=6379, db=config.REDIS_DB)
     pro_service = ProService(db, rs)
     pack_service = PackService(db, rs)
+    _ = RateService(db, rs)
 
     _, pro_id = await pro_service.add_pro(name="HelloTOJ", status=2) # pro_name: "HelloTOJ", pro_statu: "Hidden"
     _, token = await pack_service.gen_token()


### PR DESCRIPTION
## Description
When executing `./script/runserver.sh` in a newly created backend container, the following error occurs:
```
Traceback (most recent call last):
  File "/ntoj/services/pro.py", line 651, in update_pro_config
    await RateService.inst.refresh_acct_rate(all_account=True)
          ^^^^^^^^^^^^^^^^
AttributeError: type object 'RateService' has no attribute 'inst'
```

This happens because the first execution of `./script/runserver.sh` triggers `./script/install_first_pro.py`, which does not initialize `RateService`.

## What is changed
- Initialize RateService by executing RateService() before calling add_pro().