### PR TITLE
refactor(contest): centralize contest sessions and access

### DIFF
--- a/src/handlers/base.py
+++ b/src/handlers/base.py
@@ -11,6 +11,8 @@ import tornado.websocket
 from redis import asyncio as aioredis
 
 import config
+from services.contest_access import ContestAccess
+from services.contest_session import ContestSession
 from services.contests import ContestService, Contest
 from services.user import UserService, Account
 import utils.htmlgen
@@ -85,6 +87,8 @@ class RequestHandler(tornado.web.RequestHandler):
 
         self.acct: Account = None
         self.contest: Contest = None
+        self.contest_session: ContestSession | None = None
+        self.contest_access: ContestAccess | None = None
         self.base_url = base_url
 
         super().__init__(*args, **kwargs)
@@ -104,6 +108,8 @@ class RequestHandler(tornado.web.RequestHandler):
 
         kwargs["user"] = self.acct
         kwargs["base_url"] = self.base_url
+        kwargs["contest_session"] = self.contest_session
+        kwargs["contest_access"] = self.contest_access
 
         if title is not None:
             title_header = utils.htmlgen.gen_page_title(title, config.SITE_TITLE)
@@ -111,6 +117,16 @@ class RequestHandler(tornado.web.RequestHandler):
 
         data = self.tpldr.load(templ + ".html").generate(**kwargs)
         self.finish(data)
