### PR TITLE
fix(contests): improve layout and structure of contests list

### DIFF
--- a/src/static/templ/contests/contests-list.html
+++ b/src/static/templ/contests/contests-list.html
@@ -4,43 +4,47 @@
     function init() {}
 </script>
 
-<div class="col-lg-12 ms-lg-2">
+<div class="col-lg-12 px-lg-2">
     {% for contest_name, contest_list in contest_category.items() %}
-        <h4 class="mt-3 d-inline-block">{{ contest_name.capitalize() }} Contests</h4>
-        {% if contest_name == "upcoming" and user.is_kernel() %}
-            <a class="btn btn-primary d-inline-block" href="{{ url('/contests/manage/add/') }}">&#x271a;</a>
-        {% end %}
-        <table class="table table-hover table-sm table-responsive-sm col mx-lg-3">
-        <thead>
-            <tr>
-                <th scope="col">Title</th>
-                <th scope="col">Start Time</th>
-                <th scope="col">End Time</th>
-                <th scope="col">Length</th>
-                <th scope="col">Contest Type</th>
-                <th scope="col">Scoreboard</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for contest in contest_list %}
-                <tr>
-                    <th scope="row"><a href="{{ url(f'/contests/{ contest['contest_id'] }/info/') }}">{{ contest['name'] }}</a></th>
-                    <td>{{ contest['contest_start'].astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M") }}</td>
-                    <td>{{ contest['contest_end'].astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M") }}</td>
-                    <td>{{ contest['contest_end'] - contest['contest_start'] }}</td>
-                    <td>{{ ContestMode(int(contest['contest_mode'])).name }}</td>
-                    <td>{{ "Yes" if contest['is_public_scoreboard'] else "No" }}</td>
-                </tr>
+        <div class="d-flex align-items-center mt-3 mb-2">
+            <h4 class="mb-0 me-2">{{ contest_name.capitalize() }} Contests</h4>
+            {% if contest_name == "upcoming" and user.is_kernel() %}
+                <a class="btn btn-primary btn-sm" href="{{ url('/contests/manage/add/') }}">&#x271a;</a>
             {% end %}
-        </tbody>
-        {% if len(contest_list) == 0 %}
-            <tr><td colspan="6" class="text-center text-muted">No {{ contest_name }} contests</td></tr>
-        {% end %}
-        </table>
+        </div>
+
+        <div class="table-responsive">
+            <table class="table table-hover table-sm col">
+                <thead>
+                    <tr>
+                        <th scope="col">Title</th>
+                        <th scope="col">Start Time</th>
+                        <th scope="col">End Time</th>
+                        <th scope="col">Length</th>
+                        <th scope="col">Contest Type</th>
+                        <th scope="col">Scoreboard</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for contest in contest_list %}
+                        <tr>
+                            <th scope="row"><a href="{{ url(f'/contests/{ contest['contest_id'] }/info/') }}">{{ contest['name'] }}</a></th>
+                            <td>{{ contest['contest_start'].astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M") }}</td>
+                            <td>{{ contest['contest_end'].astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M") }}</td>
+                            <td>{{ contest['contest_end'] - contest['contest_start'] }}</td>
+                            <td>{{ ContestMode(int(contest['contest_mode'])).name }}</td>
+                            <td>{{ "Yes" if contest['is_public_scoreboard'] else "No" }}</td>
+                        </tr>
+                    {% end %}
+                    {% if len(contest_list) == 0 %}
+                        <tr><td colspan="6" class="text-center text-muted">No {{ contest_name }} contests</td></tr>
+                    {% end %}
+                </tbody>
+            </table>
+        </div>
     {% end %}
 
     <div class="row">
-        <div class="col-1"></div>
         <div class="col pt-3">
             {% set _p_pageoff = pageoff %}
             {% set _p_pagenum = 20 %}


### PR DESCRIPTION
The style changes are consistent to the board list in #287.

The pagination change is related to #290. Do NOT close it since we only fix the contests list in this PR.

Before:

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/c60987e8-fdeb-4454-9ff3-bfdae22cdd18" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/2a43c9e1-1f72-4d7c-8c2b-3ca93bcb7630" />

After:

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/5cfa7a93-4dab-452a-ae9a-be6ea5f1935c" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/d27c63ee-0ed7-4ff9-867c-cd7caa076bf5" />
