### PR TITLE
Remove unreferenced imports and deprecated typing module

### DIFF
--- a/src/handlers/acct.py
+++ b/src/handlers/acct.py
@@ -8,7 +8,6 @@ from msgpack import packb, unpackb
 
 import config
 from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_permission, UnifiedWebSocketHandler
-from services.log import LogService
 from services.pro import ProService, ProClassService, ProClassConst, ProConst
 from services.rate import RateService
 from services.user import UserConst, UserService

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -24,7 +24,6 @@ from services.pro import ProService, ProConst
 from services.user import UserService, UserConst
 from services.contests import UserStatus, ContestService, ChallengeResultStyle
 from services.rate import RateService
-from services.log import LogService
 from utils.numeric import parse_str_to_list
 
 chal_dispatcher = ActionDispatcher()

--- a/src/handlers/manage/acct.py
+++ b/src/handlers/manage/acct.py
@@ -1,5 +1,4 @@
 from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_permission
-from services.log import LogService
 from services.user import UserConst, UserService
 
 from ipaddress import IPv4Address, AddressValueError

--- a/src/handlers/manage/board.py
+++ b/src/handlers/manage/board.py
@@ -2,7 +2,6 @@ import datetime
 
 from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_permission
 from services.board import BoardService
-from services.log import LogService
 from services.user import UserConst
 from utils.numeric import parse_str_to_list
 

--- a/src/handlers/manage/bulletin.py
+++ b/src/handlers/manage/bulletin.py
@@ -1,6 +1,5 @@
 from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_permission
 from services.bulletin import BulletinConst, BulletinService
-from services.log import LogService
 from services.user import UserConst
 
 

--- a/src/handlers/manage/info.py
+++ b/src/handlers/manage/info.py
@@ -10,7 +10,6 @@ import psutil
 import config
 from handlers.base import ActionDispatcher, RequestHandler, UnifiedWebSocketHandler, reqenv, require_permission
 from services.user import UserConst, UserService
-from services.log import LogService
 
 info_dispatcher = ActionDispatcher()
 server_start_time = time.time()

--- a/src/handlers/manage/judge.py
+++ b/src/handlers/manage/judge.py
@@ -11,7 +11,6 @@ from handlers.base import (
     require_permission,
 )
 from services.judge import JudgeServerClusterService
-from services.log import LogService
 from services.user import UserConst
 
 

--- a/src/handlers/manage/proclass.py
+++ b/src/handlers/manage/proclass.py
@@ -1,5 +1,4 @@
 from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_permission
-from services.log import LogService
 from services.pro import ProClassService, ProClassConst
 from services.user import UserConst
 from utils.numeric import parse_str_to_list

--- a/src/handlers/manage/question.py
+++ b/src/handlers/manage/question.py
@@ -1,7 +1,6 @@
 from msgpack import unpackb
 
 from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_permission
-from services.log import LogService
 from services.ques import QuestionConst, QuestionService
 from services.user import UserConst, UserService
 

--- a/src/services/chal.py
+++ b/src/services/chal.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import datetime
 import enum
 import decimal
-from typing import Sequence
+from collections.abc import Sequence
 import logging
 
 from services.pro import ProService, ProConst, ProblemConfig

--- a/src/services/judge.py
+++ b/src/services/judge.py
@@ -5,7 +5,6 @@ import smtplib
 import logging
 from email.header import Header
 from email.mime.text import MIMEText
-from typing import Dict, List, Literal, Union
 
 from tornado.websocket import websocket_connect
 
@@ -251,11 +250,11 @@ class JudgeServerService:
 
 
 class JudgeServerClusterService:
-    def __init__(self, rs, server_urls: List[Dict]) -> None:
+    def __init__(self, rs, server_urls: list[dict]) -> None:
         JudgeServerClusterService.inst = self
         self.queue = asyncio.PriorityQueue()
         self.rs = rs
-        self.servers: List[JudgeServerService] = []
+        self.servers: list[JudgeServerService] = []
         self.idx = 0
 
         for judge_id, server in enumerate(server_urls):
@@ -318,8 +317,8 @@ class JudgeServerClusterService:
         _, status = self.servers[idx].get_server_status()
         return None, status
 
-    def get_servers_status(self) -> List[Dict]:
-        status_list: List[Dict] = []
+    def get_servers_status(self) -> list[dict]:
+        status_list: list[dict] = []
         for server in self.servers:
             _, status = server.get_server_status()
             status_list.append(status)

--- a/src/services/judge.py
+++ b/src/services/judge.py
@@ -1,14 +1,10 @@
 import json
 import decimal
 import asyncio
-import smtplib
 import logging
-from email.header import Header
-from email.mime.text import MIMEText
 
 from tornado.websocket import websocket_connect
 
-import config
 from services.rate import RateService
 from services.log import LogService
 

--- a/src/services/pro.py
+++ b/src/services/pro.py
@@ -5,7 +5,7 @@ import re
 import logging
 import asyncio
 from dataclasses import asdict, dataclass
-from typing import Sequence
+from collections.abc import Sequence
 
 from msgpack import packb, unpackb
 

--- a/src/tests/integrated/acct.py
+++ b/src/tests/integrated/acct.py
@@ -1,5 +1,3 @@
-from decimal import Decimal
-import hashlib
 import requests
 
 from services.chal import ChalConst

--- a/src/tests/integrated/rank.py
+++ b/src/tests/integrated/rank.py
@@ -1,5 +1,5 @@
 from tests.integrated.util import AsyncTest, AccountContext
-from services.pro import ProConst, CheckerType
+from services.pro import ProConst
 
 
 class UserRankTest(AsyncTest):


### PR DESCRIPTION
This pull request primarily removes unused imports and modernizes type annotations across multiple files to improve code cleanliness and consistency. The most significant changes are grouped below:

#### Removal of Unused Imports:

- In PR #236, it introduced a new method to add log, replacing `LogService.inst.add_log()`. After that change, `LogService` is no longer referenced, so this PR removes it.
- Other various imports.

#### Modernization of Type Annotations:

According to [Historical and deprecated features](https://typing.python.org/en/latest/spec/historical.html#generics-in-standard-collections), `typing` is deprecated now, so following changes is applied.
* Updated type annotations to use built-in generics (e.g., `list[dict]` instead of `List[Dict]`).
* Updated imports to use `collections.abc.Sequence` instead of `typing.Sequence`.