+
+    def refresh_contest_context(self) -> None:
+        """Rebuild request-scoped contest timing and access after a mutation."""
+        if self.contest is None or self.acct is None:
+            self.contest_session = None
+            self.contest_access = None
+            return
+
+        self.contest_access = ContestAccess.resolve(self.contest, self.acct)
+        self.contest_session = self.contest_access.session
 
     def len_check(
         self, obj, min_len: int, max_len: int, field_name: str
@@ -584,6 +600,7 @@ def reqenv(func):
 
         _, acct_id, _ = await UserService.inst.info_sign(self)
         _, self.acct = await UserService.inst.info_acct(acct_id)
+        self.refresh_contest_context()
 
         ret = await func(self, *args, **kwargs)
         return ret

--- a/src/handlers/chal.py
+++ b/src/handlers/chal.py
@@ -11,6 +11,8 @@ from handlers.base import (
     require_permission,
 )
 from handlers.contests.base import contest_require_permission
+from services.contest_access import ContestAccess, ContestPermission
+from services.contest_session import ContestSession
 from services.chal import (
     ChalService,
     ChalSearchingParamBuilder,
@@ -22,7 +24,7 @@ from services.chal import (
 )
 from services.pro import ProService, ProConst
 from services.user import UserService, UserConst
-from services.contests import UserStatus, ContestService, ChallengeResultStyle
+from services.contests import ContestService, ChallengeResultStyle
 from services.rate import RateService
 from utils.numeric import parse_str_to_list
 
@@ -128,21 +130,10 @@ class ChalListStateCallback:
             err, contest = await ContestService.inst.get_contest(chal.contest_id)
             if err:
                 return None
+            contest_access = ContestAccess.resolve(contest, viewer)
 
-            if contest.is_admin(acct_id=viewer.acct_id):
+            if contest_access.can_view_challenge_update(chal.acct_id):
                 return await gen()
-
-            if contest.is_running():
-                if viewer.acct_id == chal.acct_id:
-                    return await gen()
-
-            elif contest.is_end():
-                if viewer.acct_id == chal.acct_id:
-                    return await gen()
-                if not contest.is_admin(acct_id=chal.acct_id) and contest.is_public_scoreboard:
-                    return await gen()
-                return None
-
             return None
 
         return await gen()
@@ -330,7 +321,7 @@ class ChalStateCallback:
                         err, contest = await ContestService.inst.get_contest(chal.contest_id)
                         if err:
                             return None
-                        if contest.enable_system_test and contest.is_running():
+                        if contest.enable_system_test and ContestSession.fixed(contest).is_running():
                             # Need to filter out system-test subtasks
                             err, pro = await ProService.inst.get_pro(chal.pro_id, ProConst.PRO_STATUS_FULL)
                             if err:
@@ -359,7 +350,7 @@ class ChalStateCallback:
                         err, contest = await ContestService.inst.get_contest(chal.contest_id)
                         if err:
                             return None
-                        if contest.enable_system_test and contest.is_running():
+                        if contest.enable_system_test and ContestSession.fixed(contest).is_running():
                             # Need to filter out system-test testdata
                             err, pro = await ProService.inst.get_pro(chal.pro_id, ProConst.PRO_STATUS_FULL)
                             if err:
@@ -403,7 +394,7 @@ class ChalStateCallback:
                     err, contest = await ContestService.inst.get_contest(chal.contest_id)
                     if err:
                         return None
-                    if contest.enable_system_test and contest.is_running():
+                    if contest.enable_system_test and ContestSession.fixed(contest).is_running():
                         # Need to filter out system-test testdata and subtasks
                         err, pro = await ProService.inst.get_pro(chal.pro_id, ProConst.PRO_STATUS_FULL)
                         if err:
@@ -440,8 +431,10 @@ class ChalStateCallback:
             err, contest = await ContestService.inst.get_contest(chal.contest_id)
             if err:
                 return None
+            contest_access = ContestAccess.resolve(contest, viewer)
+            contest_session = contest_access.session
 
-            if contest.is_admin(acct_id=viewer.acct_id):
+            if contest_access.is_admin:
                 return data
 
             challenge_style = contest.pro_list.get(chal.pro_id, {}).get('challenge_style', ChallengeResultStyle.FULL)
@@ -456,7 +449,7 @@ class ChalStateCallback:
                 """
                 nonlocal msg_data
 
-                if not contest.enable_system_test or not contest.is_running():
+                if not contest.enable_system_test or not contest_session.is_running():
                     return True  # No filtering needed, continue
 
                 # Get problem config to check metadata
@@ -505,7 +498,7 @@ class ChalStateCallback:
 
                 return True  # Continue processing
 
-            if contest.is_running():
+            if contest_session.is_running():
                 if viewer.acct_id == chal.acct_id:
                     # Filter system-test first
                     if not await filter_system_test():
@@ -514,13 +507,10 @@ class ChalStateCallback:
                     return result if result is not None else None
                 return None
 
-            if contest.is_end():
-                if viewer.acct_id == chal.acct_id:
-                    result = await apply_challenge_style(challenge_style)
-                    return result if result is not None else None
-                if not contest.is_admin(acct_id=chal.acct_id) and contest.is_public_scoreboard:
-                    # NOTE: apply_challenge_style get msg_data by nonlocal
-                    msg_data = sanitize()
+            if contest_session.is_ended():
+                if contest_access.can_view_challenge_update(chal.acct_id):
+                    if viewer.acct_id != chal.acct_id:
+                        msg_data = sanitize()
                     result = await apply_challenge_style(challenge_style)
                     return result if result is not None else None
                 return None
@@ -603,7 +593,7 @@ class ChalListHandler(RequestHandler):
         flt_builder.state(state).compiler(compiler_type)
 
         isadmin = self._setup_permissions(flt_builder)
-        query_accts = self._apply_contest_filters(flt_builder, query_accts, isadmin)
+        query_accts = self._apply_contest_filters(flt_builder, query_accts)
 
         flt = flt_builder.pro(query_pros).acct(query_accts).build()
         _, chal_cnt = await ChalService.inst.get_chals_count(flt)
@@ -638,62 +628,32 @@ class ChalListHandler(RequestHandler):
         return None if len(query_accts) == 0 else query_accts
 
     def _setup_permissions(self, flt_builder: ChalSearchingParamBuilder) -> bool:
-        isadmin = self.acct.is_kernel()
-        if isadmin:
-            flt_builder.pro_statuses(ProConst.PRO_STATUS_KERNEL_USER)
-        return isadmin
+        if self.contest:
+            assert self.contest_access
+            return self.contest_access.is_admin
+        else:
+            isadmin = self.acct.is_kernel()
+            if isadmin:
+                flt_builder.pro_statuses(ProConst.PRO_STATUS_KERNEL_USER)
+            return isadmin
 
     def _apply_contest_filters(
         self,
         flt_builder: ChalSearchingParamBuilder,
         query_accts: list[int] | None,
-        isadmin: bool,
     ) -> list[int] | None:
         if not self.contest:
             return query_accts
 
-        isadmin = self.contest.is_admin(self.acct)
         flt_builder.contest(self.contest.contest_id)
         flt_builder.pro_statuses(ProConst.PRO_STATUS_CONTEST_USER)
 
-        if isadmin:
-            return query_accts
-
-        return self._get_non_admin_contest_accounts(query_accts)
-
-    def _get_non_admin_contest_accounts(
-        self, query_accts: list[int] | None
-    ) -> list[int]:
-        if not self.contest.is_start():
-            return []
-
-        if self.contest.is_running():
-            return [self.acct.acct_id]
-
-        return self._get_post_contest_accounts(query_accts)
-
-    def _get_post_contest_accounts(self, query_accts: list[int] | None) -> list[int]:
-        if not self.contest.is_public_scoreboard:
-            return [self.acct.acct_id]
-
-        if query_accts is None:
-            approved_accts = [
-                acct_id
-                for acct_id, v in self.contest.user_list.items()
-                if v["status"] == UserStatus.APPROVED
-            ]
-            return approved_accts if approved_accts else []
-        else:
-            return [
-                acct_id
-                for acct_id in query_accts
-                if not self.contest.is_admin(acct_id=acct_id)
-            ]
+        return self.contest_access.visible_challenge_accounts(query_accts)
 
 
 class ChalHandler(RequestHandler):
     @reqenv
-    @contest_require_permission("all")
+    @contest_require_permission(ContestPermission.MEMBER)
     async def get(self, chal_id: int = None):
         try:
             chal_id = int(chal_id)
@@ -709,27 +669,8 @@ class ChalHandler(RequestHandler):
             return self.error(("Enoext", "Contest not found"))
 
         elif self.contest:
-            if not self.contest.is_start():
-                if self.contest.is_admin(
-                    acct_id=chal.acct_id
-                ) and not self.contest.is_admin(self.acct):
-                    return self.error(("Eacces", "Permission denied"))
-
-            elif self.contest.is_running():
-                if (
-                    self.contest.hide_admin
-                    and self.contest.is_admin(acct_id=chal.acct_id)
-                    and not self.contest.is_admin(self.acct)
-                ) or (
-                    not self.contest.hide_admin
-                    and not (self.acct.acct_id == chal.acct_id or self.contest.is_admin(self.acct))
-                ):
-                    return self.error(("Eacces", "Permission denied"))
-
-            # After contest: if scoreboard not public, only own or admin can view
-            if not self.contest.is_running() and not self.contest.is_public_scoreboard:
-                if not (self.acct and (self.acct.acct_id == chal.acct_id or self.contest.is_admin(self.acct))):
-                    return self.error(("Eacces", "Permission denied"))
+            if not self.contest_access.can_view_challenge(chal.acct_id):
+                return self.error(("Eacces", "Permission denied"))
             allow_statuses = ProConst.PRO_STATUS_CONTEST_USER
 
         elif self.acct.is_kernel():
@@ -743,7 +684,7 @@ class ChalHandler(RequestHandler):
 
         rechal = self.acct.is_kernel()
         if self.contest:
-            rechal = rechal and self.contest.is_admin(self.acct)
+            rechal = rechal and self.contest_access.is_admin
 
         testdata_to_subtasks = defaultdict(list)
         for subtask_config in pro.config.subtask_configs.values():
@@ -755,7 +696,7 @@ class ChalHandler(RequestHandler):
 
     @reqenv
     @require_permission([UserConst.ACCTTYPE_USER, UserConst.ACCTTYPE_KERNEL])
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def post(self, chal_id: int = None):
         try:
             chal_id = int(chal_id)

--- a/src/handlers/contests/base.py
+++ b/src/handlers/contests/base.py
@@ -1,25 +1,18 @@
 import json
-from services.contests import UserStatus
+from services.contest_access import ContestPermission
 
 
-def contest_require_permission(acct_type: str):
+def contest_require_permission(permission: ContestPermission):
     def decorator(func):
         async def wrap(self, *args, **kwargs):
-            if self.contest is not None:
-                if acct_type == 'admin':
-                    if not self.contest.is_admin(acct=self.acct):
-                        await self.finish(json.dumps({'status': 'Eacces', 'data': 'Permission denied'}))
-                        return
-
-                elif acct_type == 'normal':
-                    if not self.contest.member_is_status(self.acct, UserStatus.APPROVED):
-                        await self.finish(json.dumps({'status': 'Eacces', 'data': 'Permission denied'}))
-                        return
-
-                elif acct_type == 'all':
-                    if not self.contest.is_member(acct=self.acct):
-                        await self.finish(json.dumps({'status': 'Eacces', 'data': 'Permission denied'}))
-                        return
+            if self.contest is not None and (
+                self.contest_access is None
+                or not self.contest_access.has(permission)
+            ):
+                await self.finish(
+                    json.dumps({"status": "Eacces", "data": "Permission denied"})
+                )
+                return
 
             ret = await func(self, *args, **kwargs)
             return ret

--- a/src/handlers/contests/manage/acct.py
+++ b/src/handlers/contests/manage/acct.py
@@ -1,5 +1,6 @@
 from handlers.base import reqenv, RequestHandler, ActionDispatcher
 from handlers.contests.base import contest_require_permission
+from services.contest_access import ContestPermission
 from services.contests import ContestService, UserStatus
 from services.user import UserService
 from utils.numeric import parse_str_to_list
@@ -9,7 +10,7 @@ contest_manage_acct_dispatcher = ActionDispatcher()
 
 class ContestManageAcctHandler(RequestHandler):
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def get(self):
         admin_list = []
         acct_list = []
@@ -253,7 +254,7 @@ class ContestManageAcctHandler(RequestHandler):
             )
 
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def post(self):
         reqtype = self.get_argument("reqtype")
         return await contest_manage_acct_dispatcher.dispatch(self, reqtype)

--- a/src/handlers/contests/manage/general.py
+++ b/src/handlers/contests/manage/general.py
@@ -3,6 +3,7 @@ import datetime
 from handlers.base import RequestHandler, reqenv, require_permission, ActionDispatcher
 from handlers.contests.base import contest_require_permission
 from services.chal import Compiler
+from services.contest_access import ContestPermission
 from services.user import UserConst
 from services.contests import (
     ContestConst,
@@ -20,7 +21,7 @@ contest_manage_add_dispatcher = ActionDispatcher()
 
 class ContestManageDashHandler(RequestHandler):
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def get(self):
         await self.render(
             "contests/manage/dash", f"{self.contest.name} - Manage", page="dash", contest_id=self.contest.contest_id
@@ -29,7 +30,7 @@ class ContestManageDashHandler(RequestHandler):
 
 class ContestManageGeneralHandler(RequestHandler):
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def get(self):
         await self.render(
             "contests/manage/general",
@@ -141,9 +142,10 @@ class ContestManageGeneralHandler(RequestHandler):
         self.contest.submission_cd_time = submission_cd_time
         self.contest.penalty_value = penalty_value
         self.contest.enable_system_test = enable_system_test
+        self.refresh_contest_context()
         if self.contest.freeze_scoreboard_period != freeze_scoreboard_period:
             self.contest.freeze_scoreboard_period = freeze_scoreboard_period
-            if self.contest.is_start():
+            if self.contest_session.is_started():
                 await self.rs.delete(f"contest_{self.contest.contest_id}_scores")
 
         new_score_type = ProblemScoreType.ICPC if contest_mode == ContestMode.ACM else ProblemScoreType.IOI2017
@@ -174,7 +176,7 @@ class ContestManageGeneralHandler(RequestHandler):
         return self.error(("S", ""))
 
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def post(self):
         reqtype = self.get_argument("reqtype")
         return await contest_manage_general_dispatcher.dispatch(self, reqtype)
@@ -182,7 +184,7 @@ class ContestManageGeneralHandler(RequestHandler):
 
 class ContestManageDescEditHandler(RequestHandler):
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def get(self):
         await self.render(
             "contests/manage/desc-edit",
@@ -220,7 +222,7 @@ class ContestManageDescEditHandler(RequestHandler):
         return self.error(("S", ""))
 
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def post(self):
         reqtype = self.get_argument("reqtype")
         return await contest_manage_desc_edit_dispatcher.dispatch(self, reqtype)

--- a/src/handlers/contests/manage/log.py
+++ b/src/handlers/contests/manage/log.py
@@ -1,11 +1,12 @@
 from handlers.base import RequestHandler, reqenv
 from handlers.contests.base import contest_require_permission
+from services.contest_access import ContestPermission
 from services.log import LogService
 
 
 class ContestManageLogHandler(RequestHandler):
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def get(self, log_id=None):
         """Display logs for the current contest
 

--- a/src/handlers/contests/manage/pro.py
+++ b/src/handlers/contests/manage/pro.py
@@ -3,6 +3,7 @@ import asyncio
 from handlers.base import reqenv, RequestHandler, ActionDispatcher
 from handlers.contests.base import contest_require_permission
 from services.chal import ChalConst, ChalService
+from services.contest_access import ContestPermission
 from services.contests import ContestService, ProblemScoreType, ContestMode, ChallengeResultStyle
 from services.judge import JudgeServerClusterService
 from services.pro import ProService, ProConst
@@ -13,7 +14,7 @@ contest_manage_pro_dispatcher = ActionDispatcher()
 
 class ContestManageProHandler(RequestHandler):
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def get(self):
         pro_list = []
         for pro_id in self.contest.pro_list.keys():
@@ -257,7 +258,7 @@ class ContestManageProHandler(RequestHandler):
                 self._rejudge_challenges(pro_id, admin_chals, include_system_test=True)
             )
             await asyncio.create_task(
-                self._rejudge_challenges(pro_id, normal_chals, include_system_test=self.contest.is_end())
+                self._rejudge_challenges(pro_id, normal_chals, include_system_test=self.contest_session.is_ended())
             )
 
         return self.error(("S", f"Problem(#{pro_id}) is rechallenging."))
@@ -312,7 +313,7 @@ class ContestManageProHandler(RequestHandler):
         if not self.contest.is_pro(pro_id):
             return self.error(("Enoext", f"Problem(#{pro_id}) not in contest"))
 
-        if not self.contest.is_end():
+        if not self.contest_session.is_ended():
             return self.error(("Etime", "Contest is not over yet"))
 
         err, pro = await ProService.inst.get_pro(
@@ -349,7 +350,7 @@ class ContestManageProHandler(RequestHandler):
         if not self.contest.enable_system_test:
             return self.error(("Econf", "System test is not enabled for this contest"))
 
-        if not self.contest.is_end():
+        if not self.contest_session.is_ended():
             return self.error(("Etime", "Contest must be over to start system test"))
 
         if not JudgeServerClusterService.inst.is_server_online():
@@ -385,7 +386,7 @@ class ContestManageProHandler(RequestHandler):
         return self.error(("S", f"System test started for {len(result)} AC challenges on Problem(#{pro_id})."))
 
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def post(self):
         # TODO: update problem score type
         # TODO: frontend: drag problem to change order

--- a/src/handlers/contests/manage/qa.py
+++ b/src/handlers/contests/manage/qa.py
@@ -5,6 +5,7 @@ from services.contests import ContestService
 from services.user import UserService
 from handlers.base import RequestHandler, UnifiedWebSocketHandler, reqenv, ActionDispatcher
 from handlers.contests.base import contest_require_permission
+from services.contest_access import ContestPermission
 
 SUBJECT_MIN = 1
 SUBJECT_MAX = 50
@@ -85,7 +86,7 @@ contest_manage_question_dispatcher = ActionDispatcher()
 
 class ContestManageQuestionHandler(RequestHandler):
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def get(self):
         err, questions = await ContestService.inst.get_all_question(
             self.contest.contest_id
@@ -174,7 +175,7 @@ class ContestManageQuestionHandler(RequestHandler):
         return self.error(("S", ""))
 
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def post(self):
         reqtype = self.get_argument("reqtype")
         return await contest_manage_question_dispatcher.dispatch(self, reqtype)
@@ -185,7 +186,7 @@ contest_manage_announce_dispatcher = ActionDispatcher()
 
 class ContestManageAnnounceHandler(RequestHandler):
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def get(self):
         err, announces = await ContestService.inst.get_all_announce(
             self.contest.contest_id
@@ -214,7 +215,7 @@ class ContestManageAnnounceHandler(RequestHandler):
         await ContestService.inst.add_announce(
             self.contest.contest_id, self.acct.acct_id, subject, content
         )
-        if self.contest.is_start():
+        if self.contest_session.is_started():
             await self.rs.publish(
                 "contestnewqasub",
                 json.dumps(
@@ -246,7 +247,7 @@ class ContestManageAnnounceHandler(RequestHandler):
         await ContestService.inst.edit_announce(
             self.contest.contest_id, announce_id, subject, content
         )
-        if self.contest.is_start():
+        if self.contest_session.is_started():
             await self.rs.publish(
                 "contestnewqasub",
                 json.dumps(
@@ -298,7 +299,7 @@ class ContestManageAnnounceHandler(RequestHandler):
         return self.error(("S", ""))
 
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def post(self):
         reqtype = self.get_argument("reqtype")
         return await contest_manage_announce_dispatcher.dispatch(self, reqtype)

--- a/src/handlers/contests/manage/reg.py
+++ b/src/handlers/contests/manage/reg.py
@@ -1,5 +1,6 @@
 from handlers.base import reqenv, RequestHandler, ActionDispatcher
 from handlers.contests.base import contest_require_permission
+from services.contest_access import ContestPermission
 from services.contests import ContestService, UserStatus
 from services.user import UserService
 
@@ -8,7 +9,7 @@ contest_manage_reg_dispatcher = ActionDispatcher()
 
 class ContestManageRegHandler(RequestHandler):
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def get(self):
         requested_list = []
         rejected_list = []
@@ -96,7 +97,7 @@ class ContestManageRegHandler(RequestHandler):
         return self.error(("S", f"Reject account(#{acct_id}) successfully."))
 
     @reqenv
-    @contest_require_permission("admin")
+    @contest_require_permission(ContestPermission.ADMIN)
     async def post(self):
         reqtype = self.get_argument("reqtype")
         try:

--- a/src/handlers/contests/proset.py
+++ b/src/handlers/contests/proset.py
@@ -1,4 +1,5 @@
 from handlers.base import reqenv, RequestHandler
+from services.contest_access import ContestPermission
 from services.pro import ProConst, ProService
 from services.rate import RateService
 
@@ -14,33 +15,29 @@ class ContestProsetHandler(RequestHandler):
             return self.error(("Eparam", "Invalid page offset"))
 
         show_ac_ratio = False
-        if not self.contest.is_start() and not self.contest.is_admin(self.acct):
+        if not self.contest_access.has(ContestPermission.VIEW_PROBLEM_SET):
             return self.error(('Eacces', 'Permission denied'))
 
-        elif self.contest.is_running() and not self.contest.is_member(self.acct):
-            return self.error(('Eacces', 'Permission denied'))
+        _, acct_rates = await RateService.inst.map_rate_acct(self.acct, contest_id=self.contest.contest_id)
+        _, prolist = await ProService.inst.list_pro(ProConst.PRO_STATUS_CONTEST_USER)
 
-        else:
-            _, acct_rates = await RateService.inst.map_rate_acct(self.acct, contest_id=self.contest.contest_id)
-            _, prolist = await ProService.inst.list_pro(ProConst.PRO_STATUS_CONTEST_USER)
+        prolist_order = {pro_id: idx for idx, pro_id in enumerate(self.contest.pro_list.keys())}
+        prolist = sorted(filter(lambda pro: self.contest.is_pro(pro.pro_id), prolist),
+                              key=lambda pro: prolist_order[pro.pro_id])
 
-            prolist_order = {pro_id: idx for idx, pro_id in enumerate(self.contest.pro_list.keys())}
-            prolist = sorted(filter(lambda pro: self.contest.is_pro(pro.pro_id), prolist),
-                                  key=lambda pro: prolist_order[pro.pro_id])
+        score_map: dict[int, dict] = {}
+        for pro in prolist:
+            pro_id = pro.pro_id
+            score_map[pro_id] = {'score': 0, 'state': None}
+            if pro_id in acct_rates:
+                score_map[pro_id]['score'] += acct_rates[pro.pro_id]['rate']
+                score_map[pro_id]['state'] = acct_rates[pro.pro_id]['state']
 
-            score_map: dict[int, dict] = {}
+        if self.contest.is_public_scoreboard or self.contest_access.is_admin:
+            show_ac_ratio = True
             for pro in prolist:
-                pro_id = pro.pro_id
-                score_map[pro_id] = {'score': 0, 'state': None}
-                if pro_id in acct_rates:
-                    score_map[pro_id]['score'] += acct_rates[pro.pro_id]['rate']
-                    score_map[pro_id]['state'] = acct_rates[pro.pro_id]['state']
-
-            if self.contest.is_public_scoreboard or self.contest.is_admin(self.acct):
-                show_ac_ratio = True
-                for pro in prolist:
-                    _, rate = await RateService.inst.get_pro_ac_rate(pro.pro_id, contest_id=self.contest.contest_id)
-                    score_map[pro.pro_id]['rate_data'] = rate
+                _, rate = await RateService.inst.get_pro_ac_rate(pro.pro_id, contest_id=self.contest.contest_id)
+                score_map[pro.pro_id]['rate_data'] = rate
 
         pro_total_cnt = len(prolist)
         prolist = prolist[pageoff: pageoff + 40]

--- a/src/handlers/contests/qa.py
+++ b/src/handlers/contests/qa.py
@@ -2,6 +2,7 @@ import time
 import json
 
 from services.contests import ContestService
+from services.contest_access import ContestPermission
 
 from handlers.base import RequestHandler, UnifiedWebSocketHandler, reqenv, ActionDispatcher
 from handlers.contests.base import contest_require_permission
@@ -100,10 +101,10 @@ contest_qa_dispatcher = ActionDispatcher()
 class ContestQAHandler(RequestHandler):
     @reqenv
     async def get(self):
-        if self.contest.is_admin(self.acct):
+        if not self.contest_access.has(ContestPermission.VIEW_QA):
             return self.error(("Eacces", "Permission denied"))
 
-        if self.contest.is_start():
+        if self.contest_session.is_started():
             err, announces = await ContestService.inst.get_all_announce(
                 self.contest.contest_id
             )
@@ -177,7 +178,7 @@ class ContestQAHandler(RequestHandler):
         return self.error(("S", ""))
 
     @reqenv
-    @contest_require_permission("normal")
+    @contest_require_permission(ContestPermission.ASK_QUESTION)
     async def post(self):
         reqtype = self.get_argument("reqtype")
         return await contest_qa_dispatcher.dispatch(self, reqtype)

--- a/src/handlers/contests/reg.py
+++ b/src/handlers/contests/reg.py
@@ -14,13 +14,13 @@ class ContestRegHandler(RequestHandler):
         if not self.contest:
             return self.error(("Enoext", "Contest not found"))
 
-        if self.contest.is_admin(self.acct):
+        if self.contest_access.is_admin:
             return self.error(("Eacces", "Contest admin cannot register"))
 
         await self.render("contests/reg", f"{self.contest.name} - Registration", contest=self.contest)
 
     def check(self, action_name):
-        if self.contest.is_admin(self.acct):
+        if self.contest_access.is_admin:
             return ("Eacces", f"Contest admin cannot {action_name}")
 
         if self.contest.reg_mode is RegMode.INVITED:
@@ -113,7 +113,7 @@ class ContestRegHandler(RequestHandler):
         if error := self.check("unregister"):
             return self.error(error)
 
-        if datetime.datetime.now(datetime.UTC) >= self.contest.contest_start:
+        if self.contest_session.is_started():
             return self.error(
                 ("Etime", "Contest has started, you cannot unregister now")
             )

--- a/src/handlers/contests/scoreboard.py
+++ b/src/handlers/contests/scoreboard.py
@@ -7,6 +7,7 @@ from msgpack import packb, unpackb
 
 import config
 from handlers.base import RequestHandler, UnifiedWebSocketHandler, reqenv
+from services.contest_access import ContestPermission
 from services.contests import ContestMode, ContestService, ProblemScoreType, UserStatus
 from services.user import UserService
 
@@ -110,31 +111,29 @@ class ContestScoreboardHandler(RequestHandler):
 
     @reqenv
     async def post(self):
-        if not self.contest.is_start() and not self.contest.is_admin(self.acct):
-            return self.error(('Eacces', 'Permission denied'))
-        elif not self.contest.is_public_scoreboard and not self.contest.is_member(self.acct):
+        if not self.contest_access.has(ContestPermission.VIEW_SCOREBOARD):
             return self.error(('Eacces', 'Permission denied'))
 
         has_end_time = True
-        start_time = self.contest.contest_start
+        start_time = self.contest_session.start_time
         try:
             end_time = datetime.datetime.fromisoformat(self.get_argument('display_time'))
         except (tornado.web.MissingArgumentError, ValueError):
             has_end_time = False
-            end_time = self.contest.contest_end
+            end_time = self.contest_session.end_time
 
-        if self.contest.freeze_scoreboard_period != 0 and self.contest.is_running() and not self.contest.is_admin(self.acct):
+        if self.contest.freeze_scoreboard_period != 0 and self.contest_session.is_running() and not self.contest_access.is_admin:
             if not has_end_time:
                 end_time = datetime.datetime.now(datetime.UTC)
 
-            total_seconds = int((end_time - self.contest.contest_start).total_seconds())
+            total_seconds = int((end_time - self.contest_session.start_time).total_seconds())
             minutes = total_seconds // 60
 
             if minutes >= self.contest.freeze_scoreboard_period:
-                end_time = self.contest.contest_start + datetime.timedelta(
+                end_time = self.contest_session.start_time + datetime.timedelta(
                     minutes=self.contest.freeze_scoreboard_period)
 
-        is_ended = self.contest.is_end()
+        is_ended = self.contest_session.is_ended()
 
         contest_id = self.contest.contest_id
 
@@ -144,7 +143,7 @@ class ContestScoreboardHandler(RequestHandler):
             if not self.contest.hide_admin:
                 acct_list.extend(acct_id for acct_id, v in self.contest.user_list.items() if v['status'] == UserStatus.ADMIN)
         else:
-            if not self.contest.is_admin(self.acct):
+            if not self.contest_access.is_admin:
                 acct_list = [self.acct.acct_id]
             else:
                 acct_list = [acct_id for acct_id, v in self.contest.user_list.items() if v['status'] == UserStatus.APPROVED]
@@ -157,7 +156,9 @@ class ContestScoreboardHandler(RequestHandler):
             if has_end_time or (scores := (await self.rs.hget(cache_name, str(pro_id)))) is None:
                 score_type = pro_options["score_type"]
                 if score_type == ProblemScoreType.ICPC:
-                    s[pro_id] = await ContestService.inst.get_icpc_scores(contest_id, pro_id, end_time)
+                    s[pro_id] = await ContestService.inst.get_icpc_scores(
+                        contest_id, pro_id, end_time, self.contest_session
+                    )
                     assert self.contest.contest_mode == ContestMode.ACM
                 elif score_type == ProblemScoreType.IOI2017:
                     s[pro_id] = await ContestService.inst.get_ioi2017_scores(contest_id, pro_id, end_time)

--- a/src/handlers/index.py
+++ b/src/handlers/index.py
@@ -1,5 +1,5 @@
 from handlers.base import RequestHandler, reqenv
-from services.contests import ContestService, UserStatus
+from services.contests import ContestService
 from services.ques import QuestionService
 
 
@@ -28,8 +28,8 @@ class IndexHandler(RequestHandler):
                 is_in_contest = False
 
             if contest_id != 0:
-                _, contest = await ContestService.inst.get_contest(contest_id)
-                if contest.is_admin(self.acct):
+                contest = self.contest
+                if self.contest_access.is_admin:
                     (
                         _,
                         contest_ask_cnt,
@@ -38,7 +38,7 @@ class IndexHandler(RequestHandler):
                     )
                     contest_manage = True
 
-                elif contest.is_member(self.acct, UserStatus.APPROVED):
+                elif self.contest_access.is_member:
                     (
                         _,
                         contest_notification_cnt,

--- a/src/handlers/pro.py
+++ b/src/handlers/pro.py
@@ -3,6 +3,7 @@ import tornado.web
 
 from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_permission
 from services.chal import ChalConst
+from services.contest_access import ContestPermission
 from services.judge import JudgeServerClusterService
 from services.pro import ProClassService, ProClassConst, ProConst, ProService, Problem
 from services.rate import RateService
@@ -365,12 +366,7 @@ class ProStaticHandler(RequestHandler, tornado.web.StaticFileHandler):
                 self.finish("Problem not in contest")
                 return
 
-            if not self.contest.is_member(self.acct):
-                self.set_status(403)
-                self.finish(PERMISSION_DENIED_ERROR[1])
-                return
-
-            if not self.contest.is_admin(self.acct) and not self.contest.is_running():
+            if not self.contest_access.has(ContestPermission.VIEW_PROBLEM):
                 self.set_status(403)
                 self.finish(PERMISSION_DENIED_ERROR[1])
                 return
@@ -441,10 +437,7 @@ class ProHandler(RequestHandler):
             if not self.contest.is_pro(pro_id):
                 return self.error(("Enoext", "Problem not in contest"))
 
-            if not self.contest.is_member(self.acct):
-                return self.error(PERMISSION_DENIED_ERROR)
-
-            if not self.contest.is_admin(self.acct) and not self.contest.is_running():
+            if not self.contest_access.has(ContestPermission.VIEW_PROBLEM):
                 return self.error(PERMISSION_DENIED_ERROR)
 
             allow_statuses = ProConst.PRO_STATUS_CONTEST_USER

--- a/src/handlers/submit.py
+++ b/src/handlers/submit.py
@@ -1,6 +1,7 @@
 from handlers.base import ActionDispatcher, RequestHandler, reqenv, require_permission
 from handlers.contests.base import contest_require_permission
 from services.chal import ChalService
+from services.contest_access import ContestPermission
 from services.judge import JudgeServerClusterService
 from services.pro import ProService, ProConst
 from services.user import UserConst
@@ -13,7 +14,7 @@ submit_dispatcher = ActionDispatcher()
 class SubmitHandler(RequestHandler):
     @reqenv
     @require_permission([UserConst.ACCTTYPE_USER, UserConst.ACCTTYPE_KERNEL])
-    @contest_require_permission("all")
+    @contest_require_permission(ContestPermission.SUBMIT)
     async def get(self, pro_id=None):
         try:
             pro_id = int(pro_id)
@@ -22,9 +23,6 @@ class SubmitHandler(RequestHandler):
 
         allow_statuses = ProConst.PRO_STATUS_NORMAL_USER
         if self.contest:
-            if not self.contest.is_running() and not self.contest.is_admin(self.acct):
-                return self.error(PERMISSION_DENIED_ERROR)
-
             if not self.contest.is_pro(pro_id):
                 return self.error(("Enoext", "Problem not in contest"))
 
@@ -85,7 +83,7 @@ class SubmitHandler(RequestHandler):
 
     @reqenv
     @require_permission([UserConst.ACCTTYPE_USER, UserConst.ACCTTYPE_KERNEL])
-    @contest_require_permission("all")
+    @contest_require_permission(ContestPermission.SUBMIT)
     async def post(self):
         """Handle problem submission - dispatch to type-specific handler."""
         can_submit = JudgeServerClusterService.inst.is_server_online()

--- a/src/services/contest_access.py
+++ b/src/services/contest_access.py
@@ -1,0 +1,162 @@
+import datetime
+import enum
+from dataclasses import dataclass
+
+from services.contest_session import ContestPhase, ContestSession
+from services.contests import Contest, UserStatus
+from services.user import Account
+
+
+class ContestPermission(enum.IntFlag):
+    NONE = 0
+
+    # Contest roles. PARTICIPANT intentionally means exactly APPROVED; admins
+    # are members but are not normal participants in existing authorization.
+    MEMBER = enum.auto()
+    PARTICIPANT = enum.auto()
+    ADMIN = enum.auto()
+
+    # Effective capabilities. These include the current session phase and the
+    # contest's visibility settings, so handlers do not repeat those rules.
+    VIEW_PROBLEM_SET = enum.auto()
+    VIEW_PROBLEM = enum.auto()
+    SUBMIT = enum.auto()
+    VIEW_SCOREBOARD = enum.auto()
+    VIEW_QA = enum.auto()
+    ASK_QUESTION = enum.auto()
+
+
+@dataclass(frozen=True, slots=True)
+class ContestAccess:
+    contest: Contest
+    session: ContestSession
+    permissions: ContestPermission
+    resolved_at: datetime.datetime
+
+    @classmethod
+    def resolve(
+        cls,
+        contest: Contest,
+        acct: Account,
+        now: datetime.datetime | None = None,
+    ) -> "ContestAccess":
+        now = now or datetime.datetime.now(datetime.UTC)
+        session = ContestSession.fixed(contest, acct.acct_id)
+        phase = session.phase(now)
+
+        is_member = contest.is_member(acct=acct)
+        is_participant = contest.member_is_status(acct, UserStatus.APPROVED)
+        is_admin = contest.is_admin(acct=acct)
+
+        permissions = ContestPermission.NONE
+        if is_member:
+            permissions |= ContestPermission.MEMBER
+        if is_participant:
+            permissions |= ContestPermission.PARTICIPANT
+        if is_admin:
+            permissions |= ContestPermission.ADMIN
+
+        if (
+            phase is ContestPhase.ENDED
+            or (phase is ContestPhase.RUNNING and is_member)
+            or (phase is ContestPhase.BEFORE and is_admin)
+        ):
+            permissions |= ContestPermission.VIEW_PROBLEM_SET
+
+        if is_member and (phase is ContestPhase.RUNNING or is_admin):
+            permissions |= ContestPermission.VIEW_PROBLEM | ContestPermission.SUBMIT
+
+        if (phase is not ContestPhase.BEFORE or is_admin) and (
+            contest.is_public_scoreboard or is_member
+        ):
+            permissions |= ContestPermission.VIEW_SCOREBOARD
+
+        if not is_admin:
+            permissions |= ContestPermission.VIEW_QA
+        if is_participant:
+            permissions |= ContestPermission.ASK_QUESTION
+
+        return cls(
+            contest=contest,
+            session=session,
+            permissions=permissions,
+            resolved_at=now,
+        )
+
+    def has(self, permissions: ContestPermission) -> bool:
+        return self.permissions & permissions == permissions
+
+    @property
+    def is_member(self) -> bool:
+        return self.has(ContestPermission.MEMBER)
+
+    @property
+    def is_participant(self) -> bool:
+        return self.has(ContestPermission.PARTICIPANT)
+
+    @property
+    def is_admin(self) -> bool:
+        return self.has(ContestPermission.ADMIN)
+
+    def visible_challenge_accounts(
+        self, requested_acct_ids: list[int] | None
+    ) -> list[int] | None:
+        """Apply the existing challenge-list visibility rules."""
+        if self.is_admin:
+            return requested_acct_ids
+
+        phase = self.session.phase(self.resolved_at)
+        if phase is ContestPhase.BEFORE:
+            return []
+        if phase is ContestPhase.RUNNING or not self.contest.is_public_scoreboard:
+            return [self.session.acct_id]
+
+        if requested_acct_ids is None:
+            return [
+                acct_id
+                for acct_id, options in self.contest.user_list.items()
+                if options["status"] == UserStatus.APPROVED
+            ]
+        return [
+            acct_id
+            for acct_id in requested_acct_ids
+            if not self.contest.is_admin(acct_id=acct_id)
+        ]
+
+    def can_view_challenge(self, owner_acct_id: int) -> bool:
+        """Check the existing detail-page rule for a contest challenge."""
+        if not self.is_member:
+            return False
+
+        is_owner = self.session.acct_id == owner_acct_id
+        owner_is_admin = self.contest.is_admin(acct_id=owner_acct_id)
+        phase = self.session.phase(self.resolved_at)
+
+        if phase is ContestPhase.BEFORE:
+            if owner_is_admin and not self.is_admin:
+                return False
+        elif phase is ContestPhase.RUNNING:
+            if self.contest.hide_admin and owner_is_admin and not self.is_admin:
+                return False
+            if not self.contest.hide_admin and not (is_owner or self.is_admin):
+                return False
+
+        if phase is not ContestPhase.RUNNING and not self.contest.is_public_scoreboard:
+            return is_owner or self.is_admin
+        return True
+
+    def can_view_challenge_update(self, owner_acct_id: int) -> bool:
+        """Check whether a live challenge update is visible to this account."""
+        if self.is_admin:
+            return True
+
+        is_owner = self.session.acct_id == owner_acct_id
+        phase = self.session.phase(self.resolved_at)
+        if phase is ContestPhase.RUNNING:
+            return is_owner
+        if phase is ContestPhase.ENDED:
+            return is_owner or (
+                self.contest.is_public_scoreboard
+                and not self.contest.is_admin(acct_id=owner_acct_id)
+            )
+        return False

--- a/src/services/contest_session.py
+++ b/src/services/contest_session.py
@@ -1,0 +1,58 @@
+import datetime
+import enum
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from services.contests import Contest
+
+
+class ContestPhase(enum.IntEnum):
+    BEFORE = 0
+    RUNNING = 1
+    ENDED = 2
+
+
+@dataclass(frozen=True, slots=True)
+class ContestSession:
+    """The effective contest time window for one account.
+
+    Fixed contests currently give every account the contest's configured time
+    window. Keeping that decision here gives future contest modes one place to
+    provide account-specific windows without changing handlers or scoreboards.
+    """
+
+    contest_id: int
+    acct_id: int | None
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+
+    @classmethod
+    def fixed(cls, contest: "Contest", acct_id: int | None = None) -> "ContestSession":
+        return cls(
+            contest_id=contest.contest_id,
+            acct_id=acct_id,
+            start_time=contest.contest_start,
+            end_time=contest.contest_end,
+        )
+
+    @property
+    def duration(self) -> datetime.timedelta:
+        return self.end_time - self.start_time
+
+    def phase(self, now: datetime.datetime | None = None) -> ContestPhase:
+        now = now or datetime.datetime.now(datetime.UTC)
+        if now < self.start_time:
+            return ContestPhase.BEFORE
+        if now < self.end_time:
+            return ContestPhase.RUNNING
+        return ContestPhase.ENDED
+
+    def is_started(self, now: datetime.datetime | None = None) -> bool:
+        return self.phase(now) is not ContestPhase.BEFORE
+
+    def is_running(self, now: datetime.datetime | None = None) -> bool:
+        return self.phase(now) is ContestPhase.RUNNING
+
+    def is_ended(self, now: datetime.datetime | None = None) -> bool:
+        return self.phase(now) is ContestPhase.ENDED

--- a/src/services/contests.py
+++ b/src/services/contests.py
@@ -6,6 +6,7 @@ import pickle
 import asyncpg
 
 from services.chal import Compiler, ChalConst
+from services.contest_session import ContestSession
 from services.user import Account
 
 
@@ -70,13 +71,13 @@ class Contest:
     enable_system_test: bool = False  # Enable system test feature (pretest/final test)
 
     def is_start(self) -> bool:
-        return datetime.datetime.now(datetime.UTC) >= self.contest_start
+        return ContestSession.fixed(self).is_started()
 
     def is_end(self) -> bool:
-        return datetime.datetime.now(datetime.UTC) >= self.contest_end
+        return ContestSession.fixed(self).is_ended()
 
     def is_running(self) -> bool:
-        return self.contest_start <= datetime.datetime.now(datetime.UTC) < self.contest_end
+        return ContestSession.fixed(self).is_running()
 
     def is_pro(self, pro_id: int) -> bool:
         return pro_id in self.pro_list
@@ -126,7 +127,8 @@ class ContestService:
         if (b_contest := await self.rs.hget('contest', str(contest_id))) is not None:
             contest: Contest = pickle.loads(b_contest)
 
-            if contest.is_end():
+            contest_session = ContestSession.fixed(contest)
+            if contest_session.is_ended():
                 await self.rs.hdel('contest', str(contest_id))
 
         else:
@@ -181,7 +183,7 @@ class ContestService:
                         "status": UserStatus(int(status))
                     }
 
-            if contest.is_running():
+            if ContestSession.fixed(contest).is_running():
                 b_contest = pickle.dumps(contest)
                 await self.rs.hset('contest', str(contest_id), b_contest)
 
@@ -501,7 +503,13 @@ class ContestService:
 
         return None, None
 
-    async def get_icpc_scores(self, contest_id: int, pro_id: int, before_time: datetime.datetime) -> dict:
+    async def get_icpc_scores(
+        self,
+        contest_id: int,
+        pro_id: int,
+        before_time: datetime.datetime,
+        session: ContestSession | None = None,
+    ) -> dict:
         """
         Calculate ICPC scores for a problem.
 
@@ -514,6 +522,7 @@ class ContestService:
         Filters out invalid/non-verdictable states: CE, CLE, ERR, JE, JUDGE, NOTSTARTED, REJECTED
         """
         _, contest = await self.get_contest(contest_id)
+        session = session or ContestSession.fixed(contest)
 
         # States to filter out (invalid/non-verdictable submissions)
         invalid_states = [
@@ -600,7 +609,7 @@ class ContestService:
         ''', contest_id, pro_id, before_time,
             invalid_states,  # $4: array of invalid states to filter out
             ChalConst.STATE_AC,  # $5: AC state
-            contest.contest_start,  # $6: contest start time for score calculation
+            session.start_time,  # $6: effective session start time for score calculation
             contest.penalty_value, # $7: penalty value
         )
 

--- a/src/static/templ/chal.html
+++ b/src/static/templ/chal.html
@@ -6,11 +6,11 @@
 {% set should_hide_system_test = False %}
 {% if chal.contest_id != 0 and contest is not None %}
     {% set challenge_style = contest.pro_list.get(chal.pro_id, {}).get('challenge_style', ChallengeResultStyle.FULL) %}
-    {% if contest.is_admin(acct_id=user.acct_id) %}
+    {% if contest_access.is_admin %}
         {% set challenge_style = ChallengeResultStyle.FULL %}
     {% else %}
         {# Regular users: hide system-test during contest if system test is enabled #}
-        {% if contest.enable_system_test and contest.is_running() %}
+        {% if contest.enable_system_test and contest_session.is_running() %}
             {% set should_hide_system_test = True %}
         {% end %}
     {% end %}
@@ -568,4 +568,3 @@
         <code class=""></code>
     </pre>
 {% end %}
-

--- a/src/static/templ/contests/info.html
+++ b/src/static/templ/contests/info.html
@@ -2,11 +2,11 @@
 {% from services.contests import ContestMode, RegMode, UserStatus %}
 <script>
     function init() {
-        {% if not contest.is_start() %}
+        {% if not contest_session.is_started() %}
             let desc_tex = `{{ markdown_escape(contest.desc_before_contest) }}`;
-        {% elif contest.is_running() %}
+        {% elif contest_session.is_running() %}
             let desc_tex = `{{ markdown_escape(contest.desc_during_contest) }}`;
-        {% elif contest.is_end() %}
+        {% elif contest_session.is_ended() %}
             let desc_tex = `{{ markdown_escape(contest.desc_after_contest) }}`;
         {% end %}
 
@@ -27,8 +27,8 @@
             <div class="card mb-1">
                 <div class="card-header">Start / End</div>
                 <div class="card-body">
-                    <h5>{{ contest.contest_start.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</h5>
-                    <h5>{{ contest.contest_end.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</h5>
+                    <h5>{{ contest_session.start_time.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</h5>
+                    <h5>{{ contest_session.end_time.astimezone(config.TIMEZONE).strftime("%Y-%m-%d %H:%M:%S") }}</h5>
                 </div>
             </div>
 
@@ -65,7 +65,7 @@
                 <div class="card-header">Registration Status</div>
 
                 <div class="card-body">
-                    {% if contest.is_admin(user) %}
+                    {% if contest_access.is_admin %}
                         <h5>Admin, no registration needed</h5>
                     {% else %}
                         {% set now = datetime.datetime.now(datetime.UTC) %}

--- a/src/static/templ/contests/manage/pro.html
+++ b/src/static/templ/contests/manage/pro.html
@@ -187,12 +187,12 @@
                     {% if contest.enable_system_test %}
                     <button
                         class="btn btn-info me-2 systemtestall"
-                        {% if not contest.is_end() %} disabled {% end %}
+                        {% if not contest_session.is_ended() %} disabled {% end %}
                     >System Test All</button>
                     {% end %}
                     <button
                         class="btn btn-danger me-2 publicall"
-                        {% if not contest.is_end() %} disabled {% end %}
+                        {% if not contest_session.is_ended() %} disabled {% end %}
                     >Public All Problem</button>
 
                     <table class="table table-hover table-sm table-responsive-sm col mx-lg-3">
@@ -236,15 +236,15 @@
                                     <button
                                         class="btn btn-info me-2 system-test"
                                         pro_id="{{ pro.pro_id }}"
-                                        {% if not contest.is_end() %} disabled {% end %}
-                                        title="{% if not contest.is_end() %}Contest 尚未結束{% else %}執行 System Test (重新評測所有 AC 提交){% end %}"
+                                        {% if not contest_session.is_ended() %} disabled {% end %}
+                                        title="{% if not contest_session.is_ended() %}Contest 尚未結束{% else %}執行 System Test (重新評測所有 AC 提交){% end %}"
                                     >System Test</button>
                                 {% end %}
 
                                 <button
                                     class="btn btn-danger me-2 public"
                                     pro_id="{{ pro.pro_id }}"
-                                    {% if not contest.is_end() or pro.status != ProConst.STATUS_CONTEST %} disabled {% end %}
+                                    {% if not contest_session.is_ended() or pro.status != ProConst.STATUS_CONTEST %} disabled {% end %}
                                 >Public Problem</button>
                             </td>
                         </tr>

--- a/src/static/templ/contests/proset.html
+++ b/src/static/templ/contests/proset.html
@@ -56,7 +56,7 @@ font-weight: bolder;
 </style>
 
 {% set score_color_class_map = ["state-0", "state-1", "state-2", "state-3", "state-4", "state-5", "state-6", "state-7", "state-8", "state-9", "state-10"] %}
-{% set is_end = contest.is_end() %}
+{% set is_end = contest_session.is_ended() %}
 {% set is_icpc = contest.contest_mode == ContestMode.ACM %}
 
 <div class="row">

--- a/src/static/templ/contests/qa.html
+++ b/src/static/templ/contests/qa.html
@@ -40,7 +40,7 @@
         <h1>Announcement</h1>
 
         <!-- TODO: add a button to close collapse when col-12 -->
-        {% if contest.is_start() %}
+        {% if contest_session.is_started() %}
             <div class="announce" style="overflow-y:scroll; max-height: 80vh;">
                 {% for announce in announces %}
                     <div class="card mt-2">
@@ -58,7 +58,7 @@
     </div>
 
     <div class="col-lg-7 col-12">
-        {% if contest.is_member(user, UserStatus.APPROVED) %}
+        {% if contest_access.is_participant %}
         <div class="row">
             <h1>Question</h1>
             <form>

--- a/src/static/templ/contests/reg.html
+++ b/src/static/templ/contests/reg.html
@@ -91,7 +91,7 @@
                     <button class="btn btn-primary reg form-control">Register</button>
                 {% elif contest.member_is_status(user, UserStatus.REQUESTED) and now < contest.reg_end %}
                     <button class="btn btn-primary cancel-register form-control">Cancel register</button>
-                {% elif contest.member_is_status(user, UserStatus.APPROVED) and now < contest.contest_start %}
+                {% elif contest_access.is_participant and not contest_session.is_started() %}
                     <button class="btn btn-primary unreg form-control">Unregister</button>
                 {% end %}
             {% end %}
@@ -99,4 +99,3 @@
 
     </div>
 </div>
-

--- a/src/static/templ/contests/scoreboard.html
+++ b/src/static/templ/contests/scoreboard.html
@@ -53,8 +53,8 @@ font-weight: bolder;
 <script>
     var contest_id = '{{ contest.contest_id }}';
     var post_url = `{{ url('/be/contests/${contest_id}/scoreboard') }}`;
-    var contest_start = new Date("{{ contest.contest_start.replace(tzinfo=datetime.UTC) }}");
-    var contest_end = new Date("{{ contest.contest_end.replace(tzinfo=datetime.UTC) }}");
+    var contest_start = new Date("{{ contest_session.start_time.replace(tzinfo=datetime.UTC) }}");
+    var contest_end = new Date("{{ contest_session.end_time.replace(tzinfo=datetime.UTC) }}");
     var contest_length = parseInt((contest_end - contest_start) / 1000);
     var score_color_class_map
         = ["state-0", "state-1", "state-2", "state-3", "state-4", "state-5", "state-6", "state-7", "state-8", "state-9", "state-10"];
@@ -314,7 +314,7 @@ font-weight: bolder;
         }
 
         {% set prefix_url = f"/contests/{ contest.contest_id }" %}
-        {% if contest.is_end() or not contest.is_member(user) %}
+        {% if contest_session.is_ended() or not contest_access.is_member %}
             {% set prefix_url = "" %} <!-- Redirect to STD -->
         {% end %}
         let scoreboard_html = `
@@ -455,7 +455,7 @@ font-weight: bolder;
         }
 
         {% set prefix_url = f"/contests/{ contest.contest_id }" %}
-        {% if contest.is_end() or not contest.is_member(user) %}
+        {% if contest_session.is_ended() or not contest_access.is_member %}
             {% set prefix_url = "" %} <!-- Redirect to STD -->
         {% end %}
         let icpc_scoreboard_html = `

--- a/src/static/templ/index.html
+++ b/src/static/templ/index.html
@@ -65,9 +65,9 @@
       });
 
     {% if is_in_contest %}
-        {% if not contest.is_end() %}
-            var contest_start = new Date("{{ contest.contest_start }}");
-            var contest_end = new Date("{{ contest.contest_end }}");
+        {% if not contest_session.is_ended() %}
+            var contest_start = new Date("{{ contest_session.start_time }}");
+            var contest_end = new Date("{{ contest_session.end_time }}");
             var started = false, ended = false;
             function timer1() {
                 let cur_time = new Date();
@@ -95,7 +95,7 @@
             }
         {% end %}
 
-        {% if contest.is_admin(user) %}
+        {% if contest_access.is_admin %}
           // Subscribe to admin-only new-question notifications using unified WS API
           let contest_ask_cnt = parseInt("{{ contest_ask_cnt }}");
           index.register_ws_callback('contestnewquessub', function(data) {
@@ -106,7 +106,7 @@
           });
           // Initialize channel with contest id
           index.ws_send('contestnewquessub_init', "{{ contest.contest_id }}");
-        {% elif contest.is_start() %}
+        {% elif contest_session.is_started() %}
             let contest_notification_cnt = parseInt("{{ contest_notification_cnt }}");
             index.register_ws_callback('contestnewqasub', function(data) {
               // server publishes JSON string for contestnewqasub; parse it
@@ -218,7 +218,7 @@
         <ul class="navbar-nav me-auto">
           <li class="nav-item info"><a class="nav-link" href="{{ url(f'/contests/{ contest_id }/info/') }}">Info</a></li>
 
-          {% if contest_manage or contest.is_start() %}
+          {% if contest_manage or contest_session.is_started() %}
             <li class="nav-item proset"><a class="nav-link" href="{{ url(f'/contests/{ contest_id }/proset/') }}">ProblemSet</a></li>
             <li class="nav-item chal"><a class="nav-link" href="{{ url(f'/contests/{ contest_id }/chal/') }}">Challenges</a></li>
             <li class="nav-item scoreboard"><a class="nav-link" href="{{ url(f'/contests/{ contest_id }/scoreboard/') }}">Scoreboard</a></li>

--- a/src/static/templ/pro.html
+++ b/src/static/templ/pro.html
@@ -246,7 +246,7 @@ a {
     <div id="side" class="col-lg-2 col-12 pt-lg-2" style="overflow-y: scroll;">
         <h3>{{ pro.pro_id}} / {{ pro.name }}</h3>
         {% if can_submit and pro.allow_submit %}
-            {% if contest and not contest.is_end() %}
+            {% if contest and not contest_session.is_ended() %}
                 <a class="btn btn-primary btn-lg my-lg-1" href="{{ url(f'/contests/{ contest.contest_id }/submit/{ pro.pro_id }/') }}">Submit</a><br />
             {% else %}
                 <a class="btn btn-primary btn-lg my-lg-1" href="{{ url(f'/submit/{ pro.pro_id }/') }}">Submit</a><br />

--- a/src/tests/unit/services/test_contest_access.py
+++ b/src/tests/unit/services/test_contest_access.py
@@ -1,0 +1,250 @@
+import datetime
+import unittest
+from unittest.mock import AsyncMock
+
+from services.chal import Compiler
+from services.contest_access import ContestAccess, ContestPermission
+from services.contest_session import ContestPhase, ContestSession
+from services.contests import Contest, ContestMode, ContestService, RegMode, UserStatus
+from services.user import Account, UserConst
+
+UTC = datetime.UTC
+
+
+def make_account(acct_id: int) -> Account:
+    return Account(
+        acct_id=acct_id,
+        acct_type=UserConst.ACCTTYPE_USER,
+        name=f"user-{acct_id}",
+        mail=f"user-{acct_id}@example.com",
+        photo="",
+        cover="",
+        motto="",
+        lastip="127.0.0.1",
+        last_compiler=Compiler.GPP,
+        proclass_collection=[],
+        specific_ip="",
+    )
+
+
+def make_contest(*, public_scoreboard: bool = False) -> Contest:
+    start = datetime.datetime(2026, 8, 20, 1, tzinfo=UTC)
+    return Contest(
+        contest_id=100,
+        contest_creator=1,
+        name="Test Contest",
+        contest_mode=ContestMode.IOI,
+        contest_start=start,
+        contest_end=start + datetime.timedelta(hours=5),
+        reg_mode=RegMode.FREE_REG,
+        reg_end=start,
+        user_list={
+            1: {"status": UserStatus.ADMIN},
+            2: {"status": UserStatus.APPROVED},
+        },
+        pro_list={},
+        is_public_scoreboard=public_scoreboard,
+    )
+
+
+class TestContestSession(unittest.TestCase):
+    def test_fixed_session_uses_contest_window(self):
+        contest = make_contest()
+        session = ContestSession.fixed(contest, acct_id=2)
+
+        self.assertEqual(session.contest_id, contest.contest_id)
+        self.assertEqual(session.acct_id, 2)
+        self.assertEqual(session.start_time, contest.contest_start)
+        self.assertEqual(session.end_time, contest.contest_end)
+        self.assertEqual(session.duration, datetime.timedelta(hours=5))
+
+    def test_phase_boundaries_match_existing_contest_semantics(self):
+        session = ContestSession.fixed(make_contest(), acct_id=2)
+
+        self.assertIs(
+            session.phase(session.start_time - datetime.timedelta(microseconds=1)),
+            ContestPhase.BEFORE,
+        )
+        self.assertIs(session.phase(session.start_time), ContestPhase.RUNNING)
+        self.assertIs(
+            session.phase(session.end_time - datetime.timedelta(microseconds=1)),
+            ContestPhase.RUNNING,
+        )
+        self.assertIs(session.phase(session.end_time), ContestPhase.ENDED)
+
+
+class TestContestAccess(unittest.TestCase):
+    def test_roles_preserve_member_and_participant_distinction(self):
+        contest = make_contest()
+        now = contest.contest_start + datetime.timedelta(hours=1)
+
+        admin = ContestAccess.resolve(contest, make_account(1), now)
+        participant = ContestAccess.resolve(contest, make_account(2), now)
+        outsider = ContestAccess.resolve(contest, make_account(3), now)
+
+        self.assertTrue(admin.has(ContestPermission.ADMIN | ContestPermission.MEMBER))
+        self.assertFalse(admin.has(ContestPermission.PARTICIPANT))
+        self.assertTrue(
+            participant.has(ContestPermission.PARTICIPANT | ContestPermission.MEMBER)
+        )
+        self.assertFalse(participant.has(ContestPermission.ADMIN))
+        self.assertFalse(outsider.has(ContestPermission.MEMBER))
+
+    def test_problem_access_matches_fixed_contest_rules(self):
+        contest = make_contest()
+        admin = make_account(1)
+        participant = make_account(2)
+        outsider = make_account(3)
+
+        before = contest.contest_start - datetime.timedelta(seconds=1)
+        running = contest.contest_start
+        ended = contest.contest_end
+
+        self.assertTrue(
+            ContestAccess.resolve(contest, admin, before).has(
+                ContestPermission.VIEW_PROBLEM_SET | ContestPermission.VIEW_PROBLEM
+            )
+        )
+        self.assertFalse(
+            ContestAccess.resolve(contest, participant, before).has(
+                ContestPermission.VIEW_PROBLEM_SET | ContestPermission.VIEW_PROBLEM
+            )
+        )
+        self.assertTrue(
+            ContestAccess.resolve(contest, participant, running).has(
+                ContestPermission.VIEW_PROBLEM_SET
+                | ContestPermission.VIEW_PROBLEM
+                | ContestPermission.SUBMIT
+            )
+        )
+        self.assertFalse(
+            ContestAccess.resolve(contest, outsider, running).has(
+                ContestPermission.VIEW_PROBLEM_SET
+            )
+        )
+        self.assertTrue(
+            ContestAccess.resolve(contest, outsider, ended).has(
+                ContestPermission.VIEW_PROBLEM_SET
+            )
+        )
+        self.assertFalse(
+            ContestAccess.resolve(contest, participant, ended).has(
+                ContestPermission.VIEW_PROBLEM
+            )
+        )
+
+    def test_scoreboard_access_respects_start_visibility_and_membership(self):
+        private_contest = make_contest()
+        public_contest = make_contest(public_scoreboard=True)
+        participant = make_account(2)
+        outsider = make_account(3)
+        before = private_contest.contest_start - datetime.timedelta(seconds=1)
+        running = private_contest.contest_start
+
+        self.assertFalse(
+            ContestAccess.resolve(public_contest, outsider, before).has(
+                ContestPermission.VIEW_SCOREBOARD
+            )
+        )
+        self.assertTrue(
+            ContestAccess.resolve(private_contest, participant, running).has(
+                ContestPermission.VIEW_SCOREBOARD
+            )
+        )
+        self.assertFalse(
+            ContestAccess.resolve(private_contest, outsider, running).has(
+                ContestPermission.VIEW_SCOREBOARD
+            )
+        )
+        self.assertTrue(
+            ContestAccess.resolve(public_contest, outsider, running).has(
+                ContestPermission.VIEW_SCOREBOARD
+            )
+        )
+
+    def test_creator_without_membership_keeps_existing_edge_case(self):
+        contest = make_contest()
+        contest.user_list.pop(contest.contest_creator)
+        access = ContestAccess.resolve(contest, make_account(1), contest.contest_start)
+
+        self.assertTrue(access.is_admin)
+        self.assertFalse(access.is_member)
+        self.assertFalse(access.has(ContestPermission.SUBMIT))
+        self.assertFalse(access.has(ContestPermission.VIEW_SCOREBOARD))
+
+    def test_challenge_visibility_preserves_phase_and_hide_admin_rules(self):
+        contest = make_contest(public_scoreboard=True)
+        participant = make_account(2)
+        other_participant_id = 4
+        contest.user_list[other_participant_id] = {"status": UserStatus.APPROVED}
+
+        before = contest.contest_start - datetime.timedelta(seconds=1)
+        running = contest.contest_start
+        ended = contest.contest_end
+
+        before_access = ContestAccess.resolve(contest, participant, before)
+        self.assertTrue(before_access.can_view_challenge(other_participant_id))
+        self.assertFalse(before_access.can_view_challenge(contest.contest_creator))
+
+        running_access = ContestAccess.resolve(contest, participant, running)
+        self.assertTrue(running_access.can_view_challenge(other_participant_id))
+        self.assertFalse(running_access.can_view_challenge(contest.contest_creator))
+        contest.hide_admin = False
+        running_access = ContestAccess.resolve(contest, participant, running)
+        self.assertFalse(running_access.can_view_challenge(other_participant_id))
+        self.assertTrue(running_access.can_view_challenge(participant.acct_id))
+
+        ended_access = ContestAccess.resolve(contest, participant, ended)
+        self.assertTrue(ended_access.can_view_challenge(other_participant_id))
+        contest.is_public_scoreboard = False
+        ended_access = ContestAccess.resolve(contest, participant, ended)
+        self.assertFalse(ended_access.can_view_challenge(other_participant_id))
+        self.assertTrue(ended_access.can_view_challenge(participant.acct_id))
+
+    def test_challenge_list_visibility_matches_existing_filters(self):
+        contest = make_contest(public_scoreboard=True)
+        contest.user_list[4] = {"status": UserStatus.APPROVED}
+        participant = make_account(2)
+
+        before = ContestAccess.resolve(
+            contest,
+            participant,
+            contest.contest_start - datetime.timedelta(seconds=1),
+        )
+        running = ContestAccess.resolve(contest, participant, contest.contest_start)
+        ended = ContestAccess.resolve(contest, participant, contest.contest_end)
+
+        self.assertEqual(before.visible_challenge_accounts(None), [])
+        self.assertEqual(
+            running.visible_challenge_accounts(None), [participant.acct_id]
+        )
+        self.assertEqual(ended.visible_challenge_accounts(None), [2, 4])
+        self.assertEqual(ended.visible_challenge_accounts([1, 2, 4]), [2, 4])
+
+
+class TestContestScoreSession(unittest.IsolatedAsyncioTestCase):
+    async def test_icpc_score_uses_effective_session_start(self):
+        contest = make_contest()
+        db = AsyncMock()
+        db.fetch.return_value = []
+        service = ContestService(db, AsyncMock())
+        service.get_contest = AsyncMock(return_value=(None, contest))
+        session = ContestSession(
+            contest_id=contest.contest_id,
+            acct_id=2,
+            start_time=contest.contest_start + datetime.timedelta(minutes=30),
+            end_time=contest.contest_end,
+        )
+
+        await service.get_icpc_scores(
+            contest.contest_id,
+            10,
+            session.end_time,
+            session,
+        )
+
+        self.assertEqual(db.fetch.await_args.args[6], session.start_time)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Contest timing and authorization were spread across handlers and templates, making participant-specific sessions difficult to add without duplicating access rules.

Introduce request-scoped sessions and bitmask permissions while preserving all existing fixed-contest behavior. Use effective session times for scoreboard calculations and centralize challenge visibility